### PR TITLE
feat: support autodetected and custom tool runtimes

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -86,7 +86,10 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 	client := gh.NewClient(ctx, cfg.Token)
-	targets := []tools.Tool{tools.ClaudeTool{}, tools.CursorTool{}}
+	targets, err := tools.ResolveActive(cfg)
+	if err != nil {
+		return fmt.Errorf("resolve tools: %w", err)
+	}
 
 	// Direct install: owner/repo:skillname.
 	if len(args) == 1 && skillRefPattern.MatchString(args[0]) {

--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -760,18 +760,17 @@ func (m listModel) executeRemove() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Uninstall from all tools that had this skill installed.
+	// Uninstall from every tool that originally installed the skill, even if
+	// that tool is now disabled. Resolving from installed.Tools instead of
+	// ResolveActive prevents orphaning Gemini/custom-tool installs whenever
+	// the user disables a tool after installing a skill.
 	if installed, ok := m.bag.State.Installed[sk.Name]; ok {
-		resolvedTools, err := tools.ResolveActive(m.bag.Config)
-		if err == nil {
-			for _, tool := range resolvedTools {
-				for _, t := range installed.Tools {
-					if t == tool.Name() {
-						_ = tool.Uninstall(sk.Name)
-						break
-					}
-				}
+		for _, name := range installed.Tools {
+			tool, err := tools.ResolveByName(m.bag.Config, name)
+			if err != nil {
+				continue
 			}
+			_ = tool.Uninstall(sk.Name)
 		}
 	}
 

--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -743,6 +743,7 @@ func (m listModel) executeRemove() (tea.Model, tea.Cmd) {
 	allowedPrefixes := []string{
 		filepath.Join(home, ".scribe", "skills"),
 		filepath.Join(home, ".claude", "skills"),
+		filepath.Join(home, ".codex", "skills"),
 	}
 
 	pathAllowed := false
@@ -761,12 +762,14 @@ func (m listModel) executeRemove() (tea.Model, tea.Cmd) {
 
 	// Uninstall from all tools that had this skill installed.
 	if installed, ok := m.bag.State.Installed[sk.Name]; ok {
-		detectedTools := tools.DetectTools()
-		for _, tool := range detectedTools {
-			for _, t := range installed.Tools {
-				if t == tool.Name() {
-					_ = tool.Uninstall(sk.Name)
-					break
+		resolvedTools, err := tools.ResolveActive(m.bag.Config)
+		if err == nil {
+			for _, tool := range resolvedTools {
+				for _, t := range installed.Tools {
+					if t == tool.Name() {
+						_ = tool.Uninstall(sk.Name)
+						break
+					}
 				}
 			}
 		}

--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -429,18 +429,14 @@ func (m listModel) updateList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "ctrl+c", "q":
 		if m.search != "" {
-			m.search = ""
-			m.filtered = m.applyFilter()
-			m.cursor, m.offset = 0, 0
+			m = m.resetSearch()
 			return m, nil
 		}
 		m.quitting = true
 		return m, tea.Quit
 	case "esc", "escape":
 		if m.search != "" {
-			m.search = ""
-			m.filtered = m.applyFilter()
-			m.cursor, m.offset = 0, 0
+			m = m.resetSearch()
 		}
 		return m, nil
 	case "up", "k":
@@ -467,17 +463,9 @@ func (m listModel) updateList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.statusMsg = ""
 		}
 	case "backspace":
-		if len(m.search) > 0 {
-			m.search = m.search[:len(m.search)-1]
-			m.filtered = m.applyFilter()
-			m.cursor, m.offset = 0, 0
-		}
+		m = m.backspaceSearch()
 	default:
-		if len(msg.String()) == 1 {
-			m.search += msg.String()
-			m.filtered = m.applyFilter()
-			m.cursor, m.offset = 0, 0
-		}
+		m = m.appendSearch(msg.String())
 	}
 	return m, nil
 }
@@ -527,7 +515,8 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.focus == focusList {
 		// Browsing the list with the detail pane open: arrow keys move
 		// the row cursor and the right pane refreshes live. Right/enter
-		// hands focus to the action menu.
+		// hands focus to the action menu. Character keys still filter the
+		// left list without forcing the user to close the detail pane first.
 		switch key {
 		case "up", "k":
 			if m.cursor > 0 {
@@ -546,6 +535,23 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		case "right", "l", "enter":
 			m.focus = focusActions
 			m.actionCursor = 0
+		case "backspace":
+			m = m.backspaceSearch()
+			m.actionCursor = 0
+			m.statusMsg = ""
+			if !m.selected {
+				m.focus = focusList
+			}
+		default:
+			next := m.appendSearch(key)
+			if next.search != m.search {
+				m = next
+				m.actionCursor = 0
+				m.statusMsg = ""
+				if !m.selected {
+					m.focus = focusList
+				}
+			}
 		}
 		return m, nil
 	}
@@ -687,6 +693,42 @@ func (m listModel) executeAction(key string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	return m, nil
+}
+
+func (m listModel) resetSearch() listModel {
+	m.search = ""
+	m.filtered = m.applyFilter()
+	m.cursor, m.offset = 0, 0
+	if len(m.filtered) == 0 {
+		m.selected = false
+	}
+	return m
+}
+
+func (m listModel) backspaceSearch() listModel {
+	if len(m.search) == 0 {
+		return m
+	}
+	m.search = m.search[:len(m.search)-1]
+	m.filtered = m.applyFilter()
+	m.cursor, m.offset = 0, 0
+	if len(m.filtered) == 0 {
+		m.selected = false
+	}
+	return m
+}
+
+func (m listModel) appendSearch(key string) listModel {
+	if len(key) != 1 {
+		return m
+	}
+	m.search += key
+	m.filtered = m.applyFilter()
+	m.cursor, m.offset = 0, 0
+	if len(m.filtered) == 0 {
+		m.selected = false
+	}
+	return m
 }
 
 func (m listModel) executeRemove() (tea.Model, tea.Cmd) {

--- a/cmd/list_tui_test.go
+++ b/cmd/list_tui_test.go
@@ -28,6 +28,8 @@ func key(label string) tea.KeyPressMsg {
 		return tea.KeyPressMsg{Code: 0x0d}
 	case "esc":
 		return tea.KeyPressMsg{Code: 0x1b}
+	case "backspace":
+		return tea.KeyPressMsg{Code: tea.KeyBackspace}
 	case "up":
 		return tea.KeyPressMsg{Code: tea.KeyUp}
 	case "down":
@@ -179,14 +181,16 @@ func findAction(actions []actionItem, key string) actionItem {
 // detailModel builds a listModel with two filtered rows in the detail state,
 // ready for exercising updateDetail.
 func detailModel(focus detailFocus) listModel {
+	rows := []listRow{
+		{Name: "a", Group: "g1", Local: &discovery.Skill{Name: "a", LocalPath: "/p/a"}},
+		{Name: "b", Group: "g2", Local: &discovery.Skill{Name: "b", LocalPath: "/p/b"}},
+	}
 	return listModel{
 		selected: true,
 		focus:    focus,
 		cursor:   0,
-		filtered: []listRow{
-			{Name: "a", Local: &discovery.Skill{Name: "a", LocalPath: "/p/a"}},
-			{Name: "b", Local: &discovery.Skill{Name: "b", LocalPath: "/p/b"}},
-		},
+		rows:     rows,
+		filtered: rows,
 	}
 }
 
@@ -276,6 +280,64 @@ func TestUpdateDetail_FocusActionsMovesActionCursor(t *testing.T) {
 	}
 	if lm.actionCursor != 1 {
 		t.Errorf("focusActions j should advance actionCursor, got %d", lm.actionCursor)
+	}
+}
+
+func TestUpdateDetail_FocusListTypingFiltersRows(t *testing.T) {
+	m := detailModel(focusList)
+
+	nm, _ := m.updateDetail(key("b"))
+	lm := nm.(listModel)
+	if lm.search != "b" {
+		t.Fatalf("search = %q, want %q", lm.search, "b")
+	}
+	if len(lm.filtered) != 1 {
+		t.Fatalf("filtered len = %d, want 1", len(lm.filtered))
+	}
+	if lm.filtered[0].Name != "b" {
+		t.Fatalf("filtered[0] = %q, want %q", lm.filtered[0].Name, "b")
+	}
+	if !lm.selected {
+		t.Fatal("detail pane should stay open when search still has matches")
+	}
+	if lm.focus != focusList {
+		t.Fatalf("focus = %v, want focusList", lm.focus)
+	}
+}
+
+func TestUpdateDetail_FocusListBackspaceUpdatesSearch(t *testing.T) {
+	m := detailModel(focusList)
+	m.search = "b"
+	m.filtered = []listRow{
+		{Name: "b", Group: "g2", Local: &discovery.Skill{Name: "b", LocalPath: "/p/b"}},
+	}
+
+	nm, _ := m.updateDetail(key("backspace"))
+	lm := nm.(listModel)
+	if lm.search != "" {
+		t.Fatalf("search = %q, want empty", lm.search)
+	}
+	if len(lm.filtered) != 2 {
+		t.Fatalf("filtered len = %d, want 2", len(lm.filtered))
+	}
+	if !lm.selected {
+		t.Fatal("detail pane should stay open after restoring matching rows")
+	}
+}
+
+func TestUpdateDetail_FocusListTypingNoMatchesClosesDetail(t *testing.T) {
+	m := detailModel(focusList)
+
+	nm, _ := m.updateDetail(key("z"))
+	lm := nm.(listModel)
+	if lm.search != "z" {
+		t.Fatalf("search = %q, want %q", lm.search, "z")
+	}
+	if len(lm.filtered) != 0 {
+		t.Fatalf("filtered len = %d, want 0", len(lm.filtered))
+	}
+	if lm.selected {
+		t.Fatal("detail pane should close when the current search removes all rows")
 	}
 }
 

--- a/cmd/registry_add.go
+++ b/cmd/registry_add.go
@@ -31,7 +31,7 @@ files are uploaded directly to the target registry.
 If the argument looks like "owner/repo", it's treated as a package
 reference. When the upstream repo exposes a scribe.yaml package manifest,
 its declared install commands are used automatically. Otherwise Scribe
-prompts for an install command per detected tool (claude, cursor). Use
+prompts for an install command per detected tool. Use
 --install tool=command (repeatable) to supply commands non-interactively.
 
 With no arguments in a terminal, shows an interactive browser to select
@@ -78,7 +78,14 @@ func runRegistryAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("authentication required — run `gh auth login` or set GITHUB_TOKEN")
 	}
 
-	targets := []tools.Tool{tools.ClaudeTool{}, tools.CursorTool{}}
+	targetStatuses, err := tools.ResolveStatuses(cfg)
+	if err != nil {
+		return fmt.Errorf("resolve tools: %w", err)
+	}
+	targets, err := tools.ResolveActive(cfg)
+	if err != nil {
+		return fmt.Errorf("resolve active tools: %w", err)
+	}
 	adder := &add.Adder{Client: client, Tools: targets}
 
 	// Resolve target registry.
@@ -96,7 +103,7 @@ func runRegistryAdd(cmd *cobra.Command, args []string) error {
 
 	// Package ref fast path — doesn't need local/remote discovery.
 	if len(args) == 1 && strings.Contains(args[0], "/") {
-		return runRegistryAddPackageRef(ctx, args[0], installFlags, adder, targetRepo, st, client, targets, useJSON, isTTY)
+		return runRegistryAddPackageRef(ctx, args[0], installFlags, adder, targetRepo, st, client, targets, targetStatuses, useJSON, isTTY)
 	}
 
 	// Discover candidates.
@@ -156,6 +163,7 @@ func runRegistryAddPackageRef(
 	st *state.State,
 	client *gh.Client,
 	targets []tools.Tool,
+	knownTargets []tools.Status,
 	useJSON bool,
 	isTTY bool,
 ) error {
@@ -173,7 +181,7 @@ func runRegistryAddPackageRef(
 	}
 
 	// Gather install commands.
-	installs, perr := collectInstallCommands(packageRepo, installFlags, targets, isTTY)
+	installs, perr := collectInstallCommands(packageRepo, installFlags, knownTargets, isTTY)
 	if perr != nil {
 		return perr
 	}
@@ -210,12 +218,12 @@ func isPackageManifestMissingErr(err error) bool {
 
 // collectInstallCommands returns a map of tool name → install command,
 // either from --install flags or by prompting the user.
-func collectInstallCommands(packageRepo string, flags []string, targets []tools.Tool, isTTY bool) (map[string]string, error) {
+func collectInstallCommands(packageRepo string, flags []string, knownTargets []tools.Status, isTTY bool) (map[string]string, error) {
 	// Parse --install flags first — they always win.
 	installs := map[string]string{}
 	validTools := map[string]bool{}
-	for _, t := range targets {
-		validTools[t.Name()] = true
+	for _, t := range knownTargets {
+		validTools[t.Name] = true
 	}
 
 	for _, raw := range flags {
@@ -229,7 +237,7 @@ func collectInstallCommands(packageRepo string, flags []string, targets []tools.
 			return nil, fmt.Errorf("invalid --install value %q: tool and command must be non-empty", raw)
 		}
 		if !validTools[tool] {
-			return nil, fmt.Errorf("unknown tool %q in --install — expected one of: %s", tool, strings.Join(toolNames(targets), ", "))
+			return nil, fmt.Errorf("unknown tool %q in --install — expected one of: %s", tool, strings.Join(toolNames(knownTargets), ", "))
 		}
 		installs[tool] = cmd
 	}
@@ -248,10 +256,10 @@ func collectInstallCommands(packageRepo string, flags []string, targets []tools.
 	fmt.Println("Enter the install command for each tool (leave blank to skip):")
 	fmt.Println()
 
-	for _, t := range targets {
+	for _, t := range knownTargets {
 		var value string
 		prompt := huh.NewInput().
-			Title(fmt.Sprintf("Install command for %s", t.Name())).
+			Title(fmt.Sprintf("Install command for %s", t.Name)).
 			Placeholder("e.g. /plugin install superpowers").
 			Value(&value)
 		if err := prompt.Run(); err != nil {
@@ -259,16 +267,16 @@ func collectInstallCommands(packageRepo string, flags []string, targets []tools.
 		}
 		value = strings.TrimSpace(value)
 		if value != "" {
-			installs[t.Name()] = value
+			installs[t.Name] = value
 		}
 	}
 	return installs, nil
 }
 
-func toolNames(targets []tools.Tool) []string {
+func toolNames(targets []tools.Status) []string {
 	names := make([]string, 0, len(targets))
 	for _, t := range targets {
-		names = append(names, t.Name())
+		names = append(names, t.Name)
 	}
 	return names
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -113,21 +113,18 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Uninstall from all tools.
+	// Uninstall from every tool that originally installed the skill, even if
+	// that tool is now disabled or missing from config. Otherwise disabling a
+	// tool after install would orphan its side of the skill on disk.
 	var errs []string
-	resolvedTools, err := tools.ResolveActive(cfg)
-	if err != nil {
-		return fmt.Errorf("resolve tools: %w", err)
-	}
-	for _, tool := range resolvedTools {
-		// Only uninstall from tools that had the skill installed.
-		for _, t := range installed.Tools {
-			if t == tool.Name() {
-				if err := tool.Uninstall(key); err != nil {
-					errs = append(errs, fmt.Sprintf("%s: %v", tool.Name(), err))
-				}
-				break
-			}
+	for _, name := range installed.Tools {
+		tool, err := tools.ResolveByName(cfg, name)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+			continue
+		}
+		if err := tool.Uninstall(key); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", name, err))
 		}
 	}
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -115,8 +115,11 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 	// Uninstall from all tools.
 	var errs []string
-	detectedTools := tools.DetectTools()
-	for _, tool := range detectedTools {
+	resolvedTools, err := tools.ResolveActive(cfg)
+	if err != nil {
+		return fmt.Errorf("resolve tools: %w", err)
+	}
+	for _, tool := range resolvedTools {
 		// Only uninstall from tools that had the skill installed.
 		for _, t := range installed.Tools {
 			if t == tool.Name() {

--- a/cmd/tools.go
+++ b/cmd/tools.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"charm.land/huh/v2"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
@@ -25,14 +26,31 @@ during sync.
 
 Examples:
   scribe tools                # list tools and status
+  scribe tools add gemini     # force-add a builtin tool
+  scribe tools add aider      # add a custom tool
   scribe tools enable cursor  # enable a tool
   scribe tools disable cursor # disable a tool`,
 		Args: cobra.NoArgs,
 		RunE: runToolsList,
 	}
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	cmd.AddCommand(newToolsAddCommand())
 	cmd.AddCommand(newToolsEnableCommand())
 	cmd.AddCommand(newToolsDisableCommand())
+	return cmd
+}
+
+func newToolsAddCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Add a builtin or custom tool definition",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runToolsAdd,
+	}
+	cmd.Flags().String("detect", "", "Shell command used to detect the tool")
+	cmd.Flags().String("install", "", "Shell command template used to install a skill")
+	cmd.Flags().String("uninstall", "", "Shell command template used to uninstall a skill")
+	cmd.Flags().String("path", "", "Optional installed-path template recorded in state")
 	return cmd
 }
 
@@ -62,11 +80,14 @@ func runToolsList(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	ensureToolsPopulated(cfg)
+	statuses, err := tools.ResolveStatuses(cfg)
+	if err != nil {
+		return err
+	}
 
 	useJSON := jsonFlag || !isatty.IsTerminal(os.Stdout.Fd())
 	if useJSON {
-		out, err := formatToolsListJSON(cfg.Tools)
+		out, err := formatToolsListJSON(statuses)
 		if err != nil {
 			return err
 		}
@@ -74,7 +95,71 @@ func runToolsList(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	fmt.Print(formatToolsList(cfg.Tools))
+	fmt.Print(formatToolsList(statuses))
+	return nil
+}
+
+func runToolsAdd(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	name := strings.TrimSpace(args[0])
+	detect, _ := cmd.Flags().GetString("detect")
+	install, _ := cmd.Flags().GetString("install")
+	uninstall, _ := cmd.Flags().GetString("uninstall")
+	pathTemplate, _ := cmd.Flags().GetString("path")
+
+	if _, ok := tools.BuiltinByName(name); ok {
+		upsertToolConfig(cfg, config.ToolConfig{
+			Name:    name,
+			Type:    tools.ToolTypeBuiltin,
+			Enabled: true,
+		})
+		if err := cfg.Save(); err != nil {
+			return err
+		}
+		fmt.Printf("Tool %s added\n", name)
+		return nil
+	}
+
+	if isatty.IsTerminal(os.Stdin.Fd()) {
+		if strings.TrimSpace(detect) == "" {
+			_ = huh.NewInput().Title("Detect command (optional)").Value(&detect).Run()
+		}
+		if strings.TrimSpace(install) == "" {
+			if err := huh.NewInput().Title("Install command").Value(&install).Run(); err != nil {
+				return err
+			}
+		}
+		if strings.TrimSpace(uninstall) == "" {
+			if err := huh.NewInput().Title("Uninstall command").Value(&uninstall).Run(); err != nil {
+				return err
+			}
+		}
+		if strings.TrimSpace(pathTemplate) == "" {
+			_ = huh.NewInput().Title("Installed path template (optional)").Value(&pathTemplate).Run()
+		}
+	}
+
+	if strings.TrimSpace(install) == "" || strings.TrimSpace(uninstall) == "" {
+		return fmt.Errorf("custom tool %q requires --install and --uninstall", name)
+	}
+
+	upsertToolConfig(cfg, config.ToolConfig{
+		Name:      name,
+		Type:      tools.ToolTypeCustom,
+		Enabled:   true,
+		Detect:    strings.TrimSpace(detect),
+		Install:   strings.TrimSpace(install),
+		Uninstall: strings.TrimSpace(uninstall),
+		Path:      strings.TrimSpace(pathTemplate),
+	})
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+	fmt.Printf("Tool %s added\n", name)
 	return nil
 }
 
@@ -92,76 +177,89 @@ func setToolEnabled(name string, enabled bool) error {
 		return err
 	}
 
-	ensureToolsPopulated(cfg)
-
-	found := false
 	for i := range cfg.Tools {
 		if strings.EqualFold(cfg.Tools[i].Name, name) {
 			cfg.Tools[i].Enabled = enabled
-			found = true
-			break
+			if err := cfg.Save(); err != nil {
+				return err
+			}
+			printToolAction(name, enabled)
+			return nil
 		}
 	}
 
-	if !found {
-		known := make([]string, len(cfg.Tools))
-		for i, t := range cfg.Tools {
-			known[i] = t.Name
+	if _, ok := tools.BuiltinByName(name); ok {
+		upsertToolConfig(cfg, config.ToolConfig{
+			Name:    name,
+			Type:    tools.ToolTypeBuiltin,
+			Enabled: enabled,
+		})
+		if err := cfg.Save(); err != nil {
+			return err
 		}
-		return fmt.Errorf("unknown tool %q — known tools: %s", name, strings.Join(known, ", "))
+		printToolAction(name, enabled)
+		return nil
 	}
 
-	if err := cfg.Save(); err != nil {
+	statuses, err := tools.ResolveStatuses(cfg)
+	if err != nil {
 		return err
 	}
+	known := make([]string, len(statuses))
+	for i, st := range statuses {
+		known[i] = st.Name
+	}
+	return fmt.Errorf("unknown tool %q — known tools: %s", name, strings.Join(known, ", "))
+}
 
+func printToolAction(name string, enabled bool) {
 	action := "enabled"
 	if !enabled {
 		action = "disabled"
 	}
 	fmt.Printf("Tool %s %s\n", name, action)
-	return nil
 }
 
-// ensureToolsPopulated auto-populates cfg.Tools from detected tools if empty.
-func ensureToolsPopulated(cfg *config.Config) {
-	if len(cfg.Tools) > 0 {
-		return
-	}
-	detected := tools.DetectTools()
-	for _, t := range detected {
-		cfg.Tools = append(cfg.Tools, config.ToolConfig{
-			Name:    t.Name(),
-			Enabled: true,
-		})
-	}
-}
-
-// formatToolsList returns a tab-formatted table of tools and their statuses.
-func formatToolsList(toolCfgs []config.ToolConfig) string {
-	if len(toolCfgs) == 0 {
-		return "No tools detected. Install Claude or Cursor and try again.\n"
+func formatToolsList(statuses []tools.Status) string {
+	if len(statuses) == 0 {
+		return "No tools detected or configured.\n"
 	}
 
 	var buf strings.Builder
 	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "TOOL\tSTATUS")
-	for _, t := range toolCfgs {
+	fmt.Fprintln(w, "TOOL\tTYPE\tSTATUS\tDETECTED\tSOURCE")
+	for _, t := range statuses {
 		status := "enabled"
 		if !t.Enabled {
 			status = "disabled"
 		}
-		fmt.Fprintf(w, "%s\t%s\n", t.Name, status)
+		detected := "n/a"
+		if t.DetectKnown {
+			detected = "no"
+			if t.Detected {
+				detected = "yes"
+			}
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", t.Name, t.Type, status, detected, t.Source)
 	}
 	w.Flush()
 	return buf.String()
 }
 
-// formatToolsListJSON returns JSON-encoded tool configs.
-func formatToolsListJSON(toolCfgs []config.ToolConfig) (string, error) {
-	data, err := json.MarshalIndent(toolCfgs, "", "  ")
+func formatToolsListJSON(statuses []tools.Status) (string, error) {
+	data, err := json.MarshalIndent(statuses, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("encode tools JSON: %w", err)
 	}
 	return string(data), nil
+}
+
+func upsertToolConfig(cfg *config.Config, tc config.ToolConfig) {
+	for i := range cfg.Tools {
+		if strings.EqualFold(cfg.Tools[i].Name, tc.Name) {
+			cfg.Tools[i] = tc
+			return
+		}
+	}
+	cfg.Tools = append(cfg.Tools, tc)
 }

--- a/cmd/tools_test.go
+++ b/cmd/tools_test.go
@@ -5,49 +5,38 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/tools"
 )
 
 func TestFormatToolsList(t *testing.T) {
-	tools := []config.ToolConfig{
-		{Name: "claude", Enabled: true},
-		{Name: "cursor", Enabled: false},
+	statuses := []tools.Status{
+		{Name: "claude", Type: "builtin", Enabled: true, Detected: true, DetectKnown: true, Source: "auto"},
+		{Name: "aider", Type: "custom", Enabled: false, Detected: false, DetectKnown: false, Source: "manual"},
 	}
 
-	out := formatToolsList(tools)
-
+	out := formatToolsList(statuses)
 	if out == "" {
 		t.Fatal("expected non-empty output")
 	}
-	// Should contain tool names.
-	if !strings.Contains(out, "claude") {
-		t.Errorf("output should contain 'claude', got: %s", out)
-	}
-	if !strings.Contains(out, "cursor") {
-		t.Errorf("output should contain 'cursor', got: %s", out)
-	}
-	// Should contain status indicators.
-	if !strings.Contains(out, "enabled") {
-		t.Errorf("output should contain 'enabled', got: %s", out)
-	}
-	if !strings.Contains(out, "disabled") {
-		t.Errorf("output should contain 'disabled', got: %s", out)
+	for _, want := range []string{"claude", "aider", "builtin", "custom", "enabled", "disabled", "auto", "manual"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output should contain %q, got: %s", want, out)
+		}
 	}
 }
 
 func TestFormatToolsListJSON(t *testing.T) {
-	tools := []config.ToolConfig{
-		{Name: "claude", Enabled: true},
-		{Name: "cursor", Enabled: false},
+	statuses := []tools.Status{
+		{Name: "claude", Type: "builtin", Enabled: true, Detected: true, DetectKnown: true, Source: "auto"},
+		{Name: "aider", Type: "custom", Enabled: true, Detected: false, DetectKnown: false, Source: "manual"},
 	}
 
-	out, err := formatToolsListJSON(tools)
+	out, err := formatToolsListJSON(statuses)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Should be valid JSON.
-	var parsed []config.ToolConfig
+	var parsed []tools.Status
 	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
 		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
 	}
@@ -58,15 +47,14 @@ func TestFormatToolsListJSON(t *testing.T) {
 	if parsed[0].Name != "claude" || !parsed[0].Enabled {
 		t.Errorf("unexpected first tool: %+v", parsed[0])
 	}
-	if parsed[1].Name != "cursor" || parsed[1].Enabled {
+	if parsed[1].Name != "aider" || !parsed[1].Enabled {
 		t.Errorf("unexpected second tool: %+v", parsed[1])
 	}
 }
 
 func TestFormatToolsListEmpty(t *testing.T) {
 	out := formatToolsList(nil)
-	if !strings.Contains(out, "No tools detected") {
-		t.Errorf("expected 'No tools detected' message, got: %s", out)
+	if !strings.Contains(out, "No tools detected or configured") {
+		t.Errorf("expected empty-state message, got: %s", out)
 	}
 }
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,8 +31,13 @@ type RegistryConfig struct {
 
 // ToolConfig describes an AI tool target for skill installation.
 type ToolConfig struct {
-	Name    string `yaml:"name"`
-	Enabled bool   `yaml:"enabled"`
+	Name      string `yaml:"name"`
+	Enabled   bool   `yaml:"enabled"`
+	Type      string `yaml:"type,omitempty"`      // "builtin" or "custom"
+	Detect    string `yaml:"detect,omitempty"`    // shell command used to detect custom tools
+	Install   string `yaml:"install,omitempty"`   // shell command template for custom tools
+	Uninstall string `yaml:"uninstall,omitempty"` // shell command template for custom tools
+	Path      string `yaml:"path,omitempty"`      // optional installed-path template for custom tools
 }
 
 // Config holds user preferences from ~/.scribe/config.yaml.
@@ -188,4 +193,3 @@ func (c *Config) Save() error {
 	}
 	return nil
 }
-

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -38,8 +38,8 @@ type rawFrontmatter struct {
 
 // reservedNames lists directory names that should be skipped during scanning.
 var reservedNames = map[string]bool{
-	"versions": true,
-	".git":     true,
+	"versions":  true,
+	".git":      true,
 	".DS_Store": true,
 }
 
@@ -56,9 +56,11 @@ type Skill struct {
 	Revision    int      // from state
 }
 
-// OnDisk scans ~/.scribe/skills/ (flat directories) and ~/.claude/skills/ (file symlinks)
-// for installed skills. Cross-references state.json for tracked skill metadata.
-// Deduplicates by resolved path (a skill found via both locations is one skill).
+// OnDisk scans ~/.scribe/skills/ plus tool-facing install locations that are
+// directly visible on disk. Cross-references state.json for tracked skill
+// metadata. Deduplicates by skill name, preferring the canonical Scribe store.
+// Gemini-managed installs are not scanned from disk in v1; Scribe relies on
+// state for those.
 func OnDisk(st *state.State) ([]Skill, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -66,7 +68,6 @@ func OnDisk(st *state.State) ([]Skill, error) {
 	}
 
 	scribeSkills := filepath.Join(home, ".scribe", "skills")
-	claudeSkills := filepath.Join(home, ".claude", "skills")
 
 	// seen tracks skill names we've already processed (dedup by name).
 	seen := map[string]bool{}
@@ -96,53 +97,18 @@ func OnDisk(st *state.State) ([]Skill, error) {
 		skills = append(skills, sk)
 	}
 
-	// 2. Scan ~/.claude/skills/ — file symlinks to ~/.scribe/skills/<name>/SKILL.md.
-	claudeEntries, err := os.ReadDir(claudeSkills)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return nil, fmt.Errorf("read %s: %w", claudeSkills, err)
-	}
-	for _, entry := range claudeEntries {
-		name := entry.Name()
-		if reservedNames[name] || !validSkillName.MatchString(name) {
-			continue
+	for _, scan := range []struct {
+		dir    string
+		target string
+	}{
+		{dir: filepath.Join(home, ".claude", "skills"), target: "claude"},
+		{dir: filepath.Join(home, ".codex", "skills"), target: "codex"},
+	} {
+		found, scanErr := scanToolSkills(scan.dir, scan.target, seen, st)
+		if scanErr != nil {
+			return nil, scanErr
 		}
-
-		entryPath := filepath.Join(claudeSkills, name)
-
-		// Resolve the symlink to find the actual skill directory.
-		resolved, err := filepath.EvalSymlinks(entryPath)
-		if err != nil {
-			continue // broken symlink, skip
-		}
-
-		// For file symlinks (pointing to SKILL.md), the skill dir is the parent.
-		// For directory symlinks (legacy), the skill dir is the resolved path itself.
-		info, err := os.Stat(resolved)
-		if err != nil {
-			continue
-		}
-
-		var skillDir string
-		if info.IsDir() {
-			skillDir = resolved
-		} else {
-			skillDir = filepath.Dir(resolved)
-		}
-
-		// Derive the skill name from the scribe store directory name.
-		skillName := filepath.Base(skillDir)
-		if seen[skillName] {
-			continue // already found via scribe store
-		}
-
-		// Verify SKILL.md exists in the resolved directory.
-		if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
-			continue
-		}
-
-		seen[skillName] = true
-		sk := buildSkill(skillName, skillDir, filepath.Dir(skillDir), "claude", st)
-		skills = append(skills, sk)
+		skills = append(skills, found...)
 	}
 
 	// 3. Include state-tracked skills not found on disk (orphans).
@@ -172,6 +138,52 @@ func OnDisk(st *state.State) ([]Skill, error) {
 		return skills[i].Name < skills[j].Name
 	})
 
+	return skills, nil
+}
+
+func scanToolSkills(dir, target string, seen map[string]bool, st *state.State) ([]Skill, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", dir, err)
+	}
+
+	var skills []Skill
+	for _, entry := range entries {
+		name := entry.Name()
+		if reservedNames[name] || !validSkillName.MatchString(name) {
+			continue
+		}
+
+		entryPath := filepath.Join(dir, name)
+		resolved, err := filepath.EvalSymlinks(entryPath)
+		if err != nil {
+			continue
+		}
+
+		info, err := os.Stat(resolved)
+		if err != nil {
+			continue
+		}
+
+		skillDir := resolved
+		if !info.IsDir() {
+			skillDir = filepath.Dir(resolved)
+		}
+
+		skillName := filepath.Base(skillDir)
+		if seen[skillName] {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
+			continue
+		}
+
+		seen[skillName] = true
+		skills = append(skills, buildSkill(skillName, skillDir, filepath.Dir(skillDir), target, st))
+	}
 	return skills, nil
 }
 
@@ -359,4 +371,3 @@ func truncateDescription(s string) string {
 	}
 	return s
 }
-

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -285,6 +285,41 @@ func TestOnDiskFileSymlinks(t *testing.T) {
 	}
 }
 
+func TestOnDiskCodexSymlink(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	scribeSkills := filepath.Join(home, ".scribe", "skills")
+	skillDir := filepath.Join(scribeSkills, "codex-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Codex Skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	codexSkills := filepath.Join(home, ".codex", "skills")
+	if err := os.MkdirAll(codexSkills, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(skillDir, filepath.Join(codexSkills, "codex-skill")); err != nil {
+		t.Fatal(err)
+	}
+
+	st := &state.State{Installed: map[string]state.InstalledSkill{}}
+	skills, err := OnDisk(st)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d: %+v", len(skills), skills)
+	}
+	if skills[0].Name != "codex-skill" {
+		t.Errorf("expected codex-skill, got %q", skills[0].Name)
+	}
+}
+
 func TestHasConflictMarkers(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/tools/codex.go
+++ b/internal/tools/codex.go
@@ -1,0 +1,63 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const toolCodex = "codex"
+
+// CodexTool exposes Scribe-managed skills to Codex via ~/.codex/skills.
+type CodexTool struct{}
+
+func (t CodexTool) Name() string { return toolCodex }
+
+func (t CodexTool) Detect() bool {
+	if _, err := exec.LookPath(toolCodex); err == nil {
+		return true
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	return homeDirExists(filepath.Join(home, ".codex"))
+}
+
+func (t CodexTool) Install(skillName, canonicalDir string) ([]string, error) {
+	skillsDir, err := codexSkillsDir()
+	if err != nil {
+		return nil, err
+	}
+	link := filepath.Join(skillsDir, skillName)
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create codex skills dir: %w", err)
+	}
+	if err := replaceSymlink(link, canonicalDir); err != nil {
+		return nil, fmt.Errorf("symlink codex/%s: %w", skillName, err)
+	}
+	return []string{link}, nil
+}
+
+func (t CodexTool) Uninstall(skillName string) error {
+	skillsDir, err := codexSkillsDir()
+	if err != nil {
+		return err
+	}
+	link := filepath.Join(skillsDir, skillName)
+	if err := os.Remove(link); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove codex/%s: %w", skillName, err)
+	}
+	return nil
+}
+
+func codexSkillsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, ".codex", "skills"), nil
+}

--- a/internal/tools/command.go
+++ b/internal/tools/command.go
@@ -1,0 +1,73 @@
+package tools
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// CommandTool is a configurable tool backed by shell command templates.
+type CommandTool struct {
+	ToolName         string
+	DetectCommand    string
+	InstallCommand   string
+	UninstallCommand string
+	PathTemplate     string
+}
+
+func (t CommandTool) Name() string { return t.ToolName }
+
+func (t CommandTool) Detect() bool {
+	if strings.TrimSpace(t.DetectCommand) == "" {
+		return false
+	}
+	return runShell(t.DetectCommand) == nil
+}
+
+func (t CommandTool) Install(skillName, canonicalDir string) ([]string, error) {
+	cmd := renderTemplate(t.InstallCommand, t.ToolName, skillName, canonicalDir)
+	if err := runShell(cmd); err != nil {
+		return nil, fmt.Errorf("install %s via %s: %w", skillName, t.ToolName, err)
+	}
+
+	path := renderPathTemplate(t.PathTemplate, t.ToolName, skillName, canonicalDir)
+	return []string{path}, nil
+}
+
+func (t CommandTool) Uninstall(skillName string) error {
+	cmd := renderTemplate(t.UninstallCommand, t.ToolName, skillName, "")
+	if err := runShell(cmd); err != nil {
+		return fmt.Errorf("uninstall %s via %s: %w", skillName, t.ToolName, err)
+	}
+	return nil
+}
+
+func runShell(command string) error {
+	out, err := exec.Command("sh", "-c", command).CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return err
+	}
+	return fmt.Errorf("%w: %s", err, trimmed)
+}
+
+func renderTemplate(template, toolName, skillName, canonicalDir string) string {
+	repl := strings.NewReplacer(
+		"{{tool_name}}", toolName,
+		"{{skill_name}}", skillName,
+		"{{canonical_dir}}", canonicalDir,
+		"{{skill_dir}}", canonicalDir,
+		"{{skill_md}}", strings.TrimSuffix(canonicalDir, "/")+"/SKILL.md",
+	)
+	return repl.Replace(template)
+}
+
+func renderPathTemplate(template, toolName, skillName, canonicalDir string) string {
+	if strings.TrimSpace(template) == "" {
+		return fmt.Sprintf("tool:%s:%s", toolName, skillName)
+	}
+	return renderTemplate(template, toolName, skillName, canonicalDir)
+}

--- a/internal/tools/gemini.go
+++ b/internal/tools/gemini.go
@@ -1,0 +1,58 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os/exec"
+	"strings"
+)
+
+const toolGemini = "gemini"
+
+// GeminiTool delegates skill lifecycle management to the native Gemini CLI.
+type GeminiTool struct{}
+
+func (t GeminiTool) Name() string { return toolGemini }
+
+func (t GeminiTool) Detect() bool {
+	_, err := exec.LookPath(toolGemini)
+	return err == nil
+}
+
+func (t GeminiTool) Install(skillName, canonicalDir string) ([]string, error) {
+	cmd := exec.Command(toolGemini, "skills", "link", canonicalDir, "--scope", "user", "--consent")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("gemini skills link %q: %w%s", skillName, err, formatCommandOutput(out))
+	}
+	return []string{fmt.Sprintf("gemini:user:%s", skillName)}, nil
+}
+
+func (t GeminiTool) Uninstall(skillName string) error {
+	cmd := exec.Command(toolGemini, "skills", "uninstall", skillName, "--scope", "user")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(out))
+		if strings.Contains(strings.ToLower(trimmed), "not found") {
+			return nil
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 0 {
+			return nil
+		}
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("gemini skills uninstall %q: %w%s", skillName, err, formatCommandOutput(out))
+	}
+	return nil
+}
+
+func formatCommandOutput(out []byte) string {
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return ""
+	}
+	return ": " + trimmed
+}

--- a/internal/tools/gemini.go
+++ b/internal/tools/gemini.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"errors"
 	"fmt"
-	"io/fs"
 	"os/exec"
 	"strings"
 )
@@ -30,6 +29,12 @@ func (t GeminiTool) Install(skillName, canonicalDir string) ([]string, error) {
 }
 
 func (t GeminiTool) Uninstall(skillName string) error {
+	// Fail loudly when the gemini CLI is missing from PATH. Silently returning
+	// nil would leave Gemini's side of the install in place while Scribe drops
+	// its state entry — the user never learns cleanup was skipped.
+	if _, err := exec.LookPath(toolGemini); err != nil {
+		return fmt.Errorf("gemini CLI not found in PATH — skill %q may still be linked; run `gemini skills uninstall %s --scope user` manually", skillName, skillName)
+	}
 	cmd := exec.Command(toolGemini, "skills", "uninstall", skillName, "--scope", "user")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -39,9 +44,6 @@ func (t GeminiTool) Uninstall(skillName string) error {
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 0 {
-			return nil
-		}
-		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 		return fmt.Errorf("gemini skills uninstall %q: %w%s", skillName, err, formatCommandOutput(out))

--- a/internal/tools/runtime.go
+++ b/internal/tools/runtime.go
@@ -35,6 +35,20 @@ func BuiltinByName(name string) (Tool, bool) {
 	return tool, ok
 }
 
+// ResolveByName returns a Tool for the given name regardless of whether it is
+// currently enabled. Used by uninstall paths so that a tool which originally
+// installed a skill can still clean up after it is disabled.
+func ResolveByName(cfg *config.Config, name string) (Tool, error) {
+	toolCfg := findToolConfig(cfg, name)
+	if builtin, ok := BuiltinByName(name); ok && (toolCfg == nil || toolCfg.Type != ToolTypeCustom) {
+		return builtin, nil
+	}
+	if toolCfg == nil {
+		return nil, fmt.Errorf("unknown tool %q", name)
+	}
+	return customToolFromConfig(*toolCfg)
+}
+
 func ResolveActive(cfg *config.Config) ([]Tool, error) {
 	statuses, err := ResolveStatuses(cfg)
 	if err != nil {

--- a/internal/tools/runtime.go
+++ b/internal/tools/runtime.go
@@ -1,0 +1,168 @@
+package tools
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Naoray/scribe/internal/config"
+)
+
+const (
+	ToolTypeBuiltin = "builtin"
+	ToolTypeCustom  = "custom"
+)
+
+type Status struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Enabled     bool   `json:"enabled"`
+	Detected    bool   `json:"detected"`
+	DetectKnown bool   `json:"detect_known"`
+	Source      string `json:"source"`
+}
+
+func builtinRegistry() map[string]Tool {
+	registry := make(map[string]Tool)
+	for _, tool := range DefaultTools() {
+		registry[strings.ToLower(tool.Name())] = tool
+	}
+	return registry
+}
+
+func BuiltinByName(name string) (Tool, bool) {
+	tool, ok := builtinRegistry()[strings.ToLower(name)]
+	return tool, ok
+}
+
+func ResolveActive(cfg *config.Config) ([]Tool, error) {
+	statuses, err := ResolveStatuses(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var active []Tool
+	for _, st := range statuses {
+		if !st.Enabled {
+			continue
+		}
+		toolCfg := findToolConfig(cfg, st.Name)
+		if builtin, ok := BuiltinByName(st.Name); ok && (toolCfg == nil || toolCfg.Type != ToolTypeCustom) {
+			active = append(active, builtin)
+			continue
+		}
+		if toolCfg == nil {
+			continue
+		}
+		custom, err := customToolFromConfig(*toolCfg)
+		if err != nil {
+			return nil, err
+		}
+		active = append(active, custom)
+	}
+	return active, nil
+}
+
+func ResolveStatuses(cfg *config.Config) ([]Status, error) {
+	detected := DetectTools()
+	builtinDetected := make(map[string]bool, len(detected))
+	for _, tool := range detected {
+		builtinDetected[strings.ToLower(tool.Name())] = true
+	}
+
+	statuses := make(map[string]Status)
+	for _, tool := range DefaultTools() {
+		name := strings.ToLower(tool.Name())
+		if builtinDetected[name] {
+			statuses[name] = Status{
+				Name:        tool.Name(),
+				Type:        ToolTypeBuiltin,
+				Enabled:     true,
+				Detected:    true,
+				DetectKnown: true,
+				Source:      "auto",
+			}
+		}
+	}
+
+	if cfg != nil {
+		for _, tc := range cfg.Tools {
+			name := strings.ToLower(tc.Name)
+			if name == "" {
+				continue
+			}
+			isBuiltin := false
+			if _, ok := BuiltinByName(tc.Name); ok && tc.Type != ToolTypeCustom {
+				isBuiltin = true
+			}
+
+			st := Status{
+				Name:        tc.Name,
+				Type:        tc.Type,
+				Enabled:     tc.Enabled,
+				Detected:    builtinDetected[name],
+				DetectKnown: isBuiltin || strings.TrimSpace(tc.Detect) != "",
+				Source:      "manual",
+			}
+
+			if st.Type == "" {
+				if isBuiltin {
+					st.Type = ToolTypeBuiltin
+				} else {
+					st.Type = ToolTypeCustom
+				}
+			}
+
+			if existing, ok := statuses[name]; ok {
+				st.Detected = existing.Detected
+				st.DetectKnown = existing.DetectKnown || st.DetectKnown
+				st.Source = "auto+manual"
+			} else if st.Type == ToolTypeCustom && strings.TrimSpace(tc.Detect) != "" {
+				custom, err := customToolFromConfig(tc)
+				if err != nil {
+					return nil, err
+				}
+				st.Detected = custom.Detect()
+			}
+
+			statuses[name] = st
+		}
+	}
+
+	out := make([]Status, 0, len(statuses))
+	for _, st := range statuses {
+		out = append(out, st)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
+	})
+	return out, nil
+}
+
+func customToolFromConfig(tc config.ToolConfig) (CommandTool, error) {
+	if strings.TrimSpace(tc.Install) == "" {
+		return CommandTool{}, fmt.Errorf("tool %q is missing install command", tc.Name)
+	}
+	if strings.TrimSpace(tc.Uninstall) == "" {
+		return CommandTool{}, fmt.Errorf("tool %q is missing uninstall command", tc.Name)
+	}
+	return CommandTool{
+		ToolName:         tc.Name,
+		DetectCommand:    tc.Detect,
+		InstallCommand:   tc.Install,
+		UninstallCommand: tc.Uninstall,
+		PathTemplate:     tc.Path,
+	}, nil
+}
+
+func findToolConfig(cfg *config.Config, name string) *config.ToolConfig {
+	if cfg == nil {
+		return nil
+	}
+	for i := range cfg.Tools {
+		if strings.EqualFold(cfg.Tools[i].Name, name) {
+			return &cfg.Tools[i]
+		}
+	}
+	return nil
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -3,6 +3,8 @@
 // the agent's expected directory structure.
 package tools
 
+import "os"
+
 // SkillFile represents a file to be written to the skill store.
 type SkillFile struct {
 	Path    string // relative to the skill root (e.g. "scripts/deploy.sh")
@@ -22,14 +24,28 @@ type Tool interface {
 	Detect() bool
 }
 
+// DefaultTools returns the standard set of supported AI tools.
+func DefaultTools() []Tool {
+	return []Tool{
+		ClaudeTool{},
+		CursorTool{},
+		GeminiTool{},
+		CodexTool{},
+	}
+}
+
 // DetectTools returns tools that are actually installed on this machine.
 func DetectTools() []Tool {
-	all := []Tool{ClaudeTool{}, CursorTool{}}
 	var detected []Tool
-	for _, t := range all {
+	for _, t := range DefaultTools() {
 		if t.Detect() {
 			detected = append(detected, t)
 		}
 	}
 	return detected
+}
+
+func homeDirExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -476,3 +476,63 @@ func writeExecutable(t *testing.T, path, content string) {
 		t.Fatalf("write executable %s: %v", path, err)
 	}
 }
+
+func TestResolveByNameReturnsDisabledBuiltin(t *testing.T) {
+	cfg := &config.Config{
+		Tools: []config.ToolConfig{
+			{Name: "gemini", Type: tools.ToolTypeBuiltin, Enabled: false},
+		},
+	}
+
+	tool, err := tools.ResolveByName(cfg, "gemini")
+	if err != nil {
+		t.Fatalf("ResolveByName: %v", err)
+	}
+	if tool.Name() != "gemini" {
+		t.Errorf("got %q, want gemini", tool.Name())
+	}
+}
+
+func TestResolveByNameReturnsDisabledCustom(t *testing.T) {
+	cfg := &config.Config{
+		Tools: []config.ToolConfig{
+			{Name: "aider", Type: tools.ToolTypeCustom, Enabled: false, Install: "echo i", Uninstall: "echo u"},
+		},
+	}
+
+	tool, err := tools.ResolveByName(cfg, "aider")
+	if err != nil {
+		t.Fatalf("ResolveByName: %v", err)
+	}
+	if tool.Name() != "aider" {
+		t.Errorf("got %q, want aider", tool.Name())
+	}
+}
+
+func TestResolveByNameReturnsBuiltinWhenConfigNil(t *testing.T) {
+	tool, err := tools.ResolveByName(nil, "claude")
+	if err != nil {
+		t.Fatalf("ResolveByName: %v", err)
+	}
+	if tool.Name() != "claude" {
+		t.Errorf("got %q, want claude", tool.Name())
+	}
+}
+
+func TestResolveByNameUnknown(t *testing.T) {
+	if _, err := tools.ResolveByName(nil, "nope"); err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+}
+
+func TestGeminiUninstallFailsWhenBinaryMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	err := tools.GeminiTool{}.Uninstall("deploy")
+	if err == nil {
+		t.Fatal("expected error when gemini binary is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "gemini CLI not found") {
+		t.Errorf("error message should mention missing CLI, got: %v", err)
+	}
+}

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/tools"
 )
 
@@ -207,6 +208,206 @@ func TestCursorUninstall(t *testing.T) {
 	}
 }
 
+func TestGeminiDetect(t *testing.T) {
+	home := t.TempDir()
+	binDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", binDir)
+
+	tool := tools.GeminiTool{}
+	if tool.Detect() {
+		t.Error("should not detect gemini when binary is missing")
+	}
+
+	writeExecutable(t, filepath.Join(binDir, "gemini"), "#!/bin/sh\nexit 0\n")
+	if !tool.Detect() {
+		t.Error("should detect gemini when binary exists on PATH")
+	}
+}
+
+func TestGeminiInstallAndUninstall(t *testing.T) {
+	canonicalDir := setup(t)
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "gemini.log")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	writeExecutable(t, filepath.Join(binDir, "gemini"), "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \""+logPath+"\"\n")
+
+	tool := tools.GeminiTool{}
+	paths, err := tool.Install("deploy", canonicalDir)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if len(paths) != 1 || paths[0] != "gemini:user:deploy" {
+		t.Fatalf("unexpected install paths: %v", paths)
+	}
+
+	if err := tool.Uninstall("deploy"); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "skills link "+canonicalDir+" --scope user --consent") {
+		t.Errorf("missing install call in log:\n%s", log)
+	}
+	if !strings.Contains(log, "skills uninstall deploy --scope user") {
+		t.Errorf("missing uninstall call in log:\n%s", log)
+	}
+}
+
+func TestCodexDetect(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	tool := tools.CodexTool{}
+	if tool.Detect() {
+		t.Error("should not detect codex when ~/.codex and binary are missing")
+	}
+
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	if !tool.Detect() {
+		t.Error("should detect codex when ~/.codex exists")
+	}
+}
+
+func TestCodexInstallAndUninstall(t *testing.T) {
+	canonicalDir := setup(t)
+
+	tool := tools.CodexTool{}
+	paths, err := tool.Install("deploy", canonicalDir)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 symlink path, got %d", len(paths))
+	}
+
+	resolved, err := os.Readlink(paths[0])
+	if err != nil {
+		t.Fatalf("Readlink: %v", err)
+	}
+	if resolved != canonicalDir {
+		t.Errorf("symlink points to %q, want %q", resolved, canonicalDir)
+	}
+
+	if err := tool.Uninstall("deploy"); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if _, err := os.Lstat(paths[0]); !os.IsNotExist(err) {
+		t.Error("expected codex symlink to be removed after uninstall")
+	}
+}
+
+func TestDefaultToolsIncludesGeminiAndCodex(t *testing.T) {
+	var names []string
+	for _, tool := range tools.DefaultTools() {
+		names = append(names, tool.Name())
+	}
+
+	for _, want := range []string{"claude", "cursor", "gemini", "codex"} {
+		if !strings.Contains(strings.Join(names, ","), want) {
+			t.Errorf("DefaultTools missing %q: %v", want, names)
+		}
+	}
+}
+
+func TestResolveActiveIncludesConfiguredBuiltinAndCustom(t *testing.T) {
+	cfg := &config.Config{
+		Tools: []config.ToolConfig{
+			{Name: "gemini", Type: tools.ToolTypeBuiltin, Enabled: true},
+			{Name: "aider", Type: tools.ToolTypeCustom, Enabled: true, Install: "echo install", Uninstall: "echo uninstall"},
+			{Name: "cursor", Type: tools.ToolTypeBuiltin, Enabled: false},
+		},
+	}
+
+	resolved, err := tools.ResolveActive(cfg)
+	if err != nil {
+		t.Fatalf("ResolveActive: %v", err)
+	}
+
+	var names []string
+	for _, tool := range resolved {
+		names = append(names, tool.Name())
+	}
+	if !strings.Contains(strings.Join(names, ","), "gemini") {
+		t.Errorf("expected gemini in active tools, got %v", names)
+	}
+	if !strings.Contains(strings.Join(names, ","), "aider") {
+		t.Errorf("expected aider in active tools, got %v", names)
+	}
+	if strings.Contains(strings.Join(names, ","), "cursor") {
+		t.Errorf("did not expect disabled cursor in active tools, got %v", names)
+	}
+}
+
+func TestResolveStatusesForManualBuiltinAndCustom(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	cfg := &config.Config{
+		Tools: []config.ToolConfig{
+			{Name: "codex", Type: tools.ToolTypeBuiltin, Enabled: true},
+			{Name: "aider", Type: tools.ToolTypeCustom, Enabled: true, Install: "echo install", Uninstall: "echo uninstall"},
+		},
+	}
+
+	statuses, err := tools.ResolveStatuses(cfg)
+	if err != nil {
+		t.Fatalf("ResolveStatuses: %v", err)
+	}
+
+	joined := make([]string, 0, len(statuses))
+	for _, st := range statuses {
+		joined = append(joined, st.Name+":"+st.Type+":"+st.Source)
+	}
+	all := strings.Join(joined, ",")
+	if !strings.Contains(all, "codex:builtin:manual") {
+		t.Errorf("expected manual builtin codex status, got %s", all)
+	}
+	if !strings.Contains(all, "aider:custom:manual") {
+		t.Errorf("expected custom aider status, got %s", all)
+	}
+}
+
+func TestCommandToolInstallAndUninstall(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "cmdtool.log")
+	cmd := tools.CommandTool{
+		ToolName:         "aider",
+		InstallCommand:   "printf '%s\\n' '{{tool_name}} {{skill_name}} {{canonical_dir}} {{skill_md}}' >> " + logPath,
+		UninstallCommand: "printf '%s\\n' 'remove {{tool_name}} {{skill_name}}' >> " + logPath,
+		PathTemplate:     "/tmp/{{tool_name}}/{{skill_name}}",
+	}
+
+	paths, err := cmd.Install("deploy", "/tmp/store/deploy")
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if len(paths) != 1 || paths[0] != "/tmp/aider/deploy" {
+		t.Fatalf("unexpected install paths: %v", paths)
+	}
+	if err := cmd.Uninstall("deploy"); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "aider deploy /tmp/store/deploy /tmp/store/deploy/SKILL.md") {
+		t.Errorf("install command placeholders not rendered: %s", log)
+	}
+	if !strings.Contains(log, "remove aider deploy") {
+		t.Errorf("uninstall command placeholders not rendered: %s", log)
+	}
+}
+
 func TestSlugifyRegistry(t *testing.T) {
 	cases := []struct {
 		input string
@@ -266,5 +467,12 @@ func TestCursorInstallBareName(t *testing.T) {
 	expectedLink := filepath.Join(workDir, ".cursor", "rules", "deploy.mdc")
 	if paths[0] != expectedLink {
 		t.Errorf("symlink path = %q, want %q", paths[0], expectedLink)
+	}
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", path, err)
 	}
 }

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"charm.land/huh/v2"
 	"github.com/mattn/go-isatty"
@@ -97,24 +96,11 @@ func StepResolveFormatter(_ context.Context, b *Bag) error {
 
 func StepResolveTools(_ context.Context, b *Bag) error {
 	if b.Tools == nil {
-		detected := tools.DetectTools()
-		// Filter out tools disabled in config.
-		if b.Config != nil && len(b.Config.Tools) > 0 {
-			disabled := make(map[string]bool)
-			for _, t := range b.Config.Tools {
-				if !t.Enabled {
-					disabled[strings.ToLower(t.Name)] = true
-				}
-			}
-			var filtered []tools.Tool
-			for _, t := range detected {
-				if !disabled[strings.ToLower(t.Name())] {
-					filtered = append(filtered, t)
-				}
-			}
-			detected = filtered
+		resolved, err := tools.ResolveActive(b.Config)
+		if err != nil {
+			return fmt.Errorf("resolve tools: %w", err)
 		}
-		b.Tools = detected
+		b.Tools = resolved
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- auto-detect builtin tools at runtime and merge them with manually configured tools
- add configurable command-backed custom tool runtimes via \
- update sync, add, remove, and discovery flows to use resolved active tools instead of a fixed built-in list

## Details
- builtins still have native adapters for Claude, Cursor, Gemini, and Codex
- custom tools can define detect, install, uninstall, and optional path templates
- manually added builtins can be enabled even when autodetection misses them
- tool listing now reports type, detection status, and source

## Testing
- go test ./internal/tools ./cmd ./internal/workflow ./internal/discovery ./internal/sync ./internal/config