### PR TITLE
feat: per-skill tool pinning (thin v1)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -150,6 +150,7 @@ func init() {
 		newStatusCommand(),
 		newResolveCommand(),
 		newRestoreCommand(),
+		newSkillCommand(),
 		newToolsCommand(),
 		newGuideCommand(),
 		newConfigCommand(),

--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -1,0 +1,302 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+func newSkillCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "skill",
+		Short: "Inspect or modify individual installed skills",
+		Long:  `Per-skill management. Currently provides "edit" for choosing which AI tools a skill installs into.`,
+	}
+	cmd.AddCommand(newSkillEditCommand())
+	return cmd
+}
+
+func newSkillEditCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "edit <name>",
+		Short: "Change which AI tools a skill installs into",
+		Long: `Pin a skill to a specific subset of AI tools, or return it to inherit mode
+(where it tracks globally-enabled tools).
+
+Examples:
+  scribe skill edit commit --tools claude,cursor   # pin to claude + cursor
+  scribe skill edit commit --add codex             # add codex, keep the rest
+  scribe skill edit commit --remove cursor         # drop cursor
+  scribe skill edit commit --inherit               # revert to global defaults
+  scribe skill edit commit --json                  # machine output`,
+		Args: cobra.ExactArgs(1),
+		RunE: runSkillEdit,
+	}
+	cmd.Flags().StringSlice("tools", nil, "Comma-separated list of tools to pin this skill to")
+	cmd.Flags().StringSlice("add", nil, "Add one or more tools to the current pin set")
+	cmd.Flags().StringSlice("remove", nil, "Remove one or more tools from the current pin set")
+	cmd.Flags().Bool("inherit", false, "Return the skill to inherit mode (tracks global tool settings)")
+	cmd.Flags().Bool("pin", false, "Keep the current Tools list but mark as pinned")
+	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	cmd.MarkFlagsMutuallyExclusive("tools", "inherit")
+	cmd.MarkFlagsMutuallyExclusive("tools", "add")
+	cmd.MarkFlagsMutuallyExclusive("tools", "remove")
+	cmd.MarkFlagsMutuallyExclusive("inherit", "pin")
+	cmd.MarkFlagsMutuallyExclusive("inherit", "add")
+	cmd.MarkFlagsMutuallyExclusive("inherit", "remove")
+	return cmd
+}
+
+type skillEditResult struct {
+	Name      string   `json:"name"`
+	ToolsMode string   `json:"tools_mode"`
+	Tools     []string `json:"tools"`
+	Added     []string `json:"added,omitempty"`
+	Removed   []string `json:"removed,omitempty"`
+}
+
+func runSkillEdit(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	toolsFlag, _ := cmd.Flags().GetStringSlice("tools")
+	addFlag, _ := cmd.Flags().GetStringSlice("add")
+	removeFlag, _ := cmd.Flags().GetStringSlice("remove")
+	inheritFlag, _ := cmd.Flags().GetBool("inherit")
+	pinFlag, _ := cmd.Flags().GetBool("pin")
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+
+	useJSON := jsonFlag || !isatty.IsTerminal(os.Stdout.Fd())
+
+	if len(toolsFlag) == 0 && len(addFlag) == 0 && len(removeFlag) == 0 && !inheritFlag && !pinFlag {
+		return fmt.Errorf("skill edit: supply one of --tools, --add, --remove, --inherit, or --pin")
+	}
+
+	factory := newCommandFactory()
+	cfg, err := factory.Config()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	st, err := factory.State()
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
+
+	installed, ok := st.Installed[name]
+	if !ok {
+		return fmt.Errorf("skill %q is not installed (run `scribe list` to see managed skills)", name)
+	}
+	if installed.Type == "package" {
+		return fmt.Errorf("skill %q is a package — per-skill tool pinning does not apply", name)
+	}
+
+	// Resolve globally-available tools for name lookup + install wiring.
+	available, err := tools.ResolveActive(cfg)
+	if err != nil {
+		return fmt.Errorf("resolve active tools: %w", err)
+	}
+	availableByName := make(map[string]tools.Tool, len(available))
+	availableNames := make([]string, 0, len(available))
+	for _, t := range available {
+		availableByName[t.Name()] = t
+		availableNames = append(availableNames, t.Name())
+	}
+
+	currentTools := append([]string(nil), installed.Tools...)
+
+	// Compute desired tool list + mode.
+	var desired []string
+	desiredMode := installed.ToolsMode
+
+	switch {
+	case inheritFlag:
+		desiredMode = state.ToolsModeInherit
+		desired = append([]string(nil), availableNames...)
+	case len(toolsFlag) > 0:
+		desiredMode = state.ToolsModePinned
+		desired = state.NormalizeToolSelection(splitCSV(toolsFlag))
+	case pinFlag && len(addFlag) == 0 && len(removeFlag) == 0:
+		desiredMode = state.ToolsModePinned
+		desired = state.NormalizeToolSelection(currentTools)
+	default:
+		// --add / --remove (with optional --pin implied)
+		desiredMode = state.ToolsModePinned
+		desired = state.NormalizeToolSelection(currentTools)
+		if len(addFlag) > 0 {
+			desired = state.NormalizeToolSelection(append(desired, splitCSV(addFlag)...))
+		}
+		if len(removeFlag) > 0 {
+			drop := make(map[string]bool, len(removeFlag))
+			for _, t := range splitCSV(removeFlag) {
+				drop[t] = true
+			}
+			kept := desired[:0]
+			for _, t := range desired {
+				if !drop[t] {
+					kept = append(kept, t)
+				}
+			}
+			desired = kept
+		}
+	}
+
+	// Validate desired tool names (inherit mode skips — availableNames is already filtered).
+	if desiredMode == state.ToolsModePinned {
+		var unknown []string
+		for _, t := range desired {
+			if _, ok := availableByName[t]; !ok {
+				unknown = append(unknown, t)
+			}
+		}
+		if len(unknown) > 0 {
+			return fmt.Errorf("unknown or disabled tool(s): %s (known: %s)", strings.Join(unknown, ", "), strings.Join(availableNames, ", "))
+		}
+		if len(desired) == 0 {
+			return fmt.Errorf("cannot pin skill %q to zero tools — use --inherit to revert", name)
+		}
+	}
+
+	// Diff against currently-installed tools.
+	currentSet := setOf(currentTools)
+	desiredSet := setOf(desired)
+	var added, removed []string
+	for _, t := range desired {
+		if !currentSet[t] {
+			added = append(added, t)
+		}
+	}
+	for _, t := range currentTools {
+		if !desiredSet[t] {
+			removed = append(removed, t)
+		}
+	}
+
+	// Physically apply the diff.
+	canonicalDir := filepath.Join(mustStoreDir(), name)
+	if _, err := os.Stat(canonicalDir); err != nil {
+		return fmt.Errorf("canonical store for %q missing: %w", name, err)
+	}
+
+	// Uninstall dropped tools first (best-effort — log and continue).
+	var newPathSet = make(map[string]bool, len(installed.Paths))
+	for _, p := range installed.Paths {
+		newPathSet[p] = true
+	}
+	for _, name := range removed {
+		tool, ok := availableByName[name]
+		if !ok {
+			continue
+		}
+		if err := tool.Uninstall(args[0]); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: uninstall from %s: %v\n", name, err)
+		}
+		// Drop that tool's paths from the recorded set (best-effort: match by prefix).
+		skillPath, _ := tool.SkillPath(args[0])
+		if skillPath != "" {
+			for p := range newPathSet {
+				if strings.HasPrefix(p, skillPath) || p == skillPath {
+					delete(newPathSet, p)
+				}
+			}
+		}
+	}
+
+	// Install into added tools.
+	for _, name := range added {
+		tool := availableByName[name]
+		paths, err := tool.Install(args[0], canonicalDir)
+		if err != nil {
+			return fmt.Errorf("install into %s: %w", name, err)
+		}
+		for _, p := range paths {
+			newPathSet[p] = true
+		}
+	}
+
+	// Build the final Paths slice (sorted for stable state diffs).
+	newPaths := make([]string, 0, len(newPathSet))
+	for p := range newPathSet {
+		newPaths = append(newPaths, p)
+	}
+	sort.Strings(newPaths)
+
+	// Persist.
+	installed.Tools = desired
+	installed.ToolsMode = desiredMode
+	installed.Paths = newPaths
+	st.Installed[args[0]] = installed
+	if err := st.Save(); err != nil {
+		return fmt.Errorf("save state: %w", err)
+	}
+
+	result := skillEditResult{
+		Name:      args[0],
+		ToolsMode: string(desiredMode),
+		Tools:     desired,
+		Added:     added,
+		Removed:   removed,
+	}
+	if desiredMode == state.ToolsModeInherit {
+		result.ToolsMode = "inherit"
+	}
+
+	if useJSON {
+		out, _ := json.MarshalIndent(result, "", "  ")
+		fmt.Println(string(out))
+		return nil
+	}
+
+	renderSkillEditText(result)
+	return nil
+}
+
+func renderSkillEditText(r skillEditResult) {
+	fmt.Printf("Updated %s\n", r.Name)
+	fmt.Printf("  mode:  %s\n", r.ToolsMode)
+	fmt.Printf("  tools: %s\n", strings.Join(r.Tools, ", "))
+	if len(r.Added) > 0 {
+		fmt.Printf("  +     %s\n", strings.Join(r.Added, ", "))
+	}
+	if len(r.Removed) > 0 {
+		fmt.Printf("  -     %s\n", strings.Join(r.Removed, ", "))
+	}
+}
+
+// splitCSV flattens slices like ["a,b", "c"] into ["a", "b", "c"] so users
+// can pass either --tools a,b or --tools a --tools b.
+func splitCSV(in []string) []string {
+	var out []string
+	for _, s := range in {
+		for _, part := range strings.Split(s, ",") {
+			p := strings.TrimSpace(part)
+			if p != "" {
+				out = append(out, p)
+			}
+		}
+	}
+	return out
+}
+
+func setOf(xs []string) map[string]bool {
+	m := make(map[string]bool, len(xs))
+	for _, x := range xs {
+		m[x] = true
+	}
+	return m
+}
+
+func mustStoreDir() string {
+	d, err := tools.StoreDir()
+	if err != nil {
+		panic(fmt.Sprintf("resolve store dir: %v", err))
+	}
+	return d
+}

