### PR TITLE
feat: command rework — tools, remove, list flip, new command tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Keep your team's AI coding agent skills in sync. One command, no copy-paste.
 
 ```bash
-scribe connect ArtistfyHQ/team-skills
+scribe registry connect ArtistfyHQ/team-skills
 scribe sync
 ```
 
@@ -11,7 +11,7 @@ scribe sync
 
 AI coding agents like Claude Code and Cursor work better with "skills" — markdown instruction files that teach the agent how to do specific tasks (code reviews, deployments, Laravel patterns, etc.). If you've built a good set of skills, sharing them with teammates currently means Slack links and manual file copying. Nobody knows if they're on the latest version. The person who just joined has no idea what they're missing.
 
-Scribe fixes this. You put your team's skills in a GitHub repo with a `scribe.yaml` manifest (or legacy `scribe.toml`), teammates run `scribe connect`, and `scribe sync` keeps everyone up to date automatically. Works with Claude Code and Cursor from the same manifest.
+Scribe fixes this. You put your team's skills in a GitHub repo with a `scribe.yaml` manifest (or legacy `scribe.toml`), teammates run `scribe registry connect`, and `scribe sync` keeps everyone up to date automatically. Works with Claude Code and Cursor from the same manifest.
 
 ## Install
 
@@ -67,11 +67,11 @@ go install github.com/Naoray/scribe/cmd/scribe@latest
 
 ```bash
 # 1. Connect to your team's skills repo (one time)
-scribe connect ArtistfyHQ/team-skills
+scribe registry connect ArtistfyHQ/team-skills
 
 # 2. That's it — skills are now installed and you stay in sync
 scribe sync        # run again anytime to pick up new skills
-scribe list        # see what's installed and what's outdated
+scribe list        # see what's installed
 ```
 
 ### For the team lead setting up the shared repo
@@ -79,9 +79,9 @@ scribe list        # see what's installed and what's outdated
 **Option A — Let Scribe scaffold it (recommended):**
 
 ```bash
-scribe create registry
+scribe registry create
 # Interactive prompts for team name, GitHub org, repo name, visibility
-# Creates the repo, pushes scribe.toml + README, and connects automatically
+# Creates the repo, pushes scribe.yaml + README, and connects automatically
 ```
 
 **Option B — Manual setup:**
@@ -115,22 +115,38 @@ ArtistfyHQ/team-skills/
       SKILL.md       ← your skill file
 ```
 
-4. Tell your teammate to run `scribe connect ArtistfyHQ/team-skills`
+4. Tell your teammate to run `scribe registry connect ArtistfyHQ/team-skills`
 
 ## Commands
 
+### Daily Use
+
 | Command | What it does |
 |---|---|
-| `scribe connect <owner/repo>` | Connect to a team skills repo and run an initial sync |
-| `scribe sync` | Install missing skills, update outdated ones |
-| `scribe list` | Show all skills: what's installed, what's outdated, what's missing |
-| `scribe add [name]` | Add a skill to the team registry (interactive picker or by name) |
-| `scribe create registry` | Scaffold a new team skills registry on GitHub and connect to it |
+| `scribe list` | Show all skills on this machine |
+| `scribe add [query]` | Find and install skills from registries |
+| `scribe remove <skill>` | Remove a skill from this machine |
+| `scribe sync` | Pull updates from connected registries |
+| `scribe tools` | List detected AI tools, enable/disable |
 | `scribe explain <skill>` | AI-powered skill explanation (or `--raw` for rendered SKILL.md) |
-| `scribe guide` | Interactive onboarding — walks through connect, sync, and add |
+
+### Registry Management
+
+| Command | What it does |
+|---|---|
+| `scribe registry connect <repo>` | Connect to a skill registry |
+| `scribe registry create` | Scaffold a new registry repo on GitHub |
+| `scribe registry add [name]` | Share a local skill to a registry |
 | `scribe registry list` | Show connected registries with skill counts |
 | `scribe registry enable/disable` | Enable or disable a connected registry |
-| `scribe migrate [registry]` | Convert a `scribe.toml` registry to `scribe.yaml` |
+| `scribe registry migrate` | Convert a `scribe.toml` registry to `scribe.yaml` |
+
+### Other
+
+| Command | What it does |
+|---|---|
+| `scribe guide` | Interactive setup guide |
+| `scribe --version` | Show version |
 
 ### scribe list output
 
@@ -174,7 +190,7 @@ Private GitHub repos work if you're authenticated with the `gh` CLI — Scribe p
 gh auth login   # if not already done
 ```
 
-Auth fallback chain: `gh auth token` → `GITHUB_TOKEN` env → `~/.scribe/config.toml` → unauthenticated (public repos only).
+Auth fallback chain: `gh auth token` → `GITHUB_TOKEN` env → `~/.scribe/config.yaml` → unauthenticated (public repos only).
 
 ## Agent-friendly
 
