### PR TITLE
feat: make local skill management the default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+`cmd/` contains CLI entrypoints and Bubble Tea TUIs, including the main binary at `cmd/scribe`. Core application logic lives under `internal/`, split by concern such as `internal/workflow`, `internal/sync`, `internal/state`, `internal/tools`, and `internal/provider`. User-facing docs and design notes live in `docs/`. Sample or local agent assets may exist under `agents/`, but production code should stay in `cmd/` or `internal/`.
+
+## Build, Test, and Development Commands
+
+- `go build ./...` builds all packages and catches compile-time regressions.
+- `go test ./...` runs the full test suite.
+- `go test ./internal/workflow ./internal/sync ./cmd` is a good focused pass for command and sync changes.
+- `go run ./cmd/scribe --help` runs the CLI locally.
+- `go run ./cmd/scribe list --json` is a quick smoke test for non-TTY output.
+
+## Coding Style & Naming Conventions
+
+Use standard Go formatting and keep code `gofmt`-clean. Prefer small functions, explicit error handling, and package-local helpers over cross-package shortcuts. Keep package names lowercase and file names descriptive, for example `list_tui.go` or `syncer.go`. Cobra commands should follow the existing `newXCommand` and `runX` pattern. Tests should sit next to the code they cover.
+
+## Testing Guidelines
+
+Write table-driven Go tests where practical. Name tests with `TestXxx` and keep them close to the changed package. Cover behavior changes, not just happy paths; TUI and workflow regressions should include command-path tests when possible. Run `go test ./...` before committing.
+
+## Commit & Pull Request Guidelines
+
+Follow the repo’s history: short imperative commit subjects such as `fix: preserve tools on list TUI updates` or `perf: lazy-init command dependencies`. Prefer focused commits over mixed refactors. PRs should explain the user-visible change, note risks or migration impact, and include terminal output or screenshots when changing TUI behavior.
+
+## Agent-Specific Instructions
+
+Do not read from or modify files outside this repository worktree unless the user explicitly asks for it. Treat external paths such as `~/.scribe/` as off-limits by default.

--- a/README.md
+++ b/README.md
@@ -123,10 +123,12 @@ ArtistfyHQ/team-skills/
 
 | Command | What it does |
 |---|---|
+| `scribe` | Open the local skill manager |
 | `scribe list` | Show all skills on this machine |
 | `scribe add [query]` | Find and install skills from registries |
 | `scribe remove <skill>` | Remove a skill from this machine |
 | `scribe sync` | Pull updates from connected registries |
+| `scribe status` | Show connected registries, installed count, and last sync |
 | `scribe tools` | List detected AI tools, enable/disable |
 | `scribe explain <skill>` | AI-powered skill explanation (or `--raw` for rendered SKILL.md) |
 
@@ -197,8 +199,9 @@ Auth fallback chain: `gh auth token` → `GITHUB_TOKEN` env → `~/.scribe/confi
 Scribe auto-detects non-TTY environments (CI, agent invocations). `--json` flag gives structured output:
 
 ```bash
-scribe sync --json
+scribe --json
 scribe list --json
