### PR TITLE
fix: stop sync from overwriting target READMEs

### DIFF
--- a/internal/sync/filter.go
+++ b/internal/sync/filter.go
@@ -33,6 +33,9 @@ func shouldInclude(path string) bool {
 	// Only deny exact matches at the root level (not nested).
 	if filepath.Dir(path) == "." {
 		base := strings.ToLower(filepath.Base(path))
+		if base == "readme" || strings.HasPrefix(base, "readme.") {
+			return false
+		}
 		for _, denied := range denyExact {
 			if base == denied {
 				return false

--- a/internal/sync/filter_test.go
+++ b/internal/sync/filter_test.go
@@ -10,11 +10,14 @@ func TestShouldInclude(t *testing.T) {
 	}{
 		{"skill file", "SKILL.md", true},
 		{"script", "scripts/deploy.sh", true},
-		{"readme", "README.md", true},
+		{"nested readme", "docs/README.md", true},
 		{"nested file", "lib/helper.go", true},
 
 		// Deny list — these are repo-root files that leak into skill directories
 		// when the skill path == repo root.
+		{"readme", "README.md", false},
+		{"readme txt", "README.txt", false},
+		{"readme no extension", "README", false},
 		{"dot git", ".git/config", false},
 		{"dot gitignore", ".gitignore", false},
 		{"dot gitkeep", ".gitkeep", false},

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -3,12 +3,16 @@ package sync_test
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
+	"github.com/Naoray/scribe/internal/tools"
 )
 
 type mockExecutor struct {
@@ -21,6 +25,73 @@ type mockExecutor struct {
 func (m *mockExecutor) Execute(ctx context.Context, command string, timeout time.Duration) (string, string, error) {
 	m.commands = append(m.commands, command)
 	return m.stdout, m.stderr, m.err
+}
+
+type syncTestFetcher struct {
+	files []tools.SkillFile
+}
+
+func (f *syncTestFetcher) FetchFile(ctx context.Context, owner, repo, path, ref string) ([]byte, error) {
+	return nil, nil
+}
+
+func (f *syncTestFetcher) FetchDirectory(ctx context.Context, owner, repo, dirPath, ref string) ([]tools.SkillFile, error) {
+	return f.files, nil
+}
+
+func (f *syncTestFetcher) LatestCommitSHA(ctx context.Context, owner, repo, branch string) (string, error) {
+	return "", nil
+}
+
+func (f *syncTestFetcher) GetTree(ctx context.Context, owner, repo, ref string) ([]provider.TreeEntry, error) {
+	return nil, nil
+}
+
+func TestRunWithDiff_DoesNotOverwriteTargetReadme(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	projectDir := t.TempDir()
+	readmePath := filepath.Join(projectDir, "README.md")
+	if err := os.WriteFile(readmePath, []byte("# project readme\n"), 0o644); err != nil {
+		t.Fatalf("write project readme: %v", err)
+	}
+
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{
+			files: []tools.SkillFile{
+				{Path: "SKILL.md", Content: []byte("# skill\n")},
+				{Path: "README.md", Content: []byte("# scribe readme\n")},
+			},
+		},
+		Tools: []tools.Tool{tools.CommandTool{
+			ToolName:         "project-copy",
+			InstallCommand:   "cp -R \"{{canonical_dir}}\"/. \"" + projectDir + "\"",
+			UninstallCommand: "true",
+			PathTemplate:     projectDir,
+		}},
+	}
+
+	st := &state.State{Installed: make(map[string]state.InstalledSkill)}
+	statuses := []sync.SkillStatus{{
+		Name:   "repo-root-skill",
+		Status: sync.StatusMissing,
+		Entry: &manifest.Entry{
+			Name:   "repo-root-skill",
+			Source: "github:acme/skills@main",
+		},
+	}}
+
+	if err := syncer.RunWithDiff(context.Background(), "acme/team", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+
+	got, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read project readme: %v", err)
+	}
+	if string(got) != "# project readme\n" {
+		t.Fatalf("README.md overwritten: got %q", string(got))
+	}
 }
 
 func TestApply_PackageMissing_Approved(t *testing.T) {


### PR DESCRIPTION
## Summary
- filter root-level README files out of sync payloads
- keep nested docs like `docs/README.md` intact
- add a regression test covering a target directory README overwrite during sync

## Testing
- go test ./internal/sync ./internal/tools ./internal/workflow