@@ -206,9 +222,9 @@ Scribe follows the [agentskills.io](https://agentskills.io) SKILL.md specificati
 
 ```
 ~/.scribe/
-  config.toml    # which team repos you're connected to
+  config.yaml    # connected registries, tool settings
   state.json     # what's installed, last sync time
-  skills/        # canonical skill store (symlinked by targets)
+  skills/        # canonical skill store (symlinked by tools)
 ```
 
 ## Requirements
@@ -221,18 +237,15 @@ Scribe follows the [agentskills.io](https://agentskills.io) SKILL.md specificati
 
 **What works today:**
 - `scribe sync` — full sync loop (diff, download, install, update)
-- `scribe list` — shows installed skills and their status vs team loadout
-- Claude Code and Cursor install targets
+- `scribe list` — TUI for browsing installed skills, grouped by registry
+- `scribe add` — browse and install skills from connected registries
+- `scribe remove` — uninstall skills from the machine
+- `scribe tools` — list and toggle AI tools (Claude Code, Cursor)
+- `scribe registry connect/create/add` — manage team registries
 - Private repo support via `gh auth token`
-- `--json` flag for CI/agent use
-
-- `scribe connect` — connect to a team repo with interactive setup
-- `scribe create registry` — scaffold a new team skills registry on GitHub
-- `scribe add` — add local or remote skills to your team registry
+- `--json` flag on all commands for CI/agent use
 
 **Coming later:**
-- Community registries — connect to any GitHub repo with SKILL.md files
-- Package support — third-party tools with custom install/update commands
 - `scribe upgrade` — self-update command
 - Lockfile (`scribe.lock`) — pin exact versions across the team
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -15,23 +15,41 @@ import (
 func newListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Show installed skills and their status vs team loadout",
-		RunE:  runList,
+		Short: "Show all skills on this machine",
+		Long: `Show all skills on this machine.
+
+By default, lists every skill installed locally. Use --remote to see
+available skills from connected registries instead.
+
+Examples:
+  scribe list                # local skills
+  scribe list --remote       # registry diff view
+  scribe list --registry r   # filter to one registry (implies --remote)
+  scribe list --json         # machine-readable output`,
+		RunE: runList,
 	}
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	cmd.Flags().Bool("remote", false, "Show available skills from registries (not installed)")
 	cmd.Flags().String("registry", "", "Show only this registry (owner/repo or repo name)")
 	return cmd
 }
 
 func runList(cmd *cobra.Command, args []string) error {
 	jsonFlag, _ := cmd.Flags().GetBool("json")
+	remoteFlag, _ := cmd.Flags().GetBool("remote")
 	repoFlag, _ := cmd.Flags().GetString("registry")
+
+	// --registry implies --remote (you can't filter registries in local view).
+	if repoFlag != "" {
+		remoteFlag = true
+	}
 
 	useJSON := jsonFlag || !isatty.IsTerminal(os.Stdout.Fd())
 
 	bag := &workflow.Bag{
 		Args:             args,
 		JSONFlag:         useJSON,
+		RemoteFlag:       remoteFlag,
 		RepoFlag:         repoFlag,
 		FilterRegistries: filterRegistries,
 	}

--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -267,17 +267,19 @@ func buildLocalRowsExcluding(skills []discovery.Skill, matched map[string]bool) 
 	return buildLocalRows(remaining)
 }
 
+const unmanagedGroup = "Local (unmanaged)"
+
 // registryGroupFromName extracts the registry group from a namespaced skill name.
-// "Artistfy-hq/deploy" → "Artistfy-hq", "local/foo" → "Local (unmanaged)", "bare" → "Local (unmanaged)"
+// "Artistfy-hq/deploy" → "Artistfy-hq", "local/foo" → unmanagedGroup, "bare" → unmanagedGroup
 func registryGroupFromName(name string) string {
 	if idx := strings.Index(name, "/"); idx > 0 {
 		prefix := name[:idx]
 		if prefix == "local" {
-			return "Local (unmanaged)"
+			return unmanagedGroup
 		}
 		return prefix
 	}
-	return "Local (unmanaged)"
+	return unmanagedGroup
 }
 
 func buildLocalRows(skills []discovery.Skill) []listRow {
@@ -295,12 +297,11 @@ func buildLocalRows(skills []discovery.Skill) []listRow {
 		})
 	}
 
-	// Sort: "Local (unmanaged)" last, then alphabetical group names; rows
+	// Sort: unmanagedGroup last, then alphabetical group names; rows
 	// within a group sorted by name.