--- a/cmd/skill_test.go
+++ b/cmd/skill_test.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+// seedSkillEnv provisions a tmp HOME with an installed skill `commit` linked
+// into the builtin tools and returns the test Command ready for Execute.
+func seedSkillEnv(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Config: pin the exact set of tools this test cares about. Gemini is
+	// explicitly disabled so a dev machine with gemini-cli installed can't
+	// leak into ResolveActive and break the pinning assertions below.
+	cfg := &config.Config{
+		Tools: []config.ToolConfig{
+			{Name: "claude", Type: tools.ToolTypeBuiltin, Enabled: true},
+			{Name: "cursor", Type: tools.ToolTypeBuiltin, Enabled: true},
+			{Name: "codex", Type: tools.ToolTypeBuiltin, Enabled: true},
+			{Name: "gemini", Type: tools.ToolTypeBuiltin, Enabled: false},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	// Write canonical store via WriteToStore so that later Install calls succeed.
+	files := []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# commit")}}
+	canonical, err := tools.WriteToStore("commit", files)
+	if err != nil {
+		t.Fatalf("WriteToStore: %v", err)
+	}
+
+	// Install into claude + cursor up front so "currentTools" matches reality.
+	claude := tools.ClaudeTool{}
+	cursor := tools.CursorTool{}
+	paths := []string{}
+	p1, err := claude.Install("commit", canonical)
+	if err != nil {
+		t.Fatalf("claude install: %v", err)
+	}
+	paths = append(paths, p1...)
+	p2, err := cursor.Install("commit", canonical)
+	if err != nil {
+		t.Fatalf("cursor install: %v", err)
+	}
+	paths = append(paths, p2...)
+
+	st := &state.State{
+		SchemaVersion: 4,
+		Installed: map[string]state.InstalledSkill{
+			"commit": {
+				Revision:      1,
+				InstalledHash: "abc",
+				Tools:         []string{"claude", "cursor"},
+				ToolsMode:     state.ToolsModeInherit,
+				Paths:         paths,
+				InstalledAt:   time.Now().UTC(),
+			},
+		},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+}
+
+func TestSkillEdit_PinToSubset(t *testing.T) {
+	seedSkillEnv(t)
+
+	cmd := newSkillEditCommand()
+	cmd.SetArgs([]string{"commit", "--tools", "claude", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := st.Installed["commit"]
+	if !ok {
+		t.Fatal("commit missing from state")
+	}
+	if got.ToolsMode != state.ToolsModePinned {
+		t.Errorf("ToolsMode = %q, want pinned", got.ToolsMode)
+	}
+	if !reflect.DeepEqual(got.Tools, []string{"claude"}) {
+		t.Errorf("Tools = %v, want [claude]", got.Tools)
+	}
+
+	// Cursor symlink should be gone after physical uninstall.
+	home := os.Getenv("HOME")
+	cursorPath := filepath.Join(home, ".cursor", "rules", "commit.mdc")
+	if _, err := os.Lstat(cursorPath); err == nil {
+		t.Errorf("cursor rule still present at %s", cursorPath)
+	}
+}
+
+func TestSkillEdit_AddTool(t *testing.T) {
+	seedSkillEnv(t)
+
+	cmd := newSkillEditCommand()
+	cmd.SetArgs([]string{"commit", "--add", "codex", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	st, _ := state.Load()
+	got := st.Installed["commit"]
+	if got.ToolsMode != state.ToolsModePinned {
+		t.Errorf("ToolsMode = %q, want pinned after --add", got.ToolsMode)
+	}
+	want := []string{"claude", "cursor", "codex"}
+	if !reflect.DeepEqual(got.Tools, want) {
+		t.Errorf("Tools = %v, want %v", got.Tools, want)
+	}
+}
+
+func TestSkillEdit_Inherit(t *testing.T) {
+	seedSkillEnv(t)
+
+	// First pin it.
+	pin := newSkillEditCommand()
+	pin.SetArgs([]string{"commit", "--tools", "claude", "--json"})
+	if err := pin.Execute(); err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+
+	// Then revert.
+	revert := newSkillEditCommand()
+	revert.SetArgs([]string{"commit", "--inherit", "--json"})
+	if err := revert.Execute(); err != nil {
+		t.Fatalf("revert: %v", err)
+	}
+
+	st, _ := state.Load()
+	got := st.Installed["commit"]
+	if got.ToolsMode != state.ToolsModeInherit {
+		t.Errorf("ToolsMode = %q, want inherit", got.ToolsMode)
+	}
+	// Inherit mode replays ResolveActive, which sorts alphabetically.
+	want := []string{"claude", "codex", "cursor"}
+	if !reflect.DeepEqual(got.Tools, want) {
+		t.Errorf("Tools = %v, want %v", got.Tools, want)
+	}
+}
+
+func TestSkillEdit_RejectsUnknownTool(t *testing.T) {
+	seedSkillEnv(t)
+
+	cmd := newSkillEditCommand()
+	cmd.SetArgs([]string{"commit", "--tools", "imaginary", "--json"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+}
+
+func TestSkillEdit_RejectsMissingSkill(t *testing.T) {
+	seedSkillEnv(t)
+
+	cmd := newSkillEditCommand()
+	cmd.SetArgs([]string{"nonexistent", "--tools", "claude", "--json"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing skill")
+	}
+}

--- a/internal/adopt/apply.go
+++ b/internal/adopt/apply.go
@@ -103,15 +103,16 @@ func (a *Adopter) applyOne(cand Candidate, result *Result) error {
 		return nil
 	}
 
-	// Record in state.
+	// Record in state. Adoption always starts in inherit mode — users opt into
+	// pinning via `scribe skill edit --pin`.
 	a.State.RecordInstall(cand.Name, state.InstalledSkill{
 		Revision:      1,
 		InstalledHash: cand.Hash,
 		Sources:       nil,
 		Tools:         installedToolNames,
+		ToolsMode:     state.ToolsModeInherit,
 		Paths:         allPaths,
 		Origin:        state.OriginLocal,
-		// TODO: set ToolsMode: state.ToolsModeInherit when per-skill tool mgmt lands
 	})
 
 	if err := a.State.Save(); err != nil {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -33,6 +33,20 @@ const (
 	OriginLocal Origin = "local"
 )
 
+// ToolsMode controls how the Tools field is interpreted at sync time.
+type ToolsMode string
+
+const (
+	// ToolsModeInherit is the zero value: the skill installs to whichever
+	// tools are globally enabled. Tools is a cache of the most recent
+	// effective list and may be rewritten by sync.
+	ToolsModeInherit ToolsMode = ""
+	// ToolsModePinned means the user explicitly chose this skill's tools.
+	// Sync must respect Tools verbatim (intersected with availability) and
+	// must not overwrite it based on global toggles.
+	ToolsModePinned ToolsMode = "pinned"
+)
+
 // InstalledSkill records everything needed to detect updates and uninstall.
 type InstalledSkill struct {
 	Revision      int           `json:"revision"`
@@ -40,6 +54,7 @@ type InstalledSkill struct {
 	Sources       []SkillSource `json:"sources,omitempty"`
 	InstalledAt   time.Time     `json:"installed_at"`
 	Tools         []string      `json:"tools"`
+	ToolsMode     ToolsMode     `json:"tools_mode,omitempty"`
 	Paths         []string      `json:"paths"`
 	Origin        Origin        `json:"origin,omitempty"`
 
@@ -93,6 +108,7 @@ type legacyInstalledSkill struct {
 	InstalledHash string        `json:"installed_hash,omitempty"`
 	Sources       []SkillSource `json:"sources,omitempty"`
 	Origin        Origin        `json:"origin,omitempty"`
+	ToolsMode     ToolsMode     `json:"tools_mode,omitempty"`
 }
 
 // DisplayVersion returns the version string shown in `scribe list`.
@@ -358,6 +374,7 @@ func legacyToSkill(ls legacyInstalledSkill) InstalledSkill {
 		Sources:       ls.Sources,
 		InstalledAt:   ls.InstalledAt,
 		Tools:         ls.Tools,
+		ToolsMode:     ls.ToolsMode,
 		Paths:         ls.Paths,
 		Origin:        ls.Origin,
 		Type:          ls.Type,

--- a/internal/state/tools_resolve.go
+++ b/internal/state/tools_resolve.go
@@ -1,0 +1,46 @@
+package state
+
+// EffectiveTools returns the tool names a skill should be installed into,
+// given the currently available (globally enabled) tool names.
+//
+// Inherit mode (default): union of available tools — the skill tracks global
+// settings. Pinned mode: intersection of the skill's Tools with availability,
+// preserving the user's chosen order.
+//
+// Packages (Type == "package") bypass per-skill routing and always receive the
+// full available list. This mirrors the existing behavior where packages install
+// independently of tool-facing symlinks.
+func (s InstalledSkill) EffectiveTools(available []string) []string {
+	if s.Type == "package" {
+		return append([]string(nil), available...)
+	}
+	if s.ToolsMode != ToolsModePinned {
+		return append([]string(nil), available...)
+	}
+	availSet := make(map[string]bool, len(available))
+	for _, a := range available {
+		availSet[a] = true
+	}
+	out := make([]string, 0, len(s.Tools))
+	for _, t := range s.Tools {
+		if availSet[t] {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// NormalizeToolSelection dedupes a user-provided tool list while preserving
+// order. Used by `scribe skill edit --tools` and --add.
+func NormalizeToolSelection(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, t := range in {
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	return out
+}

--- a/internal/state/tools_resolve_test.go
+++ b/internal/state/tools_resolve_test.go
@@ -1,0 +1,68 @@
+package state
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEffectiveTools_InheritReturnsAvailable(t *testing.T) {
+	sk := InstalledSkill{Tools: []string{"claude"}} // stale cache — ignored
+	got := sk.EffectiveTools([]string{"claude", "cursor"})
+	want := []string{"claude", "cursor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestEffectiveTools_PinnedIntersectsAvailable(t *testing.T) {
+	sk := InstalledSkill{
+		ToolsMode: ToolsModePinned,
+		Tools:     []string{"claude", "codex"}, // codex not available
+	}
+	got := sk.EffectiveTools([]string{"claude", "cursor"})
+	want := []string{"claude"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestEffectiveTools_PinnedPreservesOrder(t *testing.T) {
+	sk := InstalledSkill{
+		ToolsMode: ToolsModePinned,
+		Tools:     []string{"cursor", "claude"},
+	}
+	got := sk.EffectiveTools([]string{"claude", "cursor"})
+	want := []string{"cursor", "claude"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestEffectiveTools_PackagesBypass(t *testing.T) {
+	sk := InstalledSkill{
+		Type:      "package",
+		ToolsMode: ToolsModePinned,
+		Tools:     []string{"claude"},
+	}
+	got := sk.EffectiveTools([]string{"claude", "cursor"})
+	want := []string{"claude", "cursor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("packages should bypass per-skill routing: got %v, want %v", got, want)
+	}
+}
+
+func TestEffectiveTools_PinnedEmptyYieldsEmpty(t *testing.T) {
+	sk := InstalledSkill{ToolsMode: ToolsModePinned, Tools: nil}
+	got := sk.EffectiveTools([]string{"claude", "cursor"})
+	if len(got) != 0 {
+		t.Errorf("pinned with empty Tools should yield empty list, got %v", got)
+	}
+}
+
+func TestNormalizeToolSelection_DedupePreservesOrder(t *testing.T) {
+	got := NormalizeToolSelection([]string{"claude", "cursor", "claude", "", "codex"})
+	want := []string{"claude", "cursor", "codex"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -377,10 +377,14 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 				continue
 			}
 
+			// Filter to the skill's effective tools (pinned mode respects user
+			// selection; inherit mode uses every globally-enabled tool).
+			effectiveTools := selectEffectiveTools(s.Tools, installed)
+
 			var paths []string
 			var toolNames []string
 			toolFailed := false
-			for _, t := range s.Tools {
+			for _, t := range effectiveTools {
 				links, err := t.Install(sk.Name, canonicalDir)
 				if err != nil {
 					s.emit(SkillErrorMsg{Name: sk.Name, Err: fmt.Errorf("link to %s: %w", t.Name(), err)})
@@ -420,11 +424,21 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 			}
 			sources := mergeSources(installed, newSource)
 
+			// Preserve pinned ToolsMode across re-syncs. New skills default to
+			// inherit; for pinned skills we still overwrite Tools with the
+			// resolved names so stale entries (tool uninstalled globally)
+			// don't linger in state.
+			toolsMode := state.ToolsModeInherit
+			if installed != nil {
+				toolsMode = installed.ToolsMode
+			}
+
 			st.RecordInstall(sk.Name, state.InstalledSkill{
 				Revision:      nextRevision(installed),
 				InstalledHash: installedHash,
 				Sources:       sources,
 				Tools:         toolNames,
+				ToolsMode:     toolsMode,
 				Paths:         paths,
 			})
 			// Save after each successful install — partial sync is safe.
@@ -498,6 +512,27 @@ func resolveToolCmds(entry *manifest.Entry, activeTools []tools.Tool) []toolCmd 
 		cmds = append(cmds, toolCmd{installCmd: entry.Install, updateCmd: entry.Update})
 	}
 	return cmds
+}
+
+// selectEffectiveTools filters the globally-enabled tools down to the subset
+// that should receive this skill, honoring ToolsMode. Order comes from the
+// installed record for pinned mode (preserves user intent); from the global
+// list for inherit mode (preserves tool config order).
+func selectEffectiveTools(global []tools.Tool, installed *state.InstalledSkill) []tools.Tool {
+	if installed == nil || installed.ToolsMode != state.ToolsModePinned {
+		return global
+	}
+	byName := make(map[string]tools.Tool, len(global))
+	for _, t := range global {
+		byName[t.Name()] = t
+	}
+	out := make([]tools.Tool, 0, len(installed.Tools))
+	for _, name := range installed.Tools {
+		if t, ok := byName[name]; ok {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 // formatCmds formats tool commands for display in approval prompts.


### PR DESCRIPTION
## Summary

- New `scribe skill edit <name>` command lets users pin a skill to a specific subset of AI tools (or revert to inherit mode)
- `InstalledSkill.ToolsMode` field on state (`inherit` default, `pinned` when user chose a subset) — inherit skills keep auto-tracking globally-enabled tools
- Sync + adopt now honor pinned mode so re-runs don't reinstall a pinned skill into every globally-enabled tool

## Usage

    scribe skill edit commit --tools claude,cursor   # pin to subset
    scribe skill edit commit --add codex             # widen
    scribe skill edit commit --remove cursor         # shrink
    scribe skill edit commit --inherit               # revert
    scribe skill edit commit --pin                   # freeze current
    scribe skill edit commit --json                  # machine output

Physical diff is applied in-place: dropped tools are uninstalled (best-effort, warn on failure), added tools are installed (hard fail), then state is persisted.

## What is NOT in this PR

Deferred from the full plan per north-star (ship thin v1 first):

- TUI toggles in `scribe list` for interactive pinning
- Full reconcile loop across tools when global config changes
- Loadouts / named tool presets

## Test plan

- [x] `go test ./...` (all packages green)
- [x] New `cmd/skill_test.go` integration tests — pin to subset, add, inherit revert, unknown tool rejection, missing skill rejection
- [x] New `internal/state/tools_resolve_test.go` — inherit, pinned intersect, order preservation, package bypass, empty pin, normalize dedupe

🤖 Generated with [Claude Code](https://claude.com/claude-code)