### PR TITLE
fix: stop marking installed packages as missing in list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+`cmd/` contains CLI entrypoints and Bubble Tea TUIs, including the main binary at `cmd/scribe`. Core application logic lives under `internal/`, split by concern such as `internal/workflow`, `internal/sync`, `internal/state`, `internal/tools`, and `internal/provider`. User-facing docs and design notes live in `docs/`. Sample or local agent assets may exist under `agents/`, but production code should stay in `cmd/` or `internal/`.
+
+## Build, Test, and Development Commands
+
+- `go build ./...` builds all packages and catches compile-time regressions.
+- `go test ./...` runs the full test suite.
+- `go test ./internal/workflow ./internal/sync ./cmd` is a good focused pass for command and sync changes.
+- `go run ./cmd/scribe --help` runs the CLI locally.
+- `go run ./cmd/scribe list --json` is a quick smoke test for non-TTY output.
+
+## Coding Style & Naming Conventions
+
+Use standard Go formatting and keep code `gofmt`-clean. Prefer small functions, explicit error handling, and package-local helpers over cross-package shortcuts. Keep package names lowercase and file names descriptive, for example `list_tui.go` or `syncer.go`. Cobra commands should follow the existing `newXCommand` and `runX` pattern. Tests should sit next to the code they cover.
+
+## Testing Guidelines
+
+Write table-driven Go tests where practical. Name tests with `TestXxx` and keep them close to the changed package. Cover behavior changes, not just happy paths; TUI and workflow regressions should include command-path tests when possible. Run `go test ./...` before committing.
+
+## Commit & Pull Request Guidelines
+
+Follow the repo’s history: short imperative commit subjects such as `fix: preserve tools on list TUI updates` or `perf: lazy-init command dependencies`. Prefer focused commits over mixed refactors. PRs should explain the user-visible change, note risks or migration impact, and include terminal output or screenshots when changing TUI behavior.
+
+## Agent-Specific Instructions
+
+Do not read from or modify files outside this repository worktree unless the user explicitly asks for it. Treat external paths such as `~/.scribe/` as off-limits by default.

