### PR TITLE
Improve skill update UX and restore status handling

### DIFF
--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/discovery"
 	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
 	"github.com/Naoray/scribe/internal/workflow"
@@ -39,6 +40,14 @@ type listSubstate int
 const (
 	listSubstateNone listSubstate = iota
 	listSubstateConfirm
+	listSubstateUpdateChoice
+)
+
+type updateChoice int
+
+const (
+	updateChoiceMerge updateChoice = iota
+	updateChoicePreferTheirs
 )
 
 // detailFocus indicates which pane has keyboard focus while the split-screen
@@ -132,6 +141,7 @@ type updateDoneMsg struct {
 	err        error
 	merged     bool
 	conflicted bool
+	openPath   string
 }
 
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -156,6 +166,7 @@ type listModel struct {
 	actionCursor  int
 	substate      listSubstate
 	statusMsg     string
+	updateHasMods bool
 	pendingTickID int
 
 	ctx context.Context
@@ -401,6 +412,7 @@ func (m listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.filtered[i].Status = sync.StatusCurrent
 					m.statusMsg = "Updated!"
 				}
+				m.updateHasMods = false
 				break
 			}
 		}
@@ -417,9 +429,17 @@ func (m listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.pendingTickID++
 		tickID := m.pendingTickID
-		return m, tea.Tick(time.Second, func(t time.Time) tea.Msg {
+		var cmds []tea.Cmd
+		if msg.openPath != "" {
+			editor := resolveEditor(m.bag.Config)
+			cmds = append(cmds, tea.ExecProcess(exec.Command(editor, msg.openPath), func(err error) tea.Msg {
+				return editorDoneMsg{err: err}
+			}))
+		}
+		cmds = append(cmds, tea.Tick(time.Second, func(t time.Time) tea.Msg {
 			return clipboardTickMsg{id: tickID}
-		})
+		}))
+		return m, tea.Batch(cmds...)
 	case tea.KeyPressMsg:
 		if m.stage == stageLoading {
 			if msg.String() == "ctrl+c" || msg.String() == "q" {
@@ -484,6 +504,9 @@ func (m listModel) updateList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.substate == listSubstateConfirm {
 		return m.updateConfirm(msg)
+	}
+	if m.substate == listSubstateUpdateChoice {
+		return m.updateUpdateChoice(msg)
 	}
 
 	if m.cursor >= len(m.filtered) {
@@ -602,6 +625,42 @@ func (m listModel) updateConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m listModel) updateUpdateChoice(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if !m.updateHasMods {
+		switch msg.String() {
+		case "u", "enter":
+			m.substate = listSubstateNone
+			m.statusMsg = "Updating..."
+			return m, m.runUpdate(updateChoiceMerge)
+		case "esc", "escape":
+			m.substate = listSubstateNone
+			m.statusMsg = ""
+		}
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "m":
+		m.substate = listSubstateNone
+		m.statusMsg = "Updating..."
+		return m, m.runUpdate(updateChoiceMerge)
+	case "r":
+		m.substate = listSubstateNone
+		m.statusMsg = "Updating..."
+		return m, m.runUpdate(updateChoicePreferTheirs)
+	case "l":
+		m.substate = listSubstateNone
+		m.statusMsg = "Kept local version. Registry update skipped."
+		m.updateHasMods = false
+		return m, nil
+	case "esc", "escape":
+		m.substate = listSubstateNone
+		m.statusMsg = ""
+		m.updateHasMods = false
+	}
+	return m, nil
+}
+
 func (m listModel) executeAction(key string) (tea.Model, tea.Cmd) {
 	row := m.filtered[m.cursor]
 	switch key {
@@ -609,72 +668,16 @@ func (m listModel) executeAction(key string) (tea.Model, tea.Cmd) {
 		if row.Entry == nil {
 			return m, nil
 		}
-		m.statusMsg = "Updating..."
-		repo := row.Group
-		ss := sync.SkillStatus{
-			Name:      row.Name,
-			Status:    row.Status,
-			Entry:     row.Entry,
-			IsPackage: row.Entry.IsPackage(),
-			LatestSHA: row.LatestSHA,
+		if rowHasLocalModifications(row, m.bag.State) && !row.Entry.IsPackage() {
+			m.substate = listSubstateUpdateChoice
+			m.updateHasMods = true
+			m.statusMsg = "Local edits detected. Choose: [r]egistry version, keep [l]ocal version, or [m]erge with upstream."
+			return m, nil
 		}
-		if row.Local != nil {
-			if inst, ok := m.bag.State.Installed[row.Name]; ok {
-				ss.Installed = &inst
-			}
-		}
-
-		// Capture whether the local file had unsynced edits BEFORE the sync runs.
-		// Post-sync, SKILL.md has been rewritten (or 3-way merged), so
-		// IsLocallyModified can no longer tell us what we need to know.
-		wasModified := false
-		if ss.Installed != nil {
-			if storeDir, sdErr := tools.StoreDir(); sdErr == nil {
-				skillDir := filepath.Join(storeDir, row.Name)
-				wasModified = sync.IsLocallyModified(skillDir, ss.Installed.InstalledHash)
-			}
-		}
-
-		ctx := m.ctx
-		bag := m.bag
-		return m, func() tea.Msg {
-			syncer := &sync.Syncer{
-				Client:   sync.WrapGitHubClient(bag.Client),
-				Provider: bag.Provider,
-				Tools:    bag.Tools,
-				Executor: &sync.ShellExecutor{},
-				TrustAll: bag.TrustAllFlag,
-			}
-			isTTY := isatty.IsTerminal(os.Stdin.Fd())
-			if isTTY && !bag.TrustAllFlag && !bag.JSONFlag {
-				syncer.ApprovalFunc = func(name, command, source string) bool {
-					var approved bool
-					err := huh.NewConfirm().
-						Title(fmt.Sprintf("Package %q wants to run a shell command", name)).
-						Description(fmt.Sprintf("source:  %s\ncommand: %s", source, command)).
-						Affirmative("Approve").
-						Negative("Deny").
-						Value(&approved).
-						Run()
-					if err != nil {
-						return false
-					}
-					return approved
-				}
-			}
-			err := syncer.RunWithDiff(ctx, repo, []sync.SkillStatus{ss}, bag.State)
-			if err != nil {
-				return updateDoneMsg{name: row.Name, err: err}
-			}
-			// Check if the skill ended up conflicted.
-			localSkills, _ := discovery.OnDisk(bag.State)
-			for _, sk := range localSkills {
-				if sk.Name == row.Name && sk.Conflicted {
-					return updateDoneMsg{name: row.Name, conflicted: true}
-				}
-			}
-			return updateDoneMsg{name: row.Name, merged: wasModified}
-		}
+		m.substate = listSubstateUpdateChoice
+		m.updateHasMods = false
+		m.statusMsg = "No local edits detected. Update will replace the local copy with the registry version."
+		return m, nil
 	}
 	if row.Local == nil {
 		return m, nil
@@ -704,6 +707,104 @@ func (m listModel) executeAction(key string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	return m, nil
+}
+
+func (m listModel) runUpdate(choice updateChoice) tea.Cmd {
+	if m.cursor >= len(m.filtered) {
+		return nil
+	}
+
+	row := m.filtered[m.cursor]
+	repo := row.Group
+	ss := sync.SkillStatus{
+		Name:      row.Name,
+		Status:    row.Status,
+		Entry:     row.Entry,
+		IsPackage: row.Entry.IsPackage(),
+		LatestSHA: row.LatestSHA,
+	}
+	if row.Local != nil {
+		if inst, ok := m.bag.State.Installed[row.Name]; ok {
+			ss.Installed = &inst
+		}
+	}
+
+	wasModified := rowHasLocalModifications(row, m.bag.State)
+
+	ctx := m.ctx
+	bag := m.bag
+	return func() tea.Msg {
+		syncer := &sync.Syncer{
+			Client:           sync.WrapGitHubClient(bag.Client),
+			Provider:         bag.Provider,
+			Tools:            bag.Tools,
+			Executor:         &sync.ShellExecutor{},
+			TrustAll:         bag.TrustAllFlag,
+			ModifiedStrategy: sync.ModifiedStrategyMerge,
+		}
+		if choice == updateChoicePreferTheirs {
+			syncer.ModifiedStrategy = sync.ModifiedStrategyPreferTheirs
+		}
+		isTTY := isatty.IsTerminal(os.Stdin.Fd())
+		if isTTY && !bag.TrustAllFlag && !bag.JSONFlag {
+			syncer.ApprovalFunc = func(name, command, source string) bool {
+				var approved bool
+				err := huh.NewConfirm().
+					Title(fmt.Sprintf("Package %q wants to run a shell command", name)).
+					Description(fmt.Sprintf("source:  %s\ncommand: %s", source, command)).
+					Affirmative("Approve").
+					Negative("Deny").
+					Value(&approved).
+					Run()
+				if err != nil {
+					return false
+				}
+				return approved
+			}
+		}
+		err := syncer.RunWithDiff(ctx, repo, []sync.SkillStatus{ss}, bag.State)
+		if err != nil {
+			return updateDoneMsg{name: row.Name, err: err}
+		}
+		localSkills, _ := discovery.OnDisk(bag.State)
+		for _, sk := range localSkills {
+			if sk.Name == row.Name && sk.Conflicted {
+				return updateDoneMsg{
+					name:       row.Name,
+					conflicted: true,
+					openPath:   filepath.Join(sk.LocalPath, "SKILL.md"),
+				}
+			}
+		}
+		return updateDoneMsg{name: row.Name, merged: wasModified && choice == updateChoiceMerge}
+	}
+}
+
+func rowHasLocalModifications(row listRow, st *state.State) bool {
+	if row.Local != nil {
+		if row.Local.Modified {
+			return true
+		}
+		if row.Local.LocalPath != "" {
+			installed, ok := st.Installed[row.Name]
+			if !ok {
+				return false
+			}
+			return sync.IsLocallyModified(row.Local.LocalPath, installed.InstalledHash)
+		}
+	}
+	if st == nil {
+		return false
+	}
+	installed, ok := st.Installed[row.Name]
+	if !ok {
+		return false
+	}
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		return false
+	}
+	return sync.IsLocallyModified(filepath.Join(storeDir, row.Name), installed.InstalledHash)
 }
 
 func (m listModel) resetSearch() listModel {
@@ -961,6 +1062,12 @@ func (m listModel) viewSplit() string {
 	switch {
 	case m.substate == listSubstateConfirm:
 		b.WriteString(ltDimStyle.Render("y confirm · n cancel") + "\n")
+	case m.substate == listSubstateUpdateChoice:
+		if m.updateHasMods {
+			b.WriteString(ltDimStyle.Render("r registry · l local · m merge · esc cancel") + "\n")
+		} else {
+			b.WriteString(ltDimStyle.Render("u update · esc cancel") + "\n")
+		}
 	case m.focus == focusList:
 		b.WriteString(ltDimStyle.Render("↑↓ browse skills · →/enter actions · esc close · q quit") + "\n")
 	default:

--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -440,16 +440,14 @@ func (m listModel) updateList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "ctrl+c", "q":
 		if m.search != "" {
-			m.search = ""
-			m = m.refreshFiltered()
+			m = m.resetSearch()
 			return m, nil
 		}
 		m.quitting = true
 		return m, tea.Quit
 	case "esc", "escape":
 		if m.search != "" {
-			m.search = ""
-			m = m.refreshFiltered()
+			m = m.resetSearch()
 		}
 		return m, nil
 	case "up", "k":
@@ -476,15 +474,9 @@ func (m listModel) updateList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.statusMsg = ""
 		}
 	case "backspace":
-		if len(m.search) > 0 {
-			m.search = m.search[:len(m.search)-1]
-			m = m.refreshFiltered()
-		}
+		m = m.backspaceSearch()
 	default:
-		if len(msg.String()) == 1 {
-			m.search += msg.String()
-			m = m.refreshFiltered()
-		}
+		m = m.appendSearch(msg.String())
 	}
 	return m, nil
 }
@@ -534,7 +526,8 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.focus == focusList {
 		// Browsing the list with the detail pane open: arrow keys move
 		// the row cursor and the right pane refreshes live. Right/enter
-		// hands focus to the action menu.
+		// hands focus to the action menu. Character keys still filter the
+		// left list without forcing the user to close the detail pane first.
 		switch key {
 		case "up", "k":
 			if m.cursor > 0 {
@@ -553,6 +546,23 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		case "right", "l", "enter":
 			m.focus = focusActions
 			m.actionCursor = 0
+		case "backspace":
+			m = m.backspaceSearch()
+			m.actionCursor = 0
+			m.statusMsg = ""
+			if !m.selected {
+				m.focus = focusList
+			}
+		default:
+			next := m.appendSearch(key)
+			if next.search != m.search {
+				m = next
+				m.actionCursor = 0
+				m.statusMsg = ""
+				if !m.selected {
+					m.focus = focusList
+				}
+			}
 		}
 		return m, nil
 	}
@@ -694,6 +704,39 @@ func (m listModel) executeAction(key string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	return m, nil
+}
+
+func (m listModel) resetSearch() listModel {
+	m.search = ""
+	m = m.refreshFiltered()
+	if len(m.filtered) == 0 {
+		m.selected = false
+	}
+	return m
+}
+
+func (m listModel) backspaceSearch() listModel {
+	if len(m.search) == 0 {
+		return m
+	}
+	m.search = m.search[:len(m.search)-1]
+	m = m.refreshFiltered()
+	if len(m.filtered) == 0 {
+		m.selected = false
+	}
+	return m
+}
+
+func (m listModel) appendSearch(key string) listModel {
+	if len(key) != 1 {
+		return m
+	}
+	m.search += key
+	m = m.refreshFiltered()
+	if len(m.filtered) == 0 {
+		m.selected = false
+	}
+	return m
 }
 
 func (m listModel) executeRemove() (tea.Model, tea.Cmd) {

--- a/cmd/list_tui_test.go
+++ b/cmd/list_tui_test.go
@@ -28,6 +28,8 @@ func key(label string) tea.KeyPressMsg {
 		return tea.KeyPressMsg{Code: 0x0d}
 	case "esc":
 		return tea.KeyPressMsg{Code: 0x1b}
+	case "backspace":
+		return tea.KeyPressMsg{Code: tea.KeyBackspace}
 	case "up":
 		return tea.KeyPressMsg{Code: tea.KeyUp}
 	case "down":
@@ -211,14 +213,16 @@ func findAction(actions []actionItem, key string) actionItem {
 // detailModel builds a listModel with two filtered rows in the detail state,
 // ready for exercising updateDetail.
 func detailModel(focus detailFocus) listModel {
+	rows := []listRow{
+		{Name: "a", Group: "g1", Local: &discovery.Skill{Name: "a", LocalPath: "/p/a"}},
+		{Name: "b", Group: "g2", Local: &discovery.Skill{Name: "b", LocalPath: "/p/b"}},
+	}
 	return listModel{
 		selected: true,
 		focus:    focus,
 		cursor:   0,
-		filtered: []listRow{
-			{Name: "a", Local: &discovery.Skill{Name: "a", LocalPath: "/p/a"}},
-			{Name: "b", Local: &discovery.Skill{Name: "b", LocalPath: "/p/b"}},
-		},
+		rows:     rows,
+		filtered: rows,
 	}
 }
 
@@ -308,6 +312,64 @@ func TestUpdateDetail_FocusActionsMovesActionCursor(t *testing.T) {
 	}
 	if lm.actionCursor != 1 {
 		t.Errorf("focusActions j should advance actionCursor, got %d", lm.actionCursor)
+	}
+}
+
+func TestUpdateDetail_FocusListTypingFiltersRows(t *testing.T) {
+	m := detailModel(focusList)
+
+	nm, _ := m.updateDetail(key("b"))
+	lm := nm.(listModel)
+	if lm.search != "b" {
+		t.Fatalf("search = %q, want %q", lm.search, "b")
+	}
+	if len(lm.filtered) != 1 {
+		t.Fatalf("filtered len = %d, want 1", len(lm.filtered))
+	}
+	if lm.filtered[0].Name != "b" {
+		t.Fatalf("filtered[0] = %q, want %q", lm.filtered[0].Name, "b")
+	}
+	if !lm.selected {
+		t.Fatal("detail pane should stay open when search still has matches")
+	}
+	if lm.focus != focusList {
+		t.Fatalf("focus = %v, want focusList", lm.focus)
+	}
+}
+
+func TestUpdateDetail_FocusListBackspaceUpdatesSearch(t *testing.T) {
+	m := detailModel(focusList)
+	m.search = "b"
+	m.filtered = []listRow{
+		{Name: "b", Group: "g2", Local: &discovery.Skill{Name: "b", LocalPath: "/p/b"}},
+	}
+
+	nm, _ := m.updateDetail(key("backspace"))
+	lm := nm.(listModel)
+	if lm.search != "" {
+		t.Fatalf("search = %q, want empty", lm.search)
+	}
+	if len(lm.filtered) != 2 {
+		t.Fatalf("filtered len = %d, want 2", len(lm.filtered))
+	}
+	if !lm.selected {
+		t.Fatal("detail pane should stay open after restoring matching rows")
+	}
+}
+
+func TestUpdateDetail_FocusListTypingNoMatchesClosesDetail(t *testing.T) {
+	m := detailModel(focusList)
+
+	nm, _ := m.updateDetail(key("z"))
+	lm := nm.(listModel)
+	if lm.search != "z" {
+		t.Fatalf("search = %q, want %q", lm.search, "z")
+	}
+	if len(lm.filtered) != 0 {
+		t.Fatalf("filtered len = %d, want 0", len(lm.filtered))
+	}
+	if lm.selected {
+		t.Fatal("detail pane should close when the current search removes all rows")
 	}
 }
 

--- a/cmd/list_tui_test.go
+++ b/cmd/list_tui_test.go
@@ -449,13 +449,21 @@ func TestExecuteActionUpdate_PackageUsesExecutor(t *testing.T) {
 	}
 
 	nm, cmd := m.executeAction("update")
-	if cmd == nil {
-		t.Fatal("expected update command")
+	if cmd != nil {
+		t.Fatal("expected update to prompt before running")
 	}
-	if _, ok := nm.(listModel); !ok {
-		t.Fatal("expected listModel result")
+	lm := nm.(listModel)
+	if lm.substate != listSubstateUpdateChoice {
+		t.Fatalf("substate = %v, want listSubstateUpdateChoice", lm.substate)
+	}
+	if lm.updateHasMods {
+		t.Fatal("package update without local edits should not offer merge choices")
 	}
 
+	_, cmd = lm.updateUpdateChoice(key("u"))
+	if cmd == nil {
+		t.Fatal("expected update command after confirmation")
+	}
 	msg := cmd()
 	done, ok := msg.(updateDoneMsg)
 	if !ok {
@@ -471,5 +479,91 @@ func TestExecuteActionUpdate_PackageUsesExecutor(t *testing.T) {
 	}
 	if string(data) != "updated" {
 		t.Errorf("marker content = %q, want %q", string(data), "updated")
+	}
+}
+
+func TestExecuteActionUpdate_ModifiedSkillPromptsForStrategy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	skillDir := filepath.Join(home, ".scribe", "skills", "recap")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("local change\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	st := &state.State{
+		SchemaVersion: 2,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				InstalledHash: sync.ComputeFileHash([]byte("upstream base\n")),
+			},
+		},
+	}
+
+	m := listModel{
+		bag: &workflow.Bag{State: st},
+		filtered: []listRow{
+			{
+				Name:      "recap",
+				Group:     "owner/repo",
+				Status:    sync.StatusOutdated,
+				HasStatus: true,
+				Entry: &manifest.Entry{
+					Name:   "recap",
+					Source: "github:owner/repo@main",
+				},
+				Local: &discovery.Skill{Name: "recap", LocalPath: skillDir},
+			},
+		},
+	}
+
+	nm, cmd := m.executeAction("update")
+	if cmd != nil {
+		t.Fatal("expected modified skill update to wait for user choice")
+	}
+	lm := nm.(listModel)
+	if lm.substate != listSubstateUpdateChoice {
+		t.Fatalf("substate = %v, want listSubstateUpdateChoice", lm.substate)
+	}
+	if lm.statusMsg == "" {
+		t.Fatal("expected update choice explanation")
+	}
+}
+
+func TestUpdateUpdateChoice_KeepLocalSkipsUpdate(t *testing.T) {
+	m := listModel{
+		substate:      listSubstateUpdateChoice,
+		statusMsg:     "Local edits detected.",
+		updateHasMods: true,
+	}
+
+	nm, cmd := m.updateUpdateChoice(key("l"))
+	if cmd != nil {
+		t.Fatal("keep local should not start an update command")
+	}
+	lm := nm.(listModel)
+	if lm.substate != listSubstateNone {
+		t.Fatalf("substate = %v, want listSubstateNone", lm.substate)
+	}
+	if lm.statusMsg != "Kept local version. Registry update skipped." {
+		t.Fatalf("statusMsg = %q", lm.statusMsg)
+	}
+}
+
+func TestRowHasLocalModifications_UsesDiscoveredSkillState(t *testing.T) {
+	row := listRow{
+		Name: "recap",
+		Local: &discovery.Skill{
+			Name:      "recap",
+			LocalPath: "/some/non-canonical/path",
+			Modified:  true,
+		},
+	}
+
+	if !rowHasLocalModifications(row, &state.State{Installed: map[string]state.InstalledSkill{}}) {
+		t.Fatal("expected discovered Modified=true to trigger update choice")
 	}
 }

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -82,10 +82,11 @@ func runRestore(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("write restored skill: %w", err)
 	}
 
-	// Bump revision (forward operation).
+	// Bump revision (forward operation). Keep InstalledHash unchanged so the
+	// restored content is treated as a deliberate local modification against the
+	// last synced baseline and preserved on future syncs.
 	newRevision := skill.Revision + 1
 	skill.Revision = newRevision
-	skill.InstalledHash = sync.ComputeFileHash(restoreContent)
 	st.Installed[skillName] = skill
 
 	if err := st.Save(); err != nil {

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -81,8 +81,8 @@ func TestRunRestore(t *testing.T) {
 	if skill.Revision != 4 {
 		t.Errorf("expected revision 4, got %d", skill.Revision)
 	}
-	if skill.InstalledHash != sync.ComputeFileHash(oldContent) {
-		t.Errorf("expected hash of old content, got %q", skill.InstalledHash)
+	if skill.InstalledHash != sync.ComputeFileHash(currentContent) {
+		t.Errorf("expected original baseline hash to be preserved, got %q", skill.InstalledHash)
 	}
 }
 

--- a/internal/sync/compare.go
+++ b/internal/sync/compare.go
@@ -20,20 +20,12 @@ import (
 //   - any mismatch               → StatusOutdated
 //
 // Packages always use SHA comparison (they track a branch).
-func compareEntry(entry manifest.Entry, installed *state.InstalledSkill, latestSHA, registryRepo string) Status {
+func compareEntry(entry manifest.Entry, installed *state.InstalledSkill, latestSHA, registryRepo string, locallyModified bool) Status {
 	if installed == nil {
 		return StatusMissing
 	}
 
-	// Find the source entry for this registry.
-	var source *state.SkillSource
-	for i := range installed.Sources {
-		if installed.Sources[i].Registry == registryRepo {
-			source = &installed.Sources[i]
-			break
-		}
-	}
-
+	source := findSourceForRegistry(installed, registryRepo)
 	if source == nil {
 		// Installed but not from this registry — treat as missing from this registry's perspective.
 		return StatusMissing
@@ -44,32 +36,60 @@ func compareEntry(entry manifest.Entry, installed *state.InstalledSkill, latestS
 		return StatusMissing
 	}
 
-	// Packages and branches use SHA comparison.
-	// If latestSHA is empty (API unreachable), assume current to avoid spurious re-installs.
-	if entry.IsPackage() || src.IsBranch() {
-		if latestSHA == missingSkillBlobSHA {
-			return StatusOutdated
-		}
-		if latestSHA == "" {
-			return StatusCurrent
-		}
-		if source.LastSHA == latestSHA {
-			return StatusCurrent
-		}
-		return StatusOutdated
+	var status Status
+	switch {
+	case entry.IsPackage() || src.IsBranch():
+		status = compareBranchOrPackage(source, latestSHA)
+	default:
+		status = compareTag(source, src.Ref)
 	}
 
-	// Tag ref: try semver comparison first.
-	if semver.IsValid(src.Ref) && semver.IsValid(source.Ref) {
-		if semver.Compare(source.Ref, src.Ref) >= 0 {
-			return StatusCurrent // local is same or newer
+	return applyLocalModificationOverlay(status, locallyModified)
+}
+
+func findSourceForRegistry(installed *state.InstalledSkill, registryRepo string) *state.SkillSource {
+	for i := range installed.Sources {
+		if installed.Sources[i].Registry == registryRepo {
+			return &installed.Sources[i]
 		}
+	}
+	return nil
+}
+
+func compareBranchOrPackage(source *state.SkillSource, latestSHA string) Status {
+	// If the latest blob SHA is unavailable because the skill path no longer
+	// exists in the registry, it should show as outdated.
+	if latestSHA == missingSkillBlobSHA {
 		return StatusOutdated
 	}
-
-	// Non-semver tag (e.g. "v0.12.9.0"): exact match only.
-	if source.Ref == src.Ref {
+	// If the API is unavailable, assume current to avoid spurious updates.
+	if latestSHA == "" {
+		return StatusCurrent
+	}
+	if source.LastSHA == latestSHA {
 		return StatusCurrent
 	}
 	return StatusOutdated
+}
+
+func compareTag(source *state.SkillSource, desiredRef string) Status {
+	// Semver tags: local ahead is acceptable.
+	if semver.IsValid(desiredRef) && semver.IsValid(source.Ref) {
+		if semver.Compare(source.Ref, desiredRef) >= 0 {
+			return StatusCurrent
+		}
+		return StatusOutdated
+	}
+	// Non-semver tags: exact match only.
+	if source.Ref == desiredRef {
+		return StatusCurrent
+	}
+	return StatusOutdated
+}
+
+func applyLocalModificationOverlay(status Status, locallyModified bool) Status {
+	if locallyModified && status == StatusCurrent {
+		return StatusModified
+	}
+	return status
 }

--- a/internal/sync/compare_test.go
+++ b/internal/sync/compare_test.go
@@ -27,7 +27,7 @@ func installedWithSource(registry, ref, sha string) *state.InstalledSkill {
 }
 
 func TestCompareEntryMissing(t *testing.T) {
-	got := compareEntry(entry("github:a/b@v1.0.0"), nil, "", "a/b")
+	got := compareEntry(entry("github:a/b@v1.0.0"), nil, "", "a/b", false)
 	if got != StatusMissing {
 		t.Errorf("got %s, want %s", got, StatusMissing)
 	}
@@ -35,7 +35,7 @@ func TestCompareEntryMissing(t *testing.T) {
 
 func TestCompareEntryCurrentBranch(t *testing.T) {
 	inst := installedWithSource("a/b", "main", "abc123")
-	got := compareEntry(entry("github:a/b@main"), inst, "abc123", "a/b")
+	got := compareEntry(entry("github:a/b@main"), inst, "abc123", "a/b", false)
 	if got != StatusCurrent {
 		t.Errorf("got %s, want %s", got, StatusCurrent)
 	}
@@ -43,7 +43,7 @@ func TestCompareEntryCurrentBranch(t *testing.T) {
 
 func TestCompareEntryOutdatedBranch(t *testing.T) {
 	inst := installedWithSource("a/b", "main", "abc123")
-	got := compareEntry(entry("github:a/b@main"), inst, "def456", "a/b")
+	got := compareEntry(entry("github:a/b@main"), inst, "def456", "a/b", false)
 	if got != StatusOutdated {
 		t.Errorf("got %s, want %s", got, StatusOutdated)
 	}
@@ -51,7 +51,7 @@ func TestCompareEntryOutdatedBranch(t *testing.T) {
 
 func TestCompareEntryMissingBranchBlobIsOutdated(t *testing.T) {
 	inst := installedWithSource("a/b", "main", "abc123")
-	got := compareEntry(entry("github:a/b@main"), inst, missingSkillBlobSHA, "a/b")
+	got := compareEntry(entry("github:a/b@main"), inst, missingSkillBlobSHA, "a/b", false)
 	if got != StatusOutdated {
 		t.Errorf("got %s, want %s", got, StatusOutdated)
 	}
@@ -59,7 +59,7 @@ func TestCompareEntryMissingBranchBlobIsOutdated(t *testing.T) {
 
 func TestCompareEntryCurrentTag(t *testing.T) {
 	inst := installedWithSource("a/b", "v1.0.0", "")
-	got := compareEntry(entry("github:a/b@v1.0.0"), inst, "", "a/b")
+	got := compareEntry(entry("github:a/b@v1.0.0"), inst, "", "a/b", false)
 	if got != StatusCurrent {
 		t.Errorf("got %s, want %s", got, StatusCurrent)
 	}
@@ -74,7 +74,7 @@ func TestCompareEntrySourceLookup(t *testing.T) {
 			Ref:      "v1.0.0",
 		}},
 	}
-	got := compareEntry(entry("github:a/b@v1.0.0"), inst, "", "a/b")
+	got := compareEntry(entry("github:a/b@v1.0.0"), inst, "", "a/b", false)
 	if got != StatusMissing {
 		t.Errorf("got %s, want %s", got, StatusMissing)
 	}
@@ -115,7 +115,7 @@ func TestCompareEntry(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := compareEntry(c.entry, c.installed, c.latestSHA, c.registry)
+			got := compareEntry(c.entry, c.installed, c.latestSHA, c.registry, false)
 			if got != c.want {
 				t.Errorf("got %s, want %s", got, c.want)
 			}
@@ -140,10 +140,26 @@ func TestComparePackage(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := compareEntry(c.entry, c.installed, c.latestSHA, c.registry)
+			got := compareEntry(c.entry, c.installed, c.latestSHA, c.registry, false)
 			if got != c.want {
 				t.Errorf("got %s, want %s", got, c.want)
 			}
 		})
+	}
+}
+
+func TestCompareEntryModifiedBranch(t *testing.T) {
+	inst := installedWithSource("a/b", "main", "abc123")
+	got := compareEntry(entry("github:a/b@main"), inst, "abc123", "a/b", true)
+	if got != StatusModified {
+		t.Errorf("got %s, want %s", got, StatusModified)
+	}
+}
+
+func TestCompareEntryModifiedTag(t *testing.T) {
+	inst := installedWithSource("a/b", "v1.0.0", "")
+	got := compareEntry(entry("github:a/b@v1.0.0"), inst, "", "a/b", true)
+	if got != StatusModified {
+		t.Errorf("got %s, want %s", got, StatusModified)
 	}
 }

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -37,6 +37,10 @@ type Syncer struct {
 	Emit     func(any) // receives events defined in events.go
 	Executor CommandExecutor
 
+	// ModifiedStrategy controls what to do when an outdated skill also has
+	// unsynced local edits on disk.
+	ModifiedStrategy ModifiedStrategy
+
 	// TrustAll skips approval prompts for packages (--trust-all flag).
 	TrustAll bool
 
@@ -45,6 +49,14 @@ type Syncer struct {
 	// If nil and TrustAll is false, packages needing approval are skipped.
 	ApprovalFunc func(name, command, source string) bool
 }
+
+// ModifiedStrategy controls how sync treats outdated skills with local edits.
+type ModifiedStrategy int
+
+const (
+	ModifiedStrategyMerge ModifiedStrategy = iota
+	ModifiedStrategyPreferTheirs
+)
 
 // FetchManifest tries Provider.Discover first (if set), then falls back to
 // direct file fetch with scribe.yaml → scribe.toml fallback.
@@ -94,6 +106,7 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 	}
 
 	var statuses []SkillStatus
+	storeDir, _ := tools.StoreDir()
 	// Cache for package commit SHAs keyed by owner/repo/ref.
 	commitSHACache := map[string]string{}
 	// Cache for branch-skill tree listings keyed by owner/repo/ref.
@@ -106,6 +119,10 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 		entry := &m.Catalog[i]
 		// Use bare name for lookup — flat storage model.
 		installedPtr := lookupInstalled(st, entry.Name)
+		locallyModified := false
+		if installedPtr != nil && storeDir != "" {
+			locallyModified = IsLocallyModified(filepath.Join(storeDir, entry.Name), installedPtr.InstalledHash)
+		}
 
 		latestSHA := ""
 		src, err := manifest.ParseSource(entry.Source)
@@ -148,7 +165,7 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 			}
 		}
 
-		status := compareEntry(*entry, installedPtr, latestSHA, teamRepo)
+		status := compareEntry(*entry, installedPtr, latestSHA, teamRepo, locallyModified)
 		statuses = append(statuses, SkillStatus{
 			Name:       entry.Name,
 			Status:     status,
@@ -276,7 +293,7 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 				storeDir, sdErr := tools.StoreDir()
 				if sdErr == nil {
 					skillDir := filepath.Join(storeDir, sk.Name)
-					if IsLocallyModified(skillDir, installed.InstalledHash) {
+					if IsLocallyModified(skillDir, installed.InstalledHash) && s.ModifiedStrategy != ModifiedStrategyPreferTheirs {
 						// Find the new upstream SKILL.md content for merge.
 						var upstreamContent []byte
 						for _, f := range tFiles {


### PR DESCRIPTION
## Summary
- make skill updates explicit in the list TUI instead of immediately running on selection
- add local vs registry vs merge handling for locally modified skills, with automatic editor opening on merge conflicts
- treat restored skills as locally modified and surface that state in registry comparisons
- refactor sync comparison logic into smaller helpers for readability

## Testing
- go test ./internal/sync ./cmd