+scribe status --json
 scribe add --json skillname --yes
 ```
 

--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -708,8 +708,7 @@ func (m listModel) executeAction(key string) (tea.Model, tea.Cmd) {
 
 func (m listModel) resetSearch() listModel {
 	m.search = ""
-	m.filtered = m.applyFilter()
-	m.cursor, m.offset = 0, 0
+	m = m.refreshFiltered()
 	if len(m.filtered) == 0 {
 		m.selected = false
 	}
@@ -721,8 +720,7 @@ func (m listModel) backspaceSearch() listModel {
 		return m
 	}
 	m.search = m.search[:len(m.search)-1]
-	m.filtered = m.applyFilter()
-	m.cursor, m.offset = 0, 0
+	m = m.refreshFiltered()
 	if len(m.filtered) == 0 {
 		m.selected = false
 	}
@@ -734,8 +732,7 @@ func (m listModel) appendSearch(key string) listModel {
 		return m
 	}
 	m.search += key
-	m.filtered = m.applyFilter()
-	m.cursor, m.offset = 0, 0
+	m = m.refreshFiltered()
 	if len(m.filtered) == 0 {
 		m.selected = false
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,8 +22,8 @@ func newCommandFactory() *app.Factory {
 
 var rootCmd = &cobra.Command{
 	Use:           "scribe",
-	Short:         "Team skill sync for AI coding agents",
-	Long:          "Scribe syncs AI coding agent skills across your team via a shared GitHub loadout.",
+	Short:         "Manage local AI coding agent skills",
+	Long:          "Scribe manages local AI coding agent skills and keeps shared team registries in sync.",
 	Version:       Version,
 	Args:          cobra.NoArgs,
 	SilenceUsage:  true,
@@ -111,7 +111,7 @@ func runStoreMigration(factory *app.Factory) error {
 }
 
 func init() {
-	rootCmd.RunE = runHub
+	rootCmd.RunE = runDefault
 	rootCmd.Flags().Bool("json", false, "Output machine-readable JSON")
 
 	// Backward-compat aliases: hidden + deprecated, point to registry subcommands.
@@ -131,6 +131,7 @@ func init() {
 		newAddCommand(),
 		newRemoveCommand(),
 		newSyncCommand(),
+		newStatusCommand(),
 		newResolveCommand(),
 		newRestoreCommand(),
 		newToolsCommand(),

--- a/cmd/root_hub.go
+++ b/cmd/root_hub.go
@@ -20,7 +20,11 @@ import (
 
 const labelWidth = 10 // "Registries" is the longest label at 10 chars
 
-func runHub(cmd *cobra.Command, args []string) error {
+func runDefault(cmd *cobra.Command, args []string) error {
+	return runList(cmd, args)
+}
+
+func runStatus(cmd *cobra.Command, args []string) error {
 	jsonFlag, _ := cmd.Flags().GetBool("json")
 	factory := newCommandFactory()
 
@@ -34,7 +38,7 @@ func runHub(cmd *cobra.Command, args []string) error {
 	}
 
 	if jsonFlag || !isatty.IsTerminal(os.Stdout.Fd()) || os.Getenv("CI") != "" {
-		return writeHubJSON(os.Stdout, Version, cfg, st)
+		return writeStatusJSON(os.Stdout, Version, cfg, st)
 	}
 
 	if os.Getenv("TERM") == "dumb" {
@@ -50,14 +54,10 @@ func runHub(cmd *cobra.Command, args []string) error {
 
 	logo.Render(os.Stdout, Version, width)
 	writeStatusStyled(os.Stdout, cfg, st)
-
-	// Show the standard cobra help below the logo + status so users see every
-	// available command at a glance.
-	cmd.SetOut(os.Stdout)
-	return cmd.Help()
+	return nil
 }
 
-func writeHubJSON(w io.Writer, version string, cfg *config.Config, st *state.State) error {
+func writeStatusJSON(w io.Writer, version string, cfg *config.Config, st *state.State) error {
 	repos := cfg.TeamRepos()
 
 	status := struct {

--- a/cmd/root_hub_test.go
+++ b/cmd/root_hub_test.go
@@ -34,7 +34,7 @@ func TestHubJSONOutput(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := writeHubJSON(&buf, "1.0.0", cfg, st)
+	err := writeStatusJSON(&buf, "1.0.0", cfg, st)
 	if err != nil {
 		t.Fatalf("writeHubJSON error: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestHubJSONNoState(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := writeHubJSON(&buf, "dev", cfg, st)
+	err := writeStatusJSON(&buf, "dev", cfg, st)
 	if err != nil {
 		t.Fatalf("writeHubJSON error: %v", err)
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,21 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func newStatusCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show Scribe status for this machine",
+		Long: `Show Scribe status for this machine.
+
+Includes connected registries, installed skill count, and last sync time.
+
+Examples:
+  scribe status
+  scribe status --json`,
+		Args: cobra.NoArgs,
+		RunE: runStatus,
+	}
+	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	return cmd
+}

--- a/internal/workflow/list.go
+++ b/internal/workflow/list.go
@@ -13,11 +13,13 @@ import (
 )
 
 // ListLoadSteps returns the minimal step list needed before launching the
-// list TUI: it loads config and state, then leaves rendering to cmd/.
+// list TUI: it loads config/state, resolves active tools for in-place updates,
+// then leaves rendering to cmd/.
 func ListLoadSteps() []Step {
 	return []Step{
 		{"LoadConfig", StepLoadConfig},
 		{"LoadState", StepLoadState},
+		{"ResolveTools", StepResolveTools},
 	}
 }
 

--- a/internal/workflow/list_test.go
+++ b/internal/workflow/list_test.go
@@ -11,14 +11,17 @@ import (
 
 func TestListLoadSteps_Composition(t *testing.T) {
 	steps := ListLoadSteps()
-	if len(steps) != 2 {
-		t.Fatalf("ListLoadSteps() = %d steps, want 2", len(steps))
+	if len(steps) != 3 {
+		t.Fatalf("ListLoadSteps() = %d steps, want 3", len(steps))
 	}
 	if steps[0].Name != "LoadConfig" {
 		t.Errorf("step[0] = %s, want LoadConfig", steps[0].Name)
 	}
 	if steps[1].Name != "LoadState" {
 		t.Errorf("step[1] = %s, want LoadState", steps[1].Name)
+	}
+	if steps[2].Name != "ResolveTools" {
+		t.Errorf("step[2] = %s, want ResolveTools", steps[2].Name)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make bare `scribe` open the local skill manager by default
- add explicit `scribe status` for the machine/registry overview
- update docs and status JSON tests to match the new local-first UX

## Verification
- `go test ./cmd ./internal/workflow`
- `go build ./...`
- `go test ./...` *(fails in existing `internal/logo` tests unrelated to this change)*