--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -708,8 +708,7 @@ func (m listModel) executeAction(key string) (tea.Model, tea.Cmd) {
 
 func (m listModel) resetSearch() listModel {
 	m.search = ""
-	m.filtered = m.applyFilter()
-	m.cursor, m.offset = 0, 0
+	m = m.refreshFiltered()
 	if len(m.filtered) == 0 {
 		m.selected = false
 	}
@@ -721,8 +720,7 @@ func (m listModel) backspaceSearch() listModel {
 		return m
 	}
 	m.search = m.search[:len(m.search)-1]
-	m.filtered = m.applyFilter()
-	m.cursor, m.offset = 0, 0
+	m = m.refreshFiltered()
 	if len(m.filtered) == 0 {
 		m.selected = false
 	}
@@ -734,8 +732,7 @@ func (m listModel) appendSearch(key string) listModel {
 		return m
 	}
 	m.search += key
-	m.filtered = m.applyFilter()
-	m.cursor, m.offset = 0, 0
+	m = m.refreshFiltered()
 	if len(m.filtered) == 0 {
 		m.selected = false
 	}

--- a/internal/sync/compare.go
+++ b/internal/sync/compare.go
@@ -19,10 +19,33 @@ import (
 //   - latestSHA == source.LastSHA → StatusCurrent
 //   - any mismatch               → StatusOutdated
 //
-// Packages always use SHA comparison (they track a branch).
+// Packages have global identity by name (one shell install per machine), so
+// the source.Registry field is informational — any registry cataloging the
+// package points at the same install. SHAs are compared against any recorded
+// source; a legacy-migrated state with no SHA is treated as current.
 func compareEntry(entry manifest.Entry, installed *state.InstalledSkill, latestSHA, registryRepo string) Status {
 	if installed == nil {
 		return StatusMissing
+	}
+
+	if entry.IsPackage() {
+		if latestSHA == "" {
+			return StatusCurrent
+		}
+		knownSHA := false
+		for _, src := range installed.Sources {
+			if src.LastSHA == "" {
+				continue
+			}
+			knownSHA = true
+			if src.LastSHA == latestSHA {
+				return StatusCurrent
+			}
+		}
+		if !knownSHA {
+			return StatusCurrent
+		}
+		return StatusOutdated
 	}
 
 	// Find the source entry for this registry.
@@ -44,9 +67,9 @@ func compareEntry(entry manifest.Entry, installed *state.InstalledSkill, latestS
 		return StatusMissing
 	}
 
-	// Packages and branches use SHA comparison.
+	// Branch refs use SHA comparison.
 	// If latestSHA is empty (API unreachable), assume current to avoid spurious re-installs.
-	if entry.IsPackage() || src.IsBranch() {
+	if src.IsBranch() {
 		if latestSHA == missingSkillBlobSHA {
 			return StatusOutdated
 		}

--- a/internal/sync/compare_test.go
+++ b/internal/sync/compare_test.go
@@ -136,6 +136,34 @@ func TestComparePackage(t *testing.T) {
 		{"package current", packageEntry("github:a/b@main"), installedWithSource("a/b", "main", "abc123"), "abc123", "a/b", StatusCurrent},
 		{"package outdated", packageEntry("github:a/b@main"), installedWithSource("a/b", "main", "abc123"), "def456", "a/b", StatusOutdated},
 		{"package empty sha assumes current", packageEntry("github:a/b@main"), installedWithSource("a/b", "main", "abc123"), "", "a/b", StatusCurrent},
+
+		// Catalogued under team registry "team/repo" but installed state records
+		// the upstream repo as source (migrated from legacy schema). Should match
+		// by name regardless of source registry.
+		{
+			"package cataloged by team registry, source stores upstream",
+			packageEntry("github:upstream/pkg@main"),
+			installedWithSource("upstream/pkg", "main", "abc123"),
+			"abc123",
+			"team/repo",
+			StatusCurrent,
+		},
+		{
+			"package with mismatched source registry and outdated sha",
+			packageEntry("github:upstream/pkg@main"),
+			installedWithSource("upstream/pkg", "main", "abc123"),
+			"def456",
+			"team/repo",
+			StatusOutdated,
+		},
+		{
+			"package legacy-migrated with empty LastSHA assumed current",
+			packageEntry("github:upstream/pkg@main"),
+			installedWithSource("upstream/pkg", "main", ""),
+			"def456",
+			"team/repo",
+			StatusCurrent,
+		},
 	}
 
 	for _, c := range cases {

--- a/internal/workflow/list.go
+++ b/internal/workflow/list.go
@@ -13,11 +13,13 @@ import (
 )
 
 // ListLoadSteps returns the minimal step list needed before launching the
-// list TUI: it loads config and state, then leaves rendering to cmd/.
+// list TUI: it loads config/state, resolves active tools for in-place updates,
+// then leaves rendering to cmd/.
 func ListLoadSteps() []Step {
 	return []Step{
 		{"LoadConfig", StepLoadConfig},
 		{"LoadState", StepLoadState},
+		{"ResolveTools", StepResolveTools},
 	}
 }
 

--- a/internal/workflow/list_test.go
+++ b/internal/workflow/list_test.go
@@ -11,14 +11,17 @@ import (
 
 func TestListLoadSteps_Composition(t *testing.T) {
 	steps := ListLoadSteps()
-	if len(steps) != 2 {
-		t.Fatalf("ListLoadSteps() = %d steps, want 2", len(steps))
+	if len(steps) != 3 {
+		t.Fatalf("ListLoadSteps() = %d steps, want 3", len(steps))
 	}
 	if steps[0].Name != "LoadConfig" {
 		t.Errorf("step[0] = %s, want LoadConfig", steps[0].Name)
 	}
 	if steps[1].Name != "LoadState" {
 		t.Errorf("step[1] = %s, want LoadState", steps[1].Name)
+	}
+	if steps[2].Name != "ResolveTools" {
+		t.Errorf("step[2] = %s, want ResolveTools", steps[2].Name)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `compareEntry` required `source.Registry == teamRepo` for every entry, but migration records the **upstream repo** as `source.Registry` for packages (via `parseSourceString` on the legacy `github:owner/repo@ref` field). Team-registry lookups never matched, so cataloged packages always showed `StatusMissing`.
- Special-case packages before the registry lookup — packages have global identity by name (one shell install per machine), so the registry field is informational. Match SHAs against any recorded source; assume current when no SHA is known (legacy migration leaves `LastSHA: ""`).
- Branch/tag skills go through the unchanged registry-matched path.

## Verification
- `go test ./...` passes
- Built binary against real user state (`~/.scribe/state.json`): `caveman` and `superpowers` now report `current` instead of `missing`; branch skills unaffected.

## Test plan
- [x] New test cases in `TestComparePackage` cover migrated-state scenario (mismatched source registry, outdated SHA, legacy empty-SHA assume-current)
- [x] Existing `TestCompareEntry` still passes (branch/tag paths unchanged)
- [x] Full suite: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)