-	const unmanaged = "Local (unmanaged)"
 	var keys []string
 	for k := range groups {
-		if k != unmanaged {
+		if k != unmanagedGroup {
 			keys = append(keys, k)
 		}
 	}
@@ -308,8 +309,8 @@ func buildLocalRows(skills []discovery.Skill) []listRow {
 
 	var ordered []string
 	ordered = append(ordered, keys...)
-	if _, ok := groups[unmanaged]; ok {
-		ordered = append(ordered, unmanaged)
+	if _, ok := groups[unmanagedGroup]; ok {
+		ordered = append(ordered, unmanagedGroup)
 	}
 
 	var rows []listRow
@@ -592,6 +593,19 @@ func (m listModel) executeRemove() (tea.Model, tea.Cmd) {
 		m.statusMsg = "Cannot remove: path outside managed directories"
 		m.substate = listSubstateNone
 		return m, nil
+	}
+
+	// Uninstall from all tools that had this skill installed.
+	if installed, ok := m.bag.State.Installed[sk.Name]; ok {
+		detectedTools := tools.DetectTools()
+		for _, tool := range detectedTools {
+			for _, t := range installed.Tools {
+				if t == tool.Name() {
+					_ = tool.Uninstall(sk.Name)
+					break
+				}
+			}
+		}
 	}
 
 	m.bag.State.Remove(sk.Name)

--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -267,14 +267,24 @@ func buildLocalRowsExcluding(skills []discovery.Skill, matched map[string]bool) 
 	return buildLocalRows(remaining)
 }
 
+// registryGroupFromName extracts the registry group from a namespaced skill name.
+// "Artistfy-hq/deploy" → "Artistfy-hq", "local/foo" → "Local (unmanaged)", "bare" → "Local (unmanaged)"
+func registryGroupFromName(name string) string {
+	if idx := strings.Index(name, "/"); idx > 0 {
+		prefix := name[:idx]
+		if prefix == "local" {
+			return "Local (unmanaged)"
+		}
+		return prefix
+	}
+	return "Local (unmanaged)"
+}
+
 func buildLocalRows(skills []discovery.Skill) []listRow {
 	groups := map[string][]listRow{}
 	for i := range skills {
 		sk := &skills[i]
-		g := sk.Package
-		if g == "" {
-			g = "uncategorized"
-		}
+		g := registryGroupFromName(sk.Name)
 		groups[g] = append(groups[g], listRow{
 			Name:    sk.Name,
 			Group:   g,
@@ -285,21 +295,22 @@ func buildLocalRows(skills []discovery.Skill) []listRow {
 		})
 	}
 
-	// Sort: "uncategorized" first, then alphabetical group names; rows
+	// Sort: "Local (unmanaged)" last, then alphabetical group names; rows
 	// within a group sorted by name.
+	const unmanaged = "Local (unmanaged)"
 	var keys []string
 	for k := range groups {
-		if k != "uncategorized" {
+		if k != unmanaged {
 			keys = append(keys, k)
 		}
 	}
 	sort.Strings(keys)
 
 	var ordered []string
-	if _, ok := groups["uncategorized"]; ok {
-		ordered = append(ordered, "uncategorized")
-	}
 	ordered = append(ordered, keys...)
+	if _, ok := groups[unmanaged]; ok {
+		ordered = append(ordered, unmanaged)
+	}
 
 	var rows []listRow
 	for _, g := range ordered {
@@ -672,9 +683,9 @@ func (m listModel) View() tea.View {
 
 func (m listModel) viewLoading() string {
 	frame := spinnerFrames[m.spinnerFrame]
-	msg := "Fetching team skills…"
-	if m.bag != nil && m.bag.Config != nil && len(m.bag.Config.TeamRepos()) == 0 {
-		msg = "Discovering local skills…"
+	msg := "Discovering local skills…"
+	if m.bag != nil && m.bag.RemoteFlag {
+		msg = "Fetching team skills…"
 	}
 	return "\n  " + ltSpinnerStyle.Render(frame) + "  " + ltDimStyle.Render(msg) + "\n"
 }
@@ -792,7 +803,7 @@ func (m listModel) renderRows(b *strings.Builder, contentHeight, maxWidth int, c
 	// room.
 	statusReserve := 0
 	if !compact {
-		statusReserve = 12
+		statusReserve = 42 // version(14)+gap(2) + author(12)+gap(2) + icon(1)+space(1)+label(7)+breathing(3)
 	} else {
 		statusReserve = 4 // icon + padding only
 	}
@@ -876,16 +887,38 @@ func (m listModel) formatRow(row listRow, isCursor bool, nameCol int, compact bo
 	name := runewidth.Truncate(row.Name, nameCol, "…")
 	name = runewidth.FillRight(name, nameCol)
 
-	if !row.HasStatus {
-		return prefix + nameStyle.Render(name)
-	}
-
-	icon := statusStyles[row.Status].Render(row.Status.Display().Icon)
 	if compact {
+		if !row.HasStatus {
+			return prefix + nameStyle.Render(name)
+		}
+		icon := statusStyles[row.Status].Render(row.Status.Display().Icon)
 		return prefix + nameStyle.Render(name) + "  " + icon
 	}
-	label := statusStyles[row.Status].Render(row.Status.Display().Label)
-	return prefix + nameStyle.Render(name) + "  " + icon + " " + label
+
+	// Full view: name + version + author + status
+	ver := row.Version
+	if ver == "" {
+		ver = "-"
+	}
+	ver = runewidth.Truncate(ver, 14, "…")
+	ver = runewidth.FillRight(ver, 14)
+
+	author := row.Author
+	if author == "" {
+		author = "-"
+	}
+	author = runewidth.Truncate(author, 12, "…")
+	author = runewidth.FillRight(author, 12)
+
+	line := prefix + nameStyle.Render(name) + "  " + ltDimStyle.Render(ver) + "  " + ltDimStyle.Render(author)
+
+	if row.HasStatus {
+		icon := statusStyles[row.Status].Render(row.Status.Display().Icon)
+		label := statusStyles[row.Status].Render(row.Status.Display().Label)
+		line += "  " + icon + " " + label
+	}
+
+	return line
 }
 
 // renderSummary builds the colored "N current · N update · N missing" footer.
@@ -939,13 +972,13 @@ func (m listModel) renderDetailPane(row listRow, width int) string {
 		pairs = append(pairs, kv{"Author", row.Author})
 	}
 	if row.Group != "" {
-		pairs = append(pairs, kv{"Group", row.Group})
+		pairs = append(pairs, kv{"Registry", row.Group})
 	}
 	if row.Source != "" {
 		pairs = append(pairs, kv{"Source", row.Source})
 	}
 	if len(row.Targets) > 0 {
-		pairs = append(pairs, kv{"Targets", strings.Join(row.Targets, ", ")})
+		pairs = append(pairs, kv{"Tools", strings.Join(row.Targets, ", ")})
 	}
 	if row.Local != nil && row.Local.LocalPath != "" {
 		path := row.Local.LocalPath

--- a/cmd/list_tui_test.go
+++ b/cmd/list_tui_test.go
@@ -116,10 +116,10 @@ func TestActionsForRow(t *testing.T) {
 
 func TestBuildLocalRows_GroupsAndOrders(t *testing.T) {
 	skills := []discovery.Skill{
-		{Name: "zeta", Package: "gstack"},
-		{Name: "alpha", Package: ""},
-		{Name: "beta", Package: "gstack"},
-		{Name: "gamma", Package: ""},
+		{Name: "gstack/zeta"},
+		{Name: "alpha"},
+		{Name: "gstack/beta"},
+		{Name: "local/gamma"},
 	}
 	rows := buildLocalRows(skills)
 
@@ -127,16 +127,35 @@ func TestBuildLocalRows_GroupsAndOrders(t *testing.T) {
 		t.Fatalf("expected 4 rows, got %d", len(rows))
 	}
 
-	// Uncategorized first, alphabetical within group.
+	// Registry groups alphabetical first, "Local (unmanaged)" last; rows
+	// within a group sorted by name.
 	want := []struct{ name, group string }{
-		{"alpha", "uncategorized"},
-		{"gamma", "uncategorized"},
-		{"beta", "gstack"},
-		{"zeta", "gstack"},
+		{"gstack/beta", "gstack"},
+		{"gstack/zeta", "gstack"},
+		{"alpha", "Local (unmanaged)"},
+		{"local/gamma", "Local (unmanaged)"},
 	}
 	for i, w := range want {
 		if rows[i].Name != w.name || rows[i].Group != w.group {
 			t.Errorf("row %d = %+v, want name=%q group=%q", i, rows[i], w.name, w.group)
+		}
+	}
+}
+
+func TestRegistryGroupFromName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"Artistfy-hq/deploy", "Artistfy-hq"},
+		{"local/foo", "Local (unmanaged)"},
+		{"bare", "Local (unmanaged)"},
+		{"owner/skill-name", "owner"},
+	}
+	for _, tt := range tests {
+		got := registryGroupFromName(tt.name)
+		if got != tt.want {
+			t.Errorf("registryGroupFromName(%q) = %q, want %q", tt.name, got, tt.want)
 		}
 	}
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -95,8 +95,8 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	// Confirmation prompt.
-	if !yes && !useJSON {
-		if isTTY {
+	if !yes {
+		if isTTY && !useJSON {
 			var confirm bool
 			if err := huh.NewConfirm().
 				Title(fmt.Sprintf("Remove %s?", key)).

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,0 +1,250 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"charm.land/huh/v2"
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+func newRemoveCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove <skill>",
+		Short: "Uninstall a skill from the local machine",
+		Long: `Remove a skill by name or full key (e.g. "deploy" or "Artistfy-hq/deploy").
+
+If the bare name is ambiguous across registries, an interactive picker is shown
+(or an error in non-TTY mode). Skills managed by a registry will be re-installed
+on the next sync unless the registry is disconnected.`,
+		Args: cobra.ExactArgs(1),
+		RunE: runRemove,
+	}
+	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	return cmd
+}
+
+// removeResult is the JSON output for `scribe remove`.
+type removeResult struct {
+	Removed   string   `json:"removed"`
+	ManagedBy []string `json:"managed_by,omitempty"`
+	Errors    []string `json:"errors,omitempty"`
+}
+
+func runRemove(cmd *cobra.Command, args []string) error {
+	input := args[0]
+	yes, _ := cmd.Flags().GetBool("yes")
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+	useJSON := jsonFlag || !isatty.IsTerminal(os.Stdout.Fd())
+	isTTY := isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
+
+	// Load state.
+	st, err := state.Load()
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
+
+	// Collect installed keys.
+	installedKeys := make([]string, 0, len(st.Installed))
+	for k := range st.Installed {
+		installedKeys = append(installedKeys, k)
+	}
+	sort.Strings(installedKeys)
+
+	// Resolve the target.
+	key, err := resolveRemoveTarget(input, installedKeys)
+	if err != nil {
+		// If ambiguous and TTY, show a picker.
+		if isTTY && !useJSON && strings.Contains(err.Error(), "ambiguous") {
+			key, err = pickRemoveTarget(input, installedKeys)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	installed := st.Installed[key]
+
+	// Check if managed by a registry.
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	managedBy := findManagingRegistries(key, cfg.Registries)
+
+	// Warn about registry re-install.
+	if len(managedBy) > 0 && !useJSON {
+		fmt.Fprintf(os.Stderr, "⚠  %s is managed by %s — it will re-install on next sync\n",
+			key, strings.Join(managedBy, ", "))
+	}
+
+	// Confirmation prompt.
+	if !yes && !useJSON {
+		if isTTY {
+			var confirm bool
+			if err := huh.NewConfirm().
+				Title(fmt.Sprintf("Remove %s?", key)).
+				Value(&confirm).
+				Run(); err != nil {
+				return err
+			}
+			if !confirm {
+				fmt.Fprintln(os.Stderr, "Aborted.")
+				return nil
+			}
+		} else {
+			return fmt.Errorf("use --yes to confirm removal in non-interactive mode")
+		}
+	}
+
+	// Uninstall from all tools.
+	var errs []string
+	detectedTools := tools.DetectTools()
+	for _, tool := range detectedTools {
+		// Only uninstall from tools that had the skill installed.
+		for _, t := range installed.Tools {
+			if t == tool.Name() {
+				if err := tool.Uninstall(key); err != nil {
+					errs = append(errs, fmt.Sprintf("%s: %v", tool.Name(), err))
+				}
+				break
+			}
+		}
+	}
+
+	// Remove from canonical store.
+	storeDir, err := tools.StoreDir()
+	if err == nil {
+		skillDir := filepath.Join(storeDir, key)
+		if err := os.RemoveAll(skillDir); err != nil {
+			errs = append(errs, fmt.Sprintf("store: %v", err))
+		}
+	}
+
+	// Remove any remaining symlinks from installed.Paths.
+	for _, p := range installed.Paths {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Sprintf("symlink %s: %v", p, err))
+		}
+	}
+
+	// Remove from state and save.
+	st.Remove(key)
+	if err := st.Save(); err != nil {
+		return fmt.Errorf("save state: %w", err)
+	}
+
+	// Output.
+	if useJSON {
+		result := removeResult{
+			Removed:   key,
+			ManagedBy: managedBy,
+			Errors:    errs,
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	if len(errs) > 0 {
+		fmt.Fprintf(os.Stderr, "Removed %s with warnings:\n", key)
+		for _, e := range errs {
+			fmt.Fprintf(os.Stderr, "  • %s\n", e)
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "Removed %s\n", key)
+	}
+	return nil
+}
+
+// resolveRemoveTarget matches input against installed skill keys.
+// Exact namespaced match → bare name unique match → ambiguous error.
+func resolveRemoveTarget(input string, installedKeys []string) (string, error) {
+	// Exact match.
+	for _, k := range installedKeys {
+		if k == input {
+			return k, nil
+		}
+	}
+
+	// Bare name match — look at the part after the slash.
+	var matches []string
+	for _, k := range installedKeys {
+		parts := strings.SplitN(k, "/", 2)
+		if len(parts) == 2 && parts[1] == input {
+			matches = append(matches, k)
+		}
+	}
+
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return "", fmt.Errorf("%q is not installed", input)
+	default:
+		return "", fmt.Errorf("ambiguous skill %q — matches:\n  %s\nSpecify the full key to remove", input, strings.Join(matches, "\n  "))
+	}
+}
+
+// pickRemoveTarget shows an interactive picker for ambiguous skill names.
+func pickRemoveTarget(input string, installedKeys []string) (string, error) {
+	var matches []string
+	for _, k := range installedKeys {
+		parts := strings.SplitN(k, "/", 2)
+		if len(parts) == 2 && parts[1] == input {
+			matches = append(matches, k)
+		}
+	}
+
+	if len(matches) == 0 {
+		return "", fmt.Errorf("%q is not installed", input)
+	}
+
+	opts := make([]huh.Option[string], len(matches))
+	for i, m := range matches {
+		opts[i] = huh.NewOption(m, m)
+	}
+
+	var selected string
+	err := huh.NewSelect[string]().
+		Title(fmt.Sprintf("Multiple skills match %q — which one?", input)).
+		Options(opts...).
+		Value(&selected).
+		Run()
+	if err != nil {
+		return "", err
+	}
+	return selected, nil
+}
+
+// findManagingRegistries returns registry repos that manage the given skill key.
+// A skill key like "Artistfy-hq/deploy" is managed by a registry whose repo
+// slugifies to match the namespace prefix (e.g. "Artistfy/hq" → "Artistfy-hq").
+func findManagingRegistries(key string, registries []config.RegistryConfig) []string {
+	parts := strings.SplitN(key, "/", 2)
+	if len(parts) < 2 {
+		return nil
+	}
+	namespace := parts[0]
+
+	var managed []string
+	for _, r := range registries {
+		slug := strings.ReplaceAll(r.Repo, "/", "-")
+		if slug == namespace {
+			managed = append(managed, r.Repo)
+		}
+	}
+	return managed
+}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +17,9 @@ import (
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/tools"
 )
+
+// errAmbiguousSkill is returned when a bare skill name matches multiple installed keys.
+var errAmbiguousSkill = errors.New("ambiguous skill")
 
 func newRemoveCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -65,7 +69,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	key, err := resolveRemoveTarget(input, installedKeys)
 	if err != nil {
 		// If ambiguous and TTY, show a picker.
-		if isTTY && !useJSON && strings.Contains(err.Error(), "ambiguous") {
+		if isTTY && !useJSON && errors.Is(err, errAmbiguousSkill) {
 			key, err = pickRemoveTarget(input, installedKeys)
 			if err != nil {
 				return err
@@ -180,13 +184,7 @@ func resolveRemoveTarget(input string, installedKeys []string) (string, error) {
 	}
 
 	// Bare name match — look at the part after the slash.
-	var matches []string
-	for _, k := range installedKeys {
-		parts := strings.SplitN(k, "/", 2)
-		if len(parts) == 2 && parts[1] == input {
-			matches = append(matches, k)
-		}
-	}
+	matches := findBareNameMatches(input, installedKeys)
 
 	switch len(matches) {
 	case 1:
@@ -194,19 +192,14 @@ func resolveRemoveTarget(input string, installedKeys []string) (string, error) {
 	case 0:
 		return "", fmt.Errorf("%q is not installed", input)
 	default:
-		return "", fmt.Errorf("ambiguous skill %q — matches:\n  %s\nSpecify the full key to remove", input, strings.Join(matches, "\n  "))
+		return "", fmt.Errorf("%w %q — matches: %s\nSpecify the full name, e.g.: scribe remove %s",
+			errAmbiguousSkill, input, strings.Join(matches, ", "), matches[0])
 	}
 }
 
 // pickRemoveTarget shows an interactive picker for ambiguous skill names.
 func pickRemoveTarget(input string, installedKeys []string) (string, error) {
-	var matches []string
-	for _, k := range installedKeys {
-		parts := strings.SplitN(k, "/", 2)
-		if len(parts) == 2 && parts[1] == input {
-			matches = append(matches, k)
-		}
-	}
+	matches := findBareNameMatches(input, installedKeys)
 
 	if len(matches) == 0 {
 		return "", fmt.Errorf("%q is not installed", input)
@@ -227,6 +220,19 @@ func pickRemoveTarget(input string, installedKeys []string) (string, error) {
 		return "", err
 	}
 	return selected, nil
+}
+
+// findBareNameMatches returns all installed keys whose bare name (after the slash)
+// matches input case-insensitively.
+func findBareNameMatches(input string, keys []string) []string {
+	var matches []string
+	for _, k := range keys {
+		parts := strings.SplitN(k, "/", 2)
+		if len(parts) == 2 && strings.EqualFold(parts[1], input) {
+			matches = append(matches, k)
+		}
+	}
+	return matches
 }
 
 // findManagingRegistries returns registry repos that manage the given skill key.

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -167,9 +167,10 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		for _, e := range errs {
 			fmt.Fprintf(os.Stderr, "  • %s\n", e)
 		}
-	} else {
-		fmt.Fprintf(os.Stderr, "Removed %s\n", key)
+		return fmt.Errorf("removed %s with %d warning(s)", key, len(errs))
 	}
+
+	fmt.Fprintf(os.Stderr, "Removed %s\n", key)
 	return nil
 }
 

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveRemoveTarget(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		installed []string
+		want      string
+		wantErr   string
+	}{
+		{
+			name:      "exact namespaced match",
+			input:     "Artistfy-hq/recap",
+			installed: []string{"Artistfy-hq/recap", "antfu-skills/recap"},
+			want:      "Artistfy-hq/recap",
+		},
+		{
+			name:      "bare name unique match",
+			input:     "deploy",
+			installed: []string{"Artistfy-hq/deploy", "Artistfy-hq/recap"},
+			want:      "Artistfy-hq/deploy",
+		},
+		{
+			name:      "bare name ambiguous",
+			input:     "recap",
+			installed: []string{"Artistfy-hq/recap", "antfu-skills/recap"},
+			wantErr:   "ambiguous",
+		},
+		{
+			name:      "not found",
+			input:     "nonexistent",
+			installed: []string{"Artistfy-hq/recap"},
+			wantErr:   "not installed",
+		},
+		{
+			name:      "exact match case-sensitive",
+			input:     "Artistfy-hq/deploy",
+			installed: []string{"Artistfy-hq/deploy"},
+			want:      "Artistfy-hq/deploy",
+		},
+		{
+			name:      "bare name single installed",
+			input:     "recap",
+			installed: []string{"Artistfy-hq/recap"},
+			want:      "Artistfy-hq/recap",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveRemoveTarget(tc.input, tc.installed)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,21 +64,33 @@ func init() {
 	rootCmd.RunE = runHub
 	rootCmd.Flags().Bool("json", false, "Output machine-readable JSON")
 
-	// connectCmd moved under registry — add hidden alias for backward compat
+	// Backward-compat aliases: hidden + deprecated, point to registry subcommands.
 	aliasConnect := newConnectCommand()
 	aliasConnect.Hidden = true
 	aliasConnect.Deprecated = "use 'scribe registry connect' instead"
 	rootCmd.AddCommand(aliasConnect)
 
+	aliasMigrate := newMigrateCommand()
+	aliasMigrate.Hidden = true
+	aliasMigrate.Deprecated = "use 'scribe registry migrate' instead"
+	rootCmd.AddCommand(aliasMigrate)
+
+	// Top-level: daily skill management.
 	rootCmd.AddCommand(
-		newSyncCommand(),
 		newListCommand(),
 		newAddCommand(),
-		newCreateCommand(),
-		newGuideCommand(),
-		newRegistryCommand(),
-		newMigrateCommand(),
-		newExplainCommand(),
+		newRemoveCommand(),
+		newSyncCommand(),
 		newToolsCommand(),
+		newGuideCommand(),
+	)
+
+	// Registry subcommand: administration & publishing.
+	rootCmd.AddCommand(newRegistryCommand())
+
+	// Other.
+	rootCmd.AddCommand(
+		newCreateCommand(),
+		newExplainCommand(),
 	)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,5 +79,6 @@ func init() {
 		newRegistryCommand(),
 		newMigrateCommand(),
 		newExplainCommand(),
+		newToolsCommand(),
 	)
 }

--- a/cmd/tools.go
+++ b/cmd/tools.go
@@ -18,8 +18,17 @@ func newToolsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tools",
 		Short: "Manage AI tool targets for skill installation",
-		Args:  cobra.NoArgs,
-		RunE:  runToolsList,
+		Long: `Show detected AI tools and their enabled/disabled status.
+
+Use enable/disable to control which tools receive skill installations
+during sync.
+
+Examples:
+  scribe tools                # list tools and status
+  scribe tools enable cursor  # enable a tool
+  scribe tools disable cursor # disable a tool`,
+		Args: cobra.NoArgs,
+		RunE: runToolsList,
 	}
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.AddCommand(newToolsEnableCommand())

--- a/cmd/tools.go
+++ b/cmd/tools.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+func newToolsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tools",
+		Short: "Manage AI tool targets for skill installation",
+		Args:  cobra.NoArgs,
+		RunE:  runToolsList,
+	}
+	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	cmd.AddCommand(newToolsEnableCommand())
+	cmd.AddCommand(newToolsDisableCommand())
+	return cmd
+}
+
+func newToolsEnableCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "enable <name>",
+		Short: "Enable a tool for skill installation",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runToolsEnable,
+	}
+}
+
+func newToolsDisableCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "disable <name>",
+		Short: "Disable a tool for skill installation",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runToolsDisable,
+	}
+}
+
+func runToolsList(cmd *cobra.Command, _ []string) error {
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	ensureToolsPopulated(cfg)
+
+	useJSON := jsonFlag || !isatty.IsTerminal(os.Stdout.Fd())
+	if useJSON {
+		out, err := formatToolsListJSON(cfg.Tools)
+		if err != nil {
+			return err
+		}
+		fmt.Println(out)
+		return nil
+	}
+
+	fmt.Print(formatToolsList(cfg.Tools))
+	return nil
+}
+
+func runToolsEnable(cmd *cobra.Command, args []string) error {
+	return setToolEnabled(args[0], true)
+}
+
+func runToolsDisable(cmd *cobra.Command, args []string) error {
+	return setToolEnabled(args[0], false)
+}
+
+func setToolEnabled(name string, enabled bool) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	ensureToolsPopulated(cfg)
+
+	found := false
+	for i := range cfg.Tools {
+		if strings.EqualFold(cfg.Tools[i].Name, name) {
+			cfg.Tools[i].Enabled = enabled
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		known := make([]string, len(cfg.Tools))
+		for i, t := range cfg.Tools {
+			known[i] = t.Name
+		}
+		return fmt.Errorf("unknown tool %q — known tools: %s", name, strings.Join(known, ", "))
+	}
+
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	action := "enabled"
+	if !enabled {
+		action = "disabled"
+	}
+	fmt.Printf("Tool %s %s\n", name, action)
+	return nil
+}
+
+// ensureToolsPopulated auto-populates cfg.Tools from detected tools if empty.
+func ensureToolsPopulated(cfg *config.Config) {
+	if len(cfg.Tools) > 0 {
+		return
+	}
+	detected := tools.DetectTools()
+	for _, t := range detected {
+		cfg.Tools = append(cfg.Tools, config.ToolConfig{
+			Name:    t.Name(),
+			Enabled: true,
+		})
+	}
+}
+
+// formatToolsList returns a tab-formatted table of tools and their statuses.
+func formatToolsList(toolCfgs []config.ToolConfig) string {
+	if len(toolCfgs) == 0 {
+		return "No tools detected. Install Claude or Cursor and try again.\n"
+	}
+
+	var buf strings.Builder
+	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "TOOL\tSTATUS")
+	for _, t := range toolCfgs {
+		status := "enabled"
+		if !t.Enabled {
+			status = "disabled"
+		}
+		fmt.Fprintf(w, "%s\t%s\n", t.Name, status)
+	}
+	w.Flush()
+	return buf.String()
+}
+
+// formatToolsListJSON returns JSON-encoded tool configs.
+func formatToolsListJSON(toolCfgs []config.ToolConfig) (string, error) {
+	data, err := json.MarshalIndent(toolCfgs, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encode tools JSON: %w", err)
+	}
+	return string(data), nil
+}

--- a/cmd/tools_test.go
+++ b/cmd/tools_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/Naoray/scribe/internal/config"
@@ -19,17 +20,17 @@ func TestFormatToolsList(t *testing.T) {
 		t.Fatal("expected non-empty output")
 	}
 	// Should contain tool names.
-	if !containsStr(out, "claude") {
+	if !strings.Contains(out, "claude") {
 		t.Errorf("output should contain 'claude', got: %s", out)
 	}
-	if !containsStr(out, "cursor") {
+	if !strings.Contains(out, "cursor") {
 		t.Errorf("output should contain 'cursor', got: %s", out)
 	}
 	// Should contain status indicators.
-	if !containsStr(out, "enabled") {
+	if !strings.Contains(out, "enabled") {
 		t.Errorf("output should contain 'enabled', got: %s", out)
 	}
-	if !containsStr(out, "disabled") {
+	if !strings.Contains(out, "disabled") {
 		t.Errorf("output should contain 'disabled', got: %s", out)
 	}
 }
@@ -64,20 +65,8 @@ func TestFormatToolsListJSON(t *testing.T) {
 
 func TestFormatToolsListEmpty(t *testing.T) {
 	out := formatToolsList(nil)
-	if !containsStr(out, "No tools detected") {
+	if !strings.Contains(out, "No tools detected") {
 		t.Errorf("expected 'No tools detected' message, got: %s", out)
 	}
 }
 
-func containsStr(s, substr string) bool {
-	return len(s) >= len(substr) && searchStr(s, substr)
-}
-
-func searchStr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/cmd/tools_test.go
+++ b/cmd/tools_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/config"
+)
+
+func TestFormatToolsList(t *testing.T) {
+	tools := []config.ToolConfig{
+		{Name: "claude", Enabled: true},
+		{Name: "cursor", Enabled: false},
+	}
+
+	out := formatToolsList(tools)
+
+	if out == "" {
+		t.Fatal("expected non-empty output")
+	}
+	// Should contain tool names.
+	if !containsStr(out, "claude") {
+		t.Errorf("output should contain 'claude', got: %s", out)
+	}
+	if !containsStr(out, "cursor") {
+		t.Errorf("output should contain 'cursor', got: %s", out)
+	}
+	// Should contain status indicators.
+	if !containsStr(out, "enabled") {
+		t.Errorf("output should contain 'enabled', got: %s", out)
+	}
+	if !containsStr(out, "disabled") {
+		t.Errorf("output should contain 'disabled', got: %s", out)
+	}
+}
+
+func TestFormatToolsListJSON(t *testing.T) {
+	tools := []config.ToolConfig{
+		{Name: "claude", Enabled: true},
+		{Name: "cursor", Enabled: false},
+	}
+
+	out, err := formatToolsListJSON(tools)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should be valid JSON.
+	var parsed []config.ToolConfig
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+
+	if len(parsed) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(parsed))
+	}
+	if parsed[0].Name != "claude" || !parsed[0].Enabled {
+		t.Errorf("unexpected first tool: %+v", parsed[0])
+	}
+	if parsed[1].Name != "cursor" || parsed[1].Enabled {
+		t.Errorf("unexpected second tool: %+v", parsed[1])
+	}
+}
+
+func TestFormatToolsListEmpty(t *testing.T) {
+	out := formatToolsList(nil)
+	if !containsStr(out, "No tools detected") {
+		t.Errorf("expected 'No tools detected' message, got: %s", out)
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && searchStr(s, substr)
+}
+
+func searchStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,10 +29,17 @@ type RegistryConfig struct {
 	Writable bool   `yaml:"writable,omitempty"`
 }
 
+// ToolConfig describes an AI tool target for skill installation.
+type ToolConfig struct {
+	Name    string `yaml:"name"`
+	Enabled bool   `yaml:"enabled"`
+}
+
 // Config holds user preferences from ~/.scribe/config.yaml.
 type Config struct {
 	Registries []RegistryConfig `yaml:"registries,omitempty"`
 	Token      string           `yaml:"token,omitempty"`
+	Tools      []ToolConfig     `yaml:"tools,omitempty"`
 }
 
 // TeamRepos returns the list of enabled registry repos.

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -18,6 +18,7 @@ type Bag struct {
 	Args         []string
 	JSONFlag     bool
 	RepoFlag     string // --registry filter
+	RemoteFlag   bool   // --remote: show available skills from registries
 	TrustAllFlag bool   // --trust-all: approve all package commands without prompting
 
 	// Populated by steps

--- a/internal/workflow/list.go
+++ b/internal/workflow/list.go
@@ -38,8 +38,8 @@ func ListJSONSteps() []Step {
 func StepWriteListJSON(ctx context.Context, b *Bag) error {
 	w := os.Stdout
 
-	// Local view: no registries connected.
-	if len(b.Config.TeamRepos()) == 0 {
+	// Local view is the default; --remote switches to registry diff.
+	if !b.RemoteFlag {
 		skills, err := discovery.OnDisk(b.State)
 		if err != nil {
 			return err

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"charm.land/huh/v2"
 	"github.com/mattn/go-isatty"
@@ -96,7 +97,24 @@ func StepResolveFormatter(_ context.Context, b *Bag) error {
 
 func StepResolveTools(_ context.Context, b *Bag) error {
 	if b.Tools == nil {
-		b.Tools = tools.DetectTools()
+		detected := tools.DetectTools()
+		// Filter out tools disabled in config.
+		if b.Config != nil && len(b.Config.Tools) > 0 {
+			disabled := make(map[string]bool)
+			for _, t := range b.Config.Tools {
+				if !t.Enabled {
+					disabled[strings.ToLower(t.Name)] = true
+				}
+			}
+			var filtered []tools.Tool
+			for _, t := range detected {
+				if !disabled[strings.ToLower(t.Name())] {
+					filtered = append(filtered, t)
+				}
+			}
+			detected = filtered
+		}
+		b.Tools = detected
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- **`scribe tools`** — new command to list, enable, and disable AI tools (with `ToolConfig` in config)
- **`scribe remove`** — new command to uninstall skills with namespaced resolution, managed-registry warnings, and interactive disambiguation
- **`scribe list`** flipped to machine-first default; `--remote` flag for registry diff view
- **List TUI** updated: groups by registry source, shows version + author columns, renamed labels (Registry, Tools)
- **root.go** wired with new command tree; top-level `migrate` and `connect` deprecated as hidden aliases
- **README** updated with new command taxonomy and examples

Tasks 5-8 from the plan were already completed in prior PRs (#66, #67, #68, #69).

## Test plan

- [ ] `go test ./...` passes (verified locally)
- [ ] `scribe tools` lists detected tools with status
- [ ] `scribe tools enable/disable cursor` toggles and persists to config.yaml
- [ ] `scribe remove <skill>` prompts for confirmation, removes from store + state + tool links
- [ ] `scribe remove <skill> --json` requires `--yes` flag
- [ ] `scribe list` shows local skills grouped by registry
- [ ] `scribe list --remote` shows registry diff view
- [ ] `scribe --help` shows new command taxonomy (add, list, remove, sync, tools, guide, registry)
- [ ] `scribe registry --help` shows subcommands (connect, create, add, list, enable, disable, migrate)
- [ ] `scribe migrate` still works (hidden backward-compat alias)
- [ ] `scribe connect` still works (hidden backward-compat alias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)