### PR TITLE
perf: reduce list TUI arrow key lag

### DIFF
--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -135,6 +135,7 @@ type listModel struct {
 	spinnerFrame  int
 	rows          []listRow
 	filtered      []listRow
+	groupCounts   map[string]int
 	cursor        int
 	offset        int
 	search        string
@@ -354,7 +355,7 @@ func (m listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case rowsLoadedMsg:
 		m.stage = stageBrowse
 		m.rows = msg.rows
-		m.filtered = m.applyFilter()
+		m = m.refreshFiltered()
 		return m, nil
 	case loadErrMsg:
 		m.stage = stageBrowse
@@ -428,8 +429,7 @@ func (m listModel) updateList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+c", "q":
 		if m.search != "" {
 			m.search = ""
-			m.filtered = m.applyFilter()
-			m.cursor, m.offset = 0, 0
+			m = m.refreshFiltered()
 			return m, nil
 		}
 		m.quitting = true
@@ -437,8 +437,7 @@ func (m listModel) updateList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "esc", "escape":
 		if m.search != "" {
 			m.search = ""
-			m.filtered = m.applyFilter()
-			m.cursor, m.offset = 0, 0
+			m = m.refreshFiltered()
 		}
 		return m, nil
 	case "up", "k":
@@ -467,14 +466,12 @@ func (m listModel) updateList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "backspace":
 		if len(m.search) > 0 {
 			m.search = m.search[:len(m.search)-1]
-			m.filtered = m.applyFilter()
-			m.cursor, m.offset = 0, 0
+			m = m.refreshFiltered()
 		}
 	default:
 		if len(msg.String()) == 1 {
 			m.search += msg.String()
-			m.filtered = m.applyFilter()
-			m.cursor, m.offset = 0, 0
+			m = m.refreshFiltered()
 		}
 	}
 	return m, nil
@@ -737,6 +734,7 @@ func (m listModel) executeRemove() (tea.Model, tea.Cmd) {
 			break
 		}
 	}
+	m.groupCounts = buildGroupCounts(m.filtered)
 
 	if m.cursor >= len(m.filtered) {
 		m.cursor = len(m.filtered) - 1
@@ -767,6 +765,21 @@ func (m listModel) applyFilter() []listRow {
 		}
 	}
 	return out
+}
+
+func (m listModel) refreshFiltered() listModel {
+	m.filtered = m.applyFilter()
+	m.groupCounts = buildGroupCounts(m.filtered)
+	m.cursor, m.offset = 0, 0
+	return m
+}
+
+func buildGroupCounts(rows []listRow) map[string]int {
+	counts := make(map[string]int, len(rows))
+	for _, row := range rows {
+		counts[row.Group]++
+	}
+	return counts
 }
 
 // ── View ────────────────────────────────────────────────────────────────────
@@ -976,12 +989,7 @@ func (m listModel) renderRows(b *strings.Builder, contentHeight, maxWidth int, c
 }
 
 func (m listModel) formatGroupHeader(group string) string {
-	count := 0
-	for _, r := range m.filtered {
-		if r.Group == group {
-			count++
-		}
-	}
+	count := m.groupCounts[group]
 	label := group
 	if label == "" {
 		label = "(local)"

--- a/cmd/list_tui_test.go
+++ b/cmd/list_tui_test.go
@@ -165,21 +165,30 @@ func TestRefreshFilteredBuildsGroupCounts(t *testing.T) {
 		rows: []listRow{
 			{Name: "alpha", Group: "g1"},
 			{Name: "beta", Group: "g1"},
+			{Name: "delta", Group: "g1"},
 			{Name: "gamma", Group: "g2"},
 		},
-		search: "a",
+		search: "elt",
+		cursor: 2,
+		offset: 1,
 	}
 
 	m = m.refreshFiltered()
 
-	if got := len(m.filtered); got != 3 {
-		t.Fatalf("filtered len = %d, want 3", got)
+	if got := len(m.filtered); got != 1 {
+		t.Fatalf("filtered len = %d, want 1", got)
 	}
-	if got := m.groupCounts["g1"]; got != 2 {
-		t.Fatalf("groupCounts[g1] = %d, want 2", got)
+	if got := m.filtered[0].Name; got != "delta" {
+		t.Fatalf("filtered[0].Name = %q, want %q", got, "delta")
 	}
-	if got := m.groupCounts["g2"]; got != 1 {
-		t.Fatalf("groupCounts[g2] = %d, want 1", got)
+	if got := m.groupCounts["g1"]; got != 1 {
+		t.Fatalf("groupCounts[g1] = %d, want 1", got)
+	}
+	if got := m.groupCounts["g2"]; got != 0 {
+		t.Fatalf("groupCounts[g2] = %d, want 0", got)
+	}
+	if m.cursor != 0 || m.offset != 0 {
+		t.Fatalf("cursor/offset = %d/%d, want 0/0", m.cursor, m.offset)
 	}
 }
 

--- a/cmd/list_tui_test.go
+++ b/cmd/list_tui_test.go
@@ -160,6 +160,29 @@ func TestRegistryGroupFromName(t *testing.T) {
 	}
 }
 
+func TestRefreshFilteredBuildsGroupCounts(t *testing.T) {
+	m := listModel{
+		rows: []listRow{
+			{Name: "alpha", Group: "g1"},
+			{Name: "beta", Group: "g1"},
+			{Name: "gamma", Group: "g2"},
+		},
+		search: "a",
+	}
+
+	m = m.refreshFiltered()
+
+	if got := len(m.filtered); got != 3 {
+		t.Fatalf("filtered len = %d, want 3", got)
+	}
+	if got := m.groupCounts["g1"]; got != 2 {
+		t.Fatalf("groupCounts[g1] = %d, want 2", got)
+	}
+	if got := m.groupCounts["g2"]; got != 1 {
+		t.Fatalf("groupCounts[g2] = %d, want 1", got)
+	}
+}
+
 func findAction(actions []actionItem, key string) actionItem {
 	for _, a := range actions {
 		if a.key == key {


### PR DESCRIPTION
## Summary
- cache filtered group counts in the list TUI instead of recomputing them during render
- route filter refreshes through a shared helper so cached counts stay in sync
- add a regression test for filtered group-count caching

## Why
Arrow-key navigation in the split view re-renders both panes on every keypress. The left pane was recomputing per-group counts during render by rescanning the full filtered list for each visible group header, which added avoidable latency.

## Testing
- `go test ./cmd`
- `go test ./...` *(fails in existing unrelated `internal/logo` tests: `TestRenderFull`, `TestRenderCompact`, `TestRenderNoColor`)*