### PR TITLE
fix: handle legacy branch SHA migration and missing branch skills

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -125,13 +126,13 @@ func Load() (*State, error) {
 
 	data, err := os.ReadFile(path)
 	if errors.Is(err, fs.ErrNotExist) {
-		return &State{SchemaVersion: 3, Installed: make(map[string]InstalledSkill)}, nil
+		return &State{SchemaVersion: 4, Installed: make(map[string]InstalledSkill)}, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("read state: %w", err)
 	}
 	if len(bytes.TrimSpace(data)) == 0 {
-		return &State{SchemaVersion: 3, Installed: make(map[string]InstalledSkill)}, nil
+		return &State{SchemaVersion: 4, Installed: make(map[string]InstalledSkill)}, nil
 	}
 	return parseAndMigrate(data)
 }
@@ -142,8 +143,8 @@ func Load() (*State, error) {
 //  3. Namespace bare keys using Registries[0] owner prefix
 //  4. Schema v2: convert to bare keys, populate Sources, set Revision
 //  5. Schema v3: bump the state schema while preserving existing Sources.
-//     Older LastSHA values may still be commit SHAs, but the next blob-SHA
-//     based sync can refresh them in place without forcing reinstall flows.
+//  6. Schema v4: normalize branch-backed LastSHA values to the locally cached
+//     SKILL.md blob SHA so blob-SHA diffs do not force needless reinstalls.
 func parseAndMigrate(data []byte) (*State, error) {
 	var legacy legacyState
 	if err := json.Unmarshal(data, &legacy); err != nil {
@@ -259,6 +260,10 @@ func parseAndMigrate(data []byte) (*State, error) {
 	if s.SchemaVersion < 3 {
 		s.SchemaVersion = 3
 	}
+	if s.SchemaVersion < 4 {
+		normalizeBranchSourceSHAs(s)
+		s.SchemaVersion = 4
+	}
 
 	return s, nil
 }
@@ -368,4 +373,57 @@ func appendUniqueSources(base, extra []SkillSource) []SkillSource {
 
 func statePath() (string, error) {
 	return paths.StatePath()
+}
+
+func normalizeBranchSourceSHAs(s *State) {
+	storeDir, err := paths.StoreDir()
+	if err != nil {
+		return
+	}
+
+	for name, skill := range s.Installed {
+		if skill.Type == "package" {
+			continue
+		}
+		changed := false
+		for i := range skill.Sources {
+			if !isBranchRef(skill.Sources[i].Ref) {
+				continue
+			}
+			blobSHA := installedSkillBlobSHA(storeDir, name)
+			if blobSHA == "" || skill.Sources[i].LastSHA == blobSHA {
+				continue
+			}
+			skill.Sources[i].LastSHA = blobSHA
+			changed = true
+		}
+		if changed {
+			s.Installed[name] = skill
+		}
+	}
+}
+
+func isBranchRef(ref string) bool {
+	return !strings.HasPrefix(ref, "v") || !strings.Contains(ref, ".")
+}
+
+func installedSkillBlobSHA(storeDir, skillName string) string {
+	baseDir := filepath.Join(storeDir, skillName)
+	for _, candidate := range []string{
+		filepath.Join(baseDir, ".scribe-base.md"),
+		filepath.Join(baseDir, "SKILL.md"),
+	} {
+		data, err := os.ReadFile(candidate)
+		if err != nil {
+			continue
+		}
+		return gitBlobSHA(data)
+	}
+	return ""
+}
+
+func gitBlobSHA(data []byte) string {
+	payload := append([]byte(fmt.Sprintf("blob %d\x00", len(data))), data...)
+	sum := sha1.Sum(payload)
+	return fmt.Sprintf("%x", sum)
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,6 +1,8 @@
 package state_test
 
 import (
+	"crypto/sha1"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,8 +23,8 @@ func TestLoadMissing(t *testing.T) {
 	if len(s.Installed) != 0 {
 		t.Errorf("expected empty Installed, got %d entries", len(s.Installed))
 	}
-	if s.SchemaVersion != 3 {
-		t.Errorf("expected SchemaVersion=3, got %d", s.SchemaVersion)
+	if s.SchemaVersion != 4 {
+		t.Errorf("expected SchemaVersion=4, got %d", s.SchemaVersion)
 	}
 }
 
@@ -54,8 +56,8 @@ func TestSaveAndLoad(t *testing.T) {
 	if loaded.LastSync.IsZero() {
 		t.Error("expected LastSync to be set")
 	}
-	if loaded.SchemaVersion != 3 {
-		t.Errorf("expected SchemaVersion=3, got %d", loaded.SchemaVersion)
+	if loaded.SchemaVersion != 4 {
+		t.Errorf("expected SchemaVersion=4, got %d", loaded.SchemaVersion)
 	}
 
 	skill, ok := loaded.Installed["gstack"]
@@ -257,7 +259,7 @@ func TestMigrationNamespacesKeys(t *testing.T) {
 
 	skill := s.Installed["gstack"]
 	if len(skill.Sources) != 1 {
-		t.Fatalf("expected sources to be preserved by v3 migration, got %v", skill.Sources)
+		t.Fatalf("expected sources to be preserved by migration, got %v", skill.Sources)
 	}
 	if skill.Sources[0].Registry != "garrytan/gstack" || skill.Sources[0].Ref != "v0.12.9.0" {
 		t.Errorf("unexpected migrated sources: %v", skill.Sources)
@@ -273,8 +275,8 @@ func TestMigrationNamespacesKeys(t *testing.T) {
 		t.Errorf("expected Revision=1, got %d", skill.Revision)
 	}
 
-	if s.SchemaVersion != 3 {
-		t.Errorf("expected SchemaVersion=3, got %d", s.SchemaVersion)
+	if s.SchemaVersion != 4 {
+		t.Errorf("expected SchemaVersion=4, got %d", s.SchemaVersion)
 	}
 }
 
@@ -416,7 +418,7 @@ func TestStateNamespaceKeysNoRegistries(t *testing.T) {
 }
 
 // TestStateMigrateV2ToV3 verifies that a v2 state (bare keys, populated
-// Sources) gets upgraded to v3 with both sources and non-source fields
+// Sources) gets upgraded to the current schema with both sources and non-source fields
 // preserved.
 func TestStateMigrateV2ToV3(t *testing.T) {
 	home := t.TempDir()
@@ -459,13 +461,13 @@ func TestStateMigrateV2ToV3(t *testing.T) {
 		t.Errorf("expected InstalledHash=abc123, got %q", skill.InstalledHash)
 	}
 	if len(skill.Sources) != 1 {
-		t.Fatalf("expected sources preserved by v3 migration, got %v", skill.Sources)
+		t.Fatalf("expected sources preserved by migration, got %v", skill.Sources)
 	}
 	if skill.Sources[0].Registry != "ArtistfyHQ/team-skills" || skill.Sources[0].LastSHA != "def456" {
 		t.Errorf("unexpected migrated sources: %v", skill.Sources)
 	}
-	if s.SchemaVersion != 3 {
-		t.Errorf("expected SchemaVersion=3, got %d", s.SchemaVersion)
+	if s.SchemaVersion != 4 {
+		t.Errorf("expected SchemaVersion=4, got %d", s.SchemaVersion)
 	}
 }
 
@@ -502,8 +504,8 @@ func TestMigrationSchemaV2(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	if s.SchemaVersion != 3 {
-		t.Errorf("expected SchemaVersion=3, got %d", s.SchemaVersion)
+	if s.SchemaVersion != 4 {
+		t.Errorf("expected SchemaVersion=4, got %d", s.SchemaVersion)
 	}
 
 	// Qualified key should become bare.
@@ -519,7 +521,7 @@ func TestMigrationSchemaV2(t *testing.T) {
 		t.Errorf("expected bare key 'my-tool', got keys: %v", installedKeys(s))
 	}
 
-	// v3 migration preserves sources gathered during migration.
+	// Schema migration preserves sources gathered during migration.
 	deploy := s.Installed["deploy"]
 	if len(deploy.Sources) != 1 {
 		t.Fatalf("expected deploy sources preserved, got %v", deploy.Sources)
@@ -540,7 +542,7 @@ func TestMigrationSchemaV2(t *testing.T) {
 	}
 }
 
-// TestMigrationPreservesRevisionAndHash verifies v2→v3 migration preserves
+// TestMigrationPreservesRevisionAndHash verifies migration preserves
 // both source metadata and non-source fields.
 func TestMigrationPreservesRevisionAndHash(t *testing.T) {
 	home := t.TempDir()
@@ -568,8 +570,8 @@ func TestMigrationPreservesRevisionAndHash(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	if s.SchemaVersion != 3 {
-		t.Errorf("SchemaVersion: got %d, want 3", s.SchemaVersion)
+	if s.SchemaVersion != 4 {
+		t.Errorf("SchemaVersion: got %d, want 4", s.SchemaVersion)
 	}
 	skill := s.Installed["gstack"]
 	if skill.Revision != 5 {
@@ -579,7 +581,7 @@ func TestMigrationPreservesRevisionAndHash(t *testing.T) {
 		t.Errorf("InstalledHash: got %q", skill.InstalledHash)
 	}
 	if len(skill.Sources) != 1 {
-		t.Fatalf("Sources: expected preserve on v3 migration, got %v", skill.Sources)
+		t.Fatalf("Sources: expected preserve on migration, got %v", skill.Sources)
 	}
 	if skill.Sources[0].Registry != "garrytan/gstack" || skill.Sources[0].LastSHA != "commit123" {
 		t.Errorf("unexpected preserved sources: %v", skill.Sources)
@@ -712,7 +714,7 @@ func TestMigrationBareKeyCollisionCollapses(t *testing.T) {
 	os.MkdirAll(dir, 0o755)
 
 	// Two qualified keys collapse to the same bare name "deploy".
-	// Schema v3 preserves merged sources while the newer entry wins as base.
+	// Migration preserves merged sources while the newer entry wins as base.
 	os.WriteFile(filepath.Join(dir, "state.json"), []byte(`{
 		"installed": {
 			"org-a/deploy": {
@@ -739,8 +741,8 @@ func TestMigrationBareKeyCollisionCollapses(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	if s.SchemaVersion != 3 {
-		t.Errorf("expected SchemaVersion 3, got %d", s.SchemaVersion)
+	if s.SchemaVersion != 4 {
+		t.Errorf("expected SchemaVersion 4, got %d", s.SchemaVersion)
 	}
 
 	// Should have exactly one "deploy" key, not two.
@@ -754,7 +756,7 @@ func TestMigrationBareKeyCollisionCollapses(t *testing.T) {
 	}
 
 	if len(skill.Sources) != 2 {
-		t.Fatalf("expected merged sources preserved in v3, got %d: %v", len(skill.Sources), skill.Sources)
+		t.Fatalf("expected merged sources preserved, got %d: %v", len(skill.Sources), skill.Sources)
 	}
 
 	// Newer entry (org-a, 2026-04-01) should win as the base.
@@ -772,15 +774,23 @@ func installedKeys(s *state.State) []string {
 	return keys
 }
 
-// TestMigrationSchemaV3PreservesSources verifies that loading a v2 state keeps
-// SkillSource entries intact so the first sync after upgrade can refresh
-// metadata in place instead of forcing reinstalls.
-func TestMigrationSchemaV3PreservesSources(t *testing.T) {
+// TestMigrationSchemaV4NormalizesBranchBlobSHA verifies that loading an older
+// state rewrites branch-backed skill SHAs to the locally cached blob SHA while
+// leaving package commit SHAs alone.
+func TestMigrationSchemaV4NormalizesBranchBlobSHA(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
 	dir := filepath.Join(home, ".scribe")
 	os.MkdirAll(dir, 0o755)
+	storeDir := filepath.Join(dir, "skills", "xray")
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	baseContent := []byte("# Xray\n\nUpstream content.\n")
+	if err := os.WriteFile(filepath.Join(storeDir, ".scribe-base.md"), baseContent, 0o644); err != nil {
+		t.Fatalf("WriteFile .scribe-base.md: %v", err)
+	}
 	os.WriteFile(filepath.Join(dir, "state.json"), []byte(`{
 		"schema_version": 2,
 		"last_sync": "2026-04-01T00:00:00Z",
@@ -810,8 +820,8 @@ func TestMigrationSchemaV3PreservesSources(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	if s.SchemaVersion != 3 {
-		t.Errorf("SchemaVersion: got %d, want 3", s.SchemaVersion)
+	if s.SchemaVersion != 4 {
+		t.Errorf("SchemaVersion: got %d, want 4", s.SchemaVersion)
 	}
 
 	xray, ok := s.Installed["xray"]
@@ -821,7 +831,7 @@ func TestMigrationSchemaV3PreservesSources(t *testing.T) {
 	if len(xray.Sources) != 1 {
 		t.Fatalf("xray sources: got %v, want preserved source", xray.Sources)
 	}
-	if xray.Sources[0].Registry != "Artistfy/hq" || xray.Sources[0].LastSHA != "commit-xyz" {
+	if xray.Sources[0].Registry != "Artistfy/hq" || xray.Sources[0].LastSHA != gitBlobSHAForTest(baseContent) {
 		t.Errorf("xray sources: got %v", xray.Sources)
 	}
 	// Non-source fields must be preserved so the skill is still recognised.
@@ -854,16 +864,16 @@ func TestMigrationSchemaV3PreservesSources(t *testing.T) {
 	}
 }
 
-// TestMigrationSchemaV3Idempotent verifies that a v3 state passes through
-// unchanged — sources are preserved, schema stays 3.
-func TestMigrationSchemaV3Idempotent(t *testing.T) {
+// TestMigrationSchemaV4Idempotent verifies that a current-schema state passes
+// through unchanged.
+func TestMigrationSchemaV4Idempotent(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
 	dir := filepath.Join(home, ".scribe")
 	os.MkdirAll(dir, 0o755)
 	os.WriteFile(filepath.Join(dir, "state.json"), []byte(`{
-		"schema_version": 3,
+		"schema_version": 4,
 		"last_sync": "2026-04-11T00:00:00Z",
 		"installed": {
 			"xray": {
@@ -882,14 +892,20 @@ func TestMigrationSchemaV3Idempotent(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	if s.SchemaVersion != 3 {
-		t.Errorf("SchemaVersion: got %d, want 3", s.SchemaVersion)
+	if s.SchemaVersion != 4 {
+		t.Errorf("SchemaVersion: got %d, want 4", s.SchemaVersion)
 	}
 	xray := s.Installed["xray"]
 	if len(xray.Sources) != 1 {
-		t.Fatalf("xray sources: got %d, want 1 (preserved on v3 passthrough)", len(xray.Sources))
+		t.Fatalf("xray sources: got %d, want 1 (preserved on passthrough)", len(xray.Sources))
 	}
 	if xray.Sources[0].LastSHA != "blob-abc" {
 		t.Errorf("xray LastSHA: got %q, want blob-abc", xray.Sources[0].LastSHA)
 	}
+}
+
+func gitBlobSHAForTest(data []byte) string {
+	payload := append([]byte(fmt.Sprintf("blob %d\x00", len(data))), data...)
+	sum := sha1.Sum(payload)
+	return fmt.Sprintf("%x", sum)
 }

--- a/internal/sync/blobsha.go
+++ b/internal/sync/blobsha.go
@@ -7,12 +7,16 @@ import (
 	"github.com/Naoray/scribe/internal/provider"
 )
 
+// missingSkillBlobSHA marks a successful tree lookup where the referenced
+// SKILL.md does not exist in the upstream repo.
+const missingSkillBlobSHA = "__missing_skill_blob__"
+
 // resolveSkillBlobSHA returns the git blob SHA of SKILL.md for the given
 // catalog entry. This is the identity signal we compare against state:
 // commit SHAs flip on any repo activity, blob SHAs flip only when the file
-// content actually changes. Returns "" if the skill file is not present in
-// the tree (deleted, typo, or wrong path).
-func resolveSkillBlobSHA(tree []provider.TreeEntry, entry manifest.Entry) string {
+// content actually changes. The boolean reports whether the skill file was
+// found in the tree; a missing file is distinct from an API failure.
+func resolveSkillBlobSHA(tree []provider.TreeEntry, entry manifest.Entry) (string, bool) {
 	skillPath := entry.Path
 	if skillPath == "" {
 		skillPath = entry.Name
@@ -24,8 +28,8 @@ func resolveSkillBlobSHA(tree []provider.TreeEntry, entry manifest.Entry) string
 	}
 	for _, e := range tree {
 		if e.Type == "blob" && e.Path == target {
-			return e.SHA
+			return e.SHA, true
 		}
 	}
-	return ""
+	return "", false
 }

--- a/internal/sync/blobsha_test.go
+++ b/internal/sync/blobsha_test.go
@@ -25,39 +25,48 @@ func TestResolveSkillBlobSHA(t *testing.T) {
 		name  string
 		entry manifest.Entry
 		want  string
+		found bool
 	}{
 		{
 			name:  "resolves via explicit path",
 			entry: manifest.Entry{Name: "xray", Path: "skills/xray"},
 			want:  "xrayblob",
+			found: true,
 		},
 		{
 			name:  "falls back to name when path omitted",
 			entry: manifest.Entry{Name: "skills/deploy"},
 			want:  "deployblob",
+			found: true,
 		},
 		{
 			name:  "returns empty for missing skill",
 			entry: manifest.Entry{Name: "ghost", Path: "skills/ghost"},
 			want:  "",
+			found: false,
 		},
 		{
 			name:  "handles root-level skill paths",
 			entry: manifest.Entry{Name: "repo-skill", Path: "."},
 			want:  "rootsha",
+			found: true,
 		},
 		{
 			name:  "ignores tree entries (only blobs)",
 			entry: manifest.Entry{Name: "skills", Path: "skills"},
 			want:  "",
+			found: false,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := resolveSkillBlobSHA(tree, c.entry)
+			got, found := resolveSkillBlobSHA(tree, c.entry)
 			if got != c.want {
 				t.Errorf("got %q, want %q", got, c.want)
+			}
+			if found != c.found {
+				t.Errorf("found = %v, want %v", found, c.found)
 			}
 		})
 	}

--- a/internal/sync/compare.go
+++ b/internal/sync/compare.go
@@ -47,6 +47,9 @@ func compareEntry(entry manifest.Entry, installed *state.InstalledSkill, latestS
 	// Packages and branches use SHA comparison.
 	// If latestSHA is empty (API unreachable), assume current to avoid spurious re-installs.
 	if entry.IsPackage() || src.IsBranch() {
+		if latestSHA == missingSkillBlobSHA {
+			return StatusOutdated
+		}
 		if latestSHA == "" {
 			return StatusCurrent
 		}

--- a/internal/sync/compare_test.go
+++ b/internal/sync/compare_test.go
@@ -49,6 +49,14 @@ func TestCompareEntryOutdatedBranch(t *testing.T) {
 	}
 }
 
+func TestCompareEntryMissingBranchBlobIsOutdated(t *testing.T) {
+	inst := installedWithSource("a/b", "main", "abc123")
+	got := compareEntry(entry("github:a/b@main"), inst, missingSkillBlobSHA, "a/b")
+	if got != StatusOutdated {
+		t.Errorf("got %s, want %s", got, StatusOutdated)
+	}
+}
+
 func TestCompareEntryCurrentTag(t *testing.T) {
 	inst := installedWithSource("a/b", "v1.0.0", "")
 	got := compareEntry(entry("github:a/b@v1.0.0"), inst, "", "a/b")
@@ -96,6 +104,7 @@ func TestCompareEntry(t *testing.T) {
 		// Branch refs: SHA comparison
 		{"branch same sha", entry("github:a/b@main"), installedWithSource("a/b", "main", "abc123"), "abc123", "a/b", StatusCurrent},
 		{"branch diff sha", entry("github:a/b@main"), installedWithSource("a/b", "main", "abc123"), "def456", "a/b", StatusOutdated},
+		{"branch missing skill file", entry("github:a/b@main"), installedWithSource("a/b", "main", "abc123"), missingSkillBlobSHA, "a/b", StatusOutdated},
 
 		// Branch with empty SHA (API unreachable) → assume current
 		{"branch empty sha", entry("github:a/b@main"), installedWithSource("a/b", "main", "abc123"), "", "a/b", StatusCurrent},

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -1,0 +1,90 @@
+package sync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+type diffTestFetcher struct {
+	tree []provider.TreeEntry
+}
+
+func (f *diffTestFetcher) FetchFile(ctx context.Context, owner, repo, path, ref string) ([]byte, error) {
+	return nil, nil
+}
+
+func (f *diffTestFetcher) FetchDirectory(ctx context.Context, owner, repo, dirPath, ref string) ([]tools.SkillFile, error) {
+	return nil, nil
+}
+
+func (f *diffTestFetcher) LatestCommitSHA(ctx context.Context, owner, repo, branch string) (string, error) {
+	return "", nil
+}
+
+func (f *diffTestFetcher) GetTree(ctx context.Context, owner, repo, ref string) ([]provider.TreeEntry, error) {
+	return f.tree, nil
+}
+
+type diffTestProvider struct {
+	entry manifest.Entry
+}
+
+func (p *diffTestProvider) Discover(ctx context.Context, repo string) (*provider.DiscoverResult, error) {
+	return &provider.DiscoverResult{
+		Entries: []manifest.Entry{p.entry},
+		IsTeam:  true,
+	}, nil
+}
+
+func (p *diffTestProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]tools.SkillFile, error) {
+	return nil, nil
+}
+
+func TestDiffMarksBranchSkillOutdatedWhenSkillFileMissingFromTree(t *testing.T) {
+	syncer := &Syncer{
+		Client: &diffTestFetcher{
+			tree: []provider.TreeEntry{
+				{Path: "README.md", Type: "blob", SHA: "readme"},
+			},
+		},
+		Provider: &diffTestProvider{
+			entry: manifest.Entry{
+				Name:   "xray",
+				Path:   "skills/xray",
+				Source: "github:acme/skills@main",
+			},
+		},
+	}
+
+	st := &state.State{
+		Installed: map[string]state.InstalledSkill{
+			"xray": {
+				Revision: 1,
+				Sources: []state.SkillSource{{
+					Registry: "acme/team",
+					Ref:      "main",
+					LastSHA:  "old-blob",
+				}},
+			},
+		},
+	}
+
+	statuses, _, err := syncer.Diff(context.Background(), "acme/team", st)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if len(statuses) != 1 {
+		t.Fatalf("statuses = %d, want 1", len(statuses))
+	}
+	if statuses[0].Status != StatusOutdated {
+		t.Fatalf("status = %s, want %s", statuses[0].Status, StatusOutdated)
+	}
+	if statuses[0].LatestSHA != missingSkillBlobSHA {
+		t.Fatalf("latest SHA = %q, want %q", statuses[0].LatestSHA, missingSkillBlobSHA)
+	}
+}

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -138,7 +138,12 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 					}
 				}
 				if len(tree) > 0 {
-					latestSHA = resolveSkillBlobSHA(tree, *entry)
+					resolvedSHA, found := resolveSkillBlobSHA(tree, *entry)
+					if found {
+						latestSHA = resolvedSHA
+					} else {
+						latestSHA = missingSkillBlobSHA
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- migrate legacy branch-backed state entries to the local SKILL.md blob SHA during schema upgrade
- treat missing upstream SKILL.md files as real drift instead of masking them as API outages
- add regression coverage for migration and diff behavior

## Testing
- go test ./internal/state ./internal/sync