### PR TITLE
feat: reconcile managed tool projections during sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ scribe sync
 
 AI coding agents like Claude Code and Cursor work better with "skills" — markdown instruction files that teach the agent how to do specific tasks (code reviews, deployments, Laravel patterns, etc.). If you've built a good set of skills, sharing them with teammates currently means Slack links and manual file copying. Nobody knows if they're on the latest version. The person who just joined has no idea what they're missing.
 
-Scribe fixes this. You put your team's skills in a GitHub repo with a `scribe.yaml` manifest (or legacy `scribe.toml`), teammates run `scribe registry connect`, and `scribe sync` keeps everyone up to date automatically. Works with Claude Code and Cursor from the same manifest.
+Scribe fixes this. You put your team's skills in a GitHub repo with a `scribe.yaml` manifest (or legacy `scribe.toml`), teammates run `scribe registry connect`, and `scribe sync` keeps the whole machine healthy: canonical store, adopted local skills, and tool-facing installs. Works with Claude Code, Codex, and Cursor from the same manifest.
 
 ## Install
 
@@ -128,7 +128,8 @@ ArtistfyHQ/team-skills/
 | `scribe add [query]` | Find and install skills from registries |
 | `scribe adopt [name]` | Import hand-rolled skills from `~/.claude/skills` etc. into the store |
 | `scribe remove <skill>` | Remove a skill from this machine |
-| `scribe sync` | Pull updates from connected registries (runs adoption first) |
+| `scribe sync` | Reconcile local skill state, tool installs, and connected registries |
+| `scribe skill repair <skill> --tool <tool>` | Resolve preserved managed drift when a tool-local copy differs from the canonical store |
 | `scribe status` | Show connected registries, installed count, and last sync |
 | `scribe tools` | List detected AI tools, enable/disable |
 | `scribe explain <skill>` | AI-powered skill explanation (or `--raw` for rendered SKILL.md) |
@@ -181,8 +182,16 @@ syncing ArtistfyHQ/team-skills...
   laravel-init         updated to v1.1.0
   deploy               ok (main@a3f2c1b)
   frontend-prs         installed main@c9f1d2e
+repaired 1 tool installs
 
 done: 1 installed, 1 updated, 2 current, 0 failed
+```
+
+If sync finds divergent content in a managed tool path, it preserves that content and prints a repair hint instead of overwriting it:
+
+```bash
+conflict: recap in codex differs from managed copy
+run `scribe skill repair recap --tool codex` to resolve
 ```
 
 ## Adoption — claim skills you already have

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -137,10 +137,14 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Remove any remaining symlinks from installed.Paths.
-	for _, p := range installed.Paths {
+	// Remove only the projections Scribe still believes it manages.
+	managedPaths := installed.ManagedPaths
+	if len(managedPaths) == 0 {
+		managedPaths = installed.Paths
+	}
+	for _, p := range managedPaths {
 		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
-			errs = append(errs, fmt.Sprintf("symlink %s: %v", p, err))
+			errs = append(errs, fmt.Sprintf("managed path %s: %v", p, err))
 		}
 	}
 

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Naoray/scribe/internal/state"
 )
 
 func TestResolveRemoveTarget(t *testing.T) {
@@ -70,5 +74,64 @@ func TestResolveRemoveTarget(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestRemoveLeavesConflictResidue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	canonical, err := filepath.Abs(filepath.Join(home, ".scribe", "skills", "recap"))
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	if err := os.MkdirAll(canonical, 0o755); err != nil {
+		t.Fatalf("MkdirAll canonical: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(canonical, "SKILL.md"), []byte("# recap\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile canonical: %v", err)
+	}
+	managed := filepath.Join(home, ".codex", "skills", "recap")
+	if err := os.MkdirAll(filepath.Dir(managed), 0o755); err != nil {
+		t.Fatalf("MkdirAll managed dir: %v", err)
+	}
+	if err := os.Symlink(canonical, managed); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	residue := filepath.Join(home, ".claude", "skills", "recap")
+	if err := os.MkdirAll(filepath.Dir(residue), 0o755); err != nil {
+		t.Fatalf("MkdirAll residue dir: %v", err)
+	}
+	if err := os.WriteFile(residue, []byte("# recap\nlocal drift\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile residue: %v", err)
+	}
+
+	st := &state.State{
+		SchemaVersion: 4,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Revision:     1,
+				Tools:        []string{},
+				ManagedPaths: []string{managed},
+				Paths:        []string{managed},
+				Conflicts:    []state.ProjectionConflict{{Tool: "claude", Path: residue, FoundHash: "hash"}},
+			},
+		},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	cmd := newRemoveCommand()
+	cmd.SetArgs([]string{"recap", "--yes", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if _, err := os.Lstat(managed); !os.IsNotExist(err) {
+		t.Fatalf("managed path still exists: %v", err)
+	}
+	if _, err := os.Stat(residue); err != nil {
+		t.Fatalf("conflict residue missing: %v", err)
 	}
 }

--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -82,7 +82,9 @@ func newSkillRepairCommand() *cobra.Command {
 	cmd.Flags().String("tool", "", "Tool projection to repair")
 	cmd.Flags().String("from", "managed", "Conflict winner: managed or tool")
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
-	cmd.MarkFlagRequired("tool")
+	if err := cmd.MarkFlagRequired("tool"); err != nil {
+		panic(err)
+	}
 	return cmd
 }
 
@@ -334,7 +336,7 @@ func runSkillRepair(cmd *cobra.Command, args []string) error {
 	canonicalDir := filepath.Join(mustStoreDir(), name)
 
 	if source == "tool" {
-		if err := reconcile.CopyProjectionToCanonical(path, toolName, canonicalDir); err != nil {
+		if err := reconcile.CopyProjectionToCanonical(tool, path, canonicalDir); err != nil {
 			return err
 		}
 		skillMD, err := os.ReadFile(filepath.Join(canonicalDir, "SKILL.md"))
@@ -371,7 +373,7 @@ func runSkillRepair(cmd *cobra.Command, args []string) error {
 	}
 	sort.Strings(managedPaths)
 
-	filteredConflicts := installed.Conflicts[:0]
+	filteredConflicts := make([]state.ProjectionConflict, 0, len(installed.Conflicts))
 	for _, conflict := range installed.Conflicts {
 		if conflict.Tool == toolName && conflict.Path == path {
 			continue

--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -11,7 +11,9 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
+	"github.com/Naoray/scribe/internal/reconcile"
 	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
 )
 
@@ -19,9 +21,9 @@ func newSkillCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "skill",
 		Short: "Inspect or modify individual installed skills",
-		Long:  `Per-skill management. Currently provides "edit" for choosing which AI tools a skill installs into.`,
+		Long:  `Per-skill management for choosing tools and repairing managed drift.`,
 	}
-	cmd.AddCommand(newSkillEditCommand())
+	cmd.AddCommand(newSkillEditCommand(), newSkillRepairCommand())
 	return cmd
 }
 
@@ -62,6 +64,26 @@ type skillEditResult struct {
 	Tools     []string `json:"tools"`
 	Added     []string `json:"added,omitempty"`
 	Removed   []string `json:"removed,omitempty"`
+}
+
+type skillRepairResult struct {
+	Name   string `json:"name"`
+	Tool   string `json:"tool"`
+	Source string `json:"source"`
+}
+
+func newSkillRepairCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "repair <name>",
+		Short: "Resolve managed drift for a skill projection",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runSkillRepair,
+	}
+	cmd.Flags().String("tool", "", "Tool projection to repair")
+	cmd.Flags().String("from", "managed", "Conflict winner: managed or tool")
+	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	cmd.MarkFlagRequired("tool")
+	return cmd
 }
 
 func runSkillEdit(cmd *cobra.Command, args []string) error {
@@ -186,8 +208,12 @@ func runSkillEdit(cmd *cobra.Command, args []string) error {
 	}
 
 	// Uninstall dropped tools first (best-effort — log and continue).
-	var newPathSet = make(map[string]bool, len(installed.Paths))
-	for _, p := range installed.Paths {
+	existingManagedPaths := installed.ManagedPaths
+	if len(existingManagedPaths) == 0 {
+		existingManagedPaths = installed.Paths
+	}
+	var newPathSet = make(map[string]bool, len(existingManagedPaths))
+	for _, p := range existingManagedPaths {
 		newPathSet[p] = true
 	}
 	for _, name := range removed {
@@ -232,6 +258,7 @@ func runSkillEdit(cmd *cobra.Command, args []string) error {
 	installed.Tools = desired
 	installed.ToolsMode = desiredMode
 	installed.Paths = newPaths
+	installed.ManagedPaths = append([]string(nil), newPaths...)
 	st.Installed[args[0]] = installed
 	if err := st.Save(); err != nil {
 		return fmt.Errorf("save state: %w", err)
@@ -268,6 +295,103 @@ func renderSkillEditText(r skillEditResult) {
 	if len(r.Removed) > 0 {
 		fmt.Printf("  -     %s\n", strings.Join(r.Removed, ", "))
 	}
+}
+
+func runSkillRepair(cmd *cobra.Command, args []string) error {
+	toolName, _ := cmd.Flags().GetString("tool")
+	source, _ := cmd.Flags().GetString("from")
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+	useJSON := jsonFlag || !isatty.IsTerminal(os.Stdout.Fd())
+
+	if source != "managed" && source != "tool" {
+		return fmt.Errorf("skill repair: --from must be one of managed, tool")
+	}
+
+	factory := newCommandFactory()
+	cfg, err := factory.Config()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	st, err := factory.State()
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
+
+	name := args[0]
+	installed, ok := st.Installed[name]
+	if !ok {
+		return fmt.Errorf("skill %q is not installed", name)
+	}
+
+	tool, err := tools.ResolveByName(cfg, toolName)
+	if err != nil {
+		return err
+	}
+	path, err := tool.SkillPath(name)
+	if err != nil {
+		return err
+	}
+	canonicalDir := filepath.Join(mustStoreDir(), name)
+
+	if source == "tool" {
+		if err := reconcile.CopyProjectionToCanonical(path, toolName, canonicalDir); err != nil {
+			return err
+		}
+		skillMD, err := os.ReadFile(filepath.Join(canonicalDir, "SKILL.md"))
+		if err == nil {
+			installed.InstalledHash = sync.ComputeFileHash(skillMD)
+		}
+	}
+
+	if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	links, err := tool.Install(name, canonicalDir)
+	if err != nil {
+		return err
+	}
+
+	newManaged := make(map[string]bool)
+	existingManagedPaths := installed.ManagedPaths
+	if len(existingManagedPaths) == 0 {
+		existingManagedPaths = installed.Paths
+	}
+	for _, p := range existingManagedPaths {
+		if p != path {
+			newManaged[p] = true
+		}
+	}
+	for _, p := range links {
+		newManaged[p] = true
+	}
+
+	managedPaths := make([]string, 0, len(newManaged))
+	for p := range newManaged {
+		managedPaths = append(managedPaths, p)
+	}
+	sort.Strings(managedPaths)
+
+	filteredConflicts := installed.Conflicts[:0]
+	for _, conflict := range installed.Conflicts {
+		if conflict.Tool == toolName && conflict.Path == path {
+			continue
+		}
+		filteredConflicts = append(filteredConflicts, conflict)
+	}
+	installed.ManagedPaths = managedPaths
+	installed.Paths = append([]string(nil), managedPaths...)
+	installed.Conflicts = filteredConflicts
+	st.Installed[name] = installed
+	if err := st.Save(); err != nil {
+		return err
+	}
+
+	result := skillRepairResult{Name: name, Tool: toolName, Source: source}
+	if useJSON {
+		return json.NewEncoder(os.Stdout).Encode(result)
+	}
+	fmt.Printf("Repaired %s for %s using %s as the source of truth\n", name, toolName, source)
+	return nil
 }
 
 // splitCSV flattens slices like ["a,b", "c"] into ["a", "b", "c"] so users

--- a/cmd/skill_test.go
+++ b/cmd/skill_test.go
@@ -65,6 +65,7 @@ func seedSkillEnv(t *testing.T) {
 				Tools:         []string{"claude", "cursor"},
 				ToolsMode:     state.ToolsModeInherit,
 				Paths:         paths,
+				ManagedPaths:  append([]string(nil), paths...),
 				InstalledAt:   time.Now().UTC(),
 			},
 		},
@@ -174,5 +175,96 @@ func TestSkillEdit_RejectsMissingSkill(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for missing skill")
+	}
+}
+
+func TestSkillRepair_ManagedWins(t *testing.T) {
+	seedSkillEnv(t)
+
+	home := os.Getenv("HOME")
+	canonical := filepath.Join(home, ".scribe", "skills", "commit")
+	codexPath := filepath.Join(home, ".codex", "skills", "commit")
+	if err := os.MkdirAll(codexPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexPath, "SKILL.md"), []byte("# commit\nlocal drift\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	skill := st.Installed["commit"]
+	skill.Tools = []string{"claude", "cursor", "codex"}
+	skill.ToolsMode = state.ToolsModePinned
+	skill.Conflicts = []state.ProjectionConflict{{Tool: "codex", Path: codexPath, FoundHash: "deadbeef", SeenAt: time.Now().UTC()}}
+	st.Installed["commit"] = skill
+	if err := st.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	cmd := newSkillRepairCommand()
+	cmd.SetArgs([]string{"commit", "--tool", "codex", "--from", "managed", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	resolved, err := filepath.EvalSymlinks(codexPath)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	canonical, _ = filepath.EvalSymlinks(canonical)
+	if resolved != canonical {
+		t.Fatalf("codex path resolves to %q, want %q", resolved, canonical)
+	}
+
+	st, err = state.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Installed["commit"].Conflicts) != 0 {
+		t.Fatalf("Conflicts = %v, want cleared", st.Installed["commit"].Conflicts)
+	}
+}
+
+func TestSkillRepair_ToolWins(t *testing.T) {
+	seedSkillEnv(t)
+
+	home := os.Getenv("HOME")
+	codexPath := filepath.Join(home, ".codex", "skills", "commit")
+	if err := os.MkdirAll(codexPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	toolContent := []byte("# commit\npromoted\n")
+	if err := os.WriteFile(filepath.Join(codexPath, "SKILL.md"), toolContent, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	skill := st.Installed["commit"]
+	skill.Tools = []string{"claude", "cursor", "codex"}
+	skill.ToolsMode = state.ToolsModePinned
+	skill.Conflicts = []state.ProjectionConflict{{Tool: "codex", Path: codexPath, FoundHash: "deadbeef", SeenAt: time.Now().UTC()}}
+	st.Installed["commit"] = skill
+	if err := st.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	cmd := newSkillRepairCommand()
+	cmd.SetArgs([]string{"commit", "--tool", "codex", "--from", "tool", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".scribe", "skills", "commit", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != string(toolContent) {
+		t.Fatalf("canonical SKILL.md = %q, want %q", string(data), string(toolContent))
 	}
 }

--- a/docs/superpowers/plans/2026-04-11-sync-system-reconcile.md
+++ b/docs/superpowers/plans/2026-04-11-sync-system-reconcile.md
@@ -1,0 +1,273 @@
+# Sync System Reconcile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `scribe sync` reconcile managed filesystem-backed tool projections, preserve divergent unmanaged copies, and expose a repair command for managed drift.
+
+**Architecture:** Add a dedicated reconcile pass driven by `state.Installed` and tool `SkillPath` inspection, then wire it into the sync workflow before and after registry reconciliation. Split desired tool intent from observed managed projections in state, surface conflicts through workflow formatter output and JSON, and add a focused `scribe skill repair` command for operator-driven resolution.
+
+**Tech Stack:** Go, Cobra, existing `internal/workflow`, `internal/state`, `internal/tools`, and `internal/sync` packages
+
+---
+
+### Task 1: Add state support for managed projections and reconcile residue
+
+**Files:**
+- Modify: `internal/state/state.go`
+- Modify: `internal/state/state_test.go`
+- Modify: `internal/state/testdata/state.json`
+
+- [ ] **Step 1: Write the failing state migration tests**
+
+```go
+func TestParseAndMigrateSeedsManagedPathsFromPaths(t *testing.T) {
+	raw := []byte(`{
+	  "schema_version": 4,
+	  "installed": {
+	    "recap": {
+	      "revision": 1,
+	      "installed_hash": "abc",
+	      "tools": ["codex"],
+	      "paths": ["/tmp/.codex/skills/recap"]
+	    }
+	  }
+	}`)
+
+	st, err := parseAndMigrate(raw)
+	if err != nil {
+		t.Fatalf("parseAndMigrate: %v", err)
+	}
+	got := st.Installed["recap"]
+	if diff := cmp.Diff(got.Paths, got.ManagedPaths); diff != "" {
+		t.Fatalf("managed paths mismatch (-want +got):\n%s", diff)
+	}
+}
+```
+
+- [ ] **Step 2: Run the state test to verify it fails**
+
+Run: `go test ./internal/state -run TestParseAndMigrateSeedsManagedPathsFromPaths`
+Expected: FAIL because `ManagedPaths` does not exist yet
+
+- [ ] **Step 3: Add the new state fields and migration behavior**
+
+```go
+type ProjectionConflict struct {
+	Tool      string    `json:"tool"`
+	Path      string    `json:"path"`
+	FoundHash string    `json:"found_hash"`
+	SeenAt    time.Time `json:"seen_at"`
+}
+
+type InstalledSkill struct {
+	// ...
+	Paths               []string             `json:"paths"`
+	ManagedPaths        []string             `json:"managed_paths,omitempty"`
+	ProjectionConflicts []ProjectionConflict `json:"projection_conflicts,omitempty"`
+}
+```
+
+- [ ] **Step 4: Run the state package tests**
+
+Run: `go test ./internal/state`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/state/state.go internal/state/state_test.go internal/state/testdata/state.json
+git commit -m "feat: track managed skill projections"
+```
+
+### Task 2: Add reconcile engine coverage and events
+
+**Files:**
+- Create: `internal/reconcile/reconcile.go`
+- Create: `internal/reconcile/reconcile_test.go`
+- Modify: `internal/tools/tool.go`
+- Modify: `internal/sync/events.go`
+
+- [ ] **Step 1: Write failing reconcile tests for missing, same-hash, divergent, and stale paths**
+
+```go
+func TestReconcileRepairsMissingCodexProjection(t *testing.T) {}
+func TestReconcileNormalizesSameHashDirectory(t *testing.T) {}
+func TestReconcilePreservesDivergentDirectoryAsConflict(t *testing.T) {}
+func TestReconcileRemovesStaleManagedProjection(t *testing.T) {}
+```
+
+- [ ] **Step 2: Run the reconcile tests to verify they fail**
+
+Run: `go test ./internal/reconcile -run TestReconcile`
+Expected: FAIL because the package and reconcile types do not exist yet
+
+- [ ] **Step 3: Implement inspectable filesystem-backed tool behavior and reconcile results**
+
+```go
+type Tool interface {
+	Name() string
+	Install(skillName, canonicalDir string) ([]string, error)
+	Uninstall(skillName string) error
+	Detect() bool
+	SkillPath(skillName string) (string, error)
+	SupportsProjectionInspect() bool
+}
+```
+
+```go
+type ActionKind string
+
+const (
+	ActionInstalled ActionKind = "installed"
+	ActionRelinked  ActionKind = "relinked"
+	ActionRemoved   ActionKind = "removed"
+	ActionConflict  ActionKind = "conflict"
+	ActionUnchanged ActionKind = "unchanged"
+)
+```
+
+- [ ] **Step 4: Run reconcile and tool tests**
+
+Run: `go test ./internal/reconcile ./internal/tools`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/reconcile/reconcile.go internal/reconcile/reconcile_test.go internal/tools/tool.go internal/sync/events.go
+git commit -m "feat: add sync projection reconcile engine"
+```
+
+### Task 3: Wire reconcile into sync workflow and output
+
+**Files:**
+- Modify: `internal/workflow/sync.go`
+- Modify: `internal/workflow/formatter.go`
+- Modify: `internal/workflow/formatter_text.go`
+- Modify: `internal/workflow/formatter_json.go`
+- Modify: `internal/workflow/sync_test.go`
+- Modify: `internal/workflow/sync_adopt_test.go`
+- Modify: `internal/workflow/formatter_test.go`
+
+- [ ] **Step 1: Write failing workflow tests for ordering and summary output**
+
+```go
+func TestSyncStepsIncludeReconcileBeforeAndAfterRegistrySync(t *testing.T) {}
+func TestJSONFormatterIncludesReconcileSummaryAndConflicts(t *testing.T) {}
+func TestTextFormatterPrintsRepairAndConflictSummary(t *testing.T) {}
+```
+
+- [ ] **Step 2: Run the workflow tests to verify they fail**
+
+Run: `go test ./internal/workflow -run 'TestSyncStepsIncludeReconcileBeforeAndAfterRegistrySync|TestJSONFormatterIncludesReconcileSummaryAndConflicts|TestTextFormatterPrintsRepairAndConflictSummary'`
+Expected: FAIL because reconcile phases and formatter methods are missing
+
+- [ ] **Step 3: Implement reconcile workflow steps before and after registry sync**
+
+```go
+return []Step{
+	{"LoadConfig", StepLoadConfig},
+	{"LoadState", StepLoadState},
+	{"CheckConnected", StepCheckConnected},
+	{"FilterRegistries", StepFilterRegistries},
+	{"ResolveFormatter", StepResolveFormatter},
+	{"ResolveTools", StepResolveTools},
+	{"Adopt", StepAdopt},
+	{"ReconcileSystem", StepReconcileSystem},
+	{"SyncSkills", StepSyncSkills},
+	{"ReconcileSystem", StepReconcileSystem},
+}
+```
+
+- [ ] **Step 4: Run the workflow test package**
+
+Run: `go test ./internal/workflow`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/workflow/sync.go internal/workflow/formatter.go internal/workflow/formatter_text.go internal/workflow/formatter_json.go internal/workflow/sync_test.go internal/workflow/sync_adopt_test.go internal/workflow/formatter_test.go
+git commit -m "feat: run projection reconcile during sync"
+```
+
+### Task 4: Add managed drift repair and safe remove cleanup
+
+**Files:**
+- Modify: `cmd/skill.go`
+- Modify: `cmd/skill_test.go`
+- Modify: `cmd/remove.go`
+- Modify: `cmd/remove_test.go`
+
+- [ ] **Step 1: Write failing command tests for `scribe skill repair` and conflict-safe remove**
+
+```go
+func TestSkillRepairCanonicalWins(t *testing.T) {}
+func TestSkillRepairPromotesToolCopyToCanonical(t *testing.T) {}
+func TestRemoveLeavesProjectionConflictResidue(t *testing.T) {}
+```
+
+- [ ] **Step 2: Run the command tests to verify they fail**
+
+Run: `go test ./cmd -run 'TestSkillRepairCanonicalWins|TestSkillRepairPromotesToolCopyToCanonical|TestRemoveLeavesProjectionConflictResidue'`
+Expected: FAIL because the subcommand and cleanup rules do not exist yet
+
+- [ ] **Step 3: Implement the repair subcommand and remove cleanup updates**
+
+```go
+cmd.AddCommand(newSkillEditCommand(), newSkillRepairCommand())
+```
+
+```go
+for _, p := range installed.ManagedPaths {
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Sprintf("managed path %s: %v", p, err))
+	}
+}
+```
+
+- [ ] **Step 4: Run the command package tests**
+
+Run: `go test ./cmd`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/skill.go cmd/skill_test.go cmd/remove.go cmd/remove_test.go
+git commit -m "feat: add managed skill repair flow"
+```
+
+### Task 5: Final verification and branch handoff
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/superpowers/specs/2026-04-11-sync-system-reconcile-design.md` (only if implementation requires clarifying notes)
+
+- [ ] **Step 1: Update docs for the new sync meaning and repair command**
+
+```md
+`scribe sync` keeps connected registries, local skills, and installed filesystem-backed tool projections in sync.
+```
+
+- [ ] **Step 2: Run focused verification**
+
+Run: `go test ./internal/state ./internal/reconcile ./internal/workflow ./cmd`
+Expected: PASS
+
+- [ ] **Step 3: Run full verification**
+
+Run: `go test ./...`
+Expected: PASS, or the same pre-existing `internal/logo` failures observed at baseline and no new failures in sync/state/command packages
+
+- [ ] **Step 4: Inspect git diff and prepare PR**
+
+Run: `git status --short && git diff --stat`
+Expected: only intended reconcile-related changes
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md docs/superpowers/specs/2026-04-11-sync-system-reconcile-design.md docs/superpowers/plans/2026-04-11-sync-system-reconcile.md
+git commit -m "docs: describe sync system reconcile flow"
+```

--- a/docs/superpowers/specs/2026-04-11-sync-system-reconcile-design.md
+++ b/docs/superpowers/specs/2026-04-11-sync-system-reconcile-design.md
@@ -17,6 +17,7 @@ This closes the current gap where Scribe manages a skill in `~/.scribe/skills/<n
 3. Detect duplicate or drifted unmanaged copies in tool directories during normal sync
 4. Preserve user data by refusing to auto-overwrite divergent unmanaged content
 5. Ensure Codex-visible installed skills actually appear under `~/.codex/skills/`
+6. Preserve per-skill tool intent while still repairing tool-facing projections
 
 ## Non-Goals
 
@@ -24,6 +25,7 @@ This closes the current gap where Scribe manages a skill in `~/.scribe/skills/<n
 - Three-way merge across multiple unmanaged tool copies
 - Background or daemon-based reconciliation outside explicit `scribe sync`
 - Reworking package install behavior in this pass
+- Full drift inspection for non-filesystem-backed tool integrations in v1
 
 ---
 
@@ -78,9 +80,9 @@ The preferred order is:
 
 1. resolve active tools
 2. adoption scan/import for unmanaged skills
-3. local system reconcile for all state-managed skills
+3. local system reconcile for all filesystem-backed, state-managed skills
 4. upstream registry sync/update
-5. final local system reconcile for any newly installed or tool-changed skills
+5. final local system reconcile for any newly installed or tool-changed filesystem-backed skills
 
 The second reconcile pass matters because registry sync may install new skills, change effective tools, or refresh canonical content. Ending with reconcile ensures the machine is correct after all mutations, not just midway through the run.
 
@@ -88,16 +90,18 @@ The second reconcile pass matters because registry sync may install new skills, 
 
 Introduce a reconcile engine driven from `state.Installed`.
 
+V1 reconcile applies only to tools with inspectable filesystem projections, such as Claude, Cursor, and Codex. Tools like Gemini that are managed through an external CLI and do not expose a stable `SkillPath` are out of scope for drift inspection in this pass. They still participate in normal install/uninstall flows, but not in path healing or hash-based conflict detection.
+
 For each installed skill:
 
-1. Resolve its effective target tools from `InstalledSkill.Tools`, `ToolsMode`, config tool enablement, and tool availability
+1. Resolve its desired target tools from `InstalledSkill.Tools`, `ToolsMode`, config tool enablement, and tool availability
 2. Compute the expected canonical dir: `~/.scribe/skills/<name>/`
 3. For each expected tool path:
    - if missing: install the symlink or link projection
    - if already points to canonical content: no-op
    - if it is a same-hash real copy: replace with the canonical link
    - if it is different content: emit a reconcile conflict and leave it untouched
-4. For each recorded-but-no-longer-expected tool path:
+4. For each previously managed filesystem projection that is no longer expected:
    - uninstall it unless doing so would remove divergent unmanaged content not created by Scribe
 
 The default posture is:
@@ -146,10 +150,29 @@ TTY output should stay compact:
 
 ```text
 conflict: recap in codex differs from managed copy
-run `scribe adopt recap` to inspect/resolve
+run `scribe skill repair recap --tool codex` to resolve
 ```
 
 `--verbose` and `--json` can include hashes and paths.
+
+### Conflict resolution command
+
+Managed-skill drift should not be resolved through `scribe adopt`. `adopt` is for unmanaged skill intake.
+
+Add a dedicated repair path for already-managed skills:
+
+```bash
+scribe skill repair <name> --tool <tool>
+```
+
+Initial behavior can stay narrow and explicit:
+
+- inspect the conflict
+- choose whether the canonical store wins or the tool-local copy wins
+- if canonical wins: replace the divergent projection with the canonical link
+- if tool-local wins: promote the tool-local copy into the canonical store, snapshotting current canonical content first
+
+This gives managed drift an operator-facing home without overloading `adopt`.
 
 ## 6. Codex Installation And Autocomplete
 
@@ -169,6 +192,7 @@ Result:
 
 - `sync` is the automatic system reconciler
 - `adopt` is the explicit intake and conflict-resolution command for unmanaged skills
+- `skill repair` is the explicit repair command for managed-skill drift
 
 That means:
 - `sync` should still run the adoption scan
@@ -179,7 +203,7 @@ In other words: `adopt` becomes a focused maintenance command, not a prerequisit
 
 ## 8. State And API Changes
 
-This design does not require a new ownership model, but it does require explicit reconcile data structures and events.
+This design does not require a new ownership model, but it does require explicit reconcile data structures, a clean split between intent and projection, and new workflow events.
 
 ### New reconcile result types
 
@@ -209,11 +233,54 @@ type SkillConflict struct {
 
 These should be emitted as workflow events so the existing formatter layer can keep UI concerns out of core logic.
 
+### State model split
+
+`InstalledSkill.Tools` must remain desired intent, not observed output.
+
+That means:
+
+- `Tools` continues to represent the tools the skill should be installed into
+- `ToolsMode` continues to control whether that intent is inherited or pinned
+- reconcile must not rewrite `Tools` based on temporary tool absence, inspection gaps, or unresolved conflicts
+
+Observed projections need separate tracking. Add a new field:
+
+```go
+type InstalledSkill struct {
+    // existing fields
+    Paths []string `json:"paths"`
+
+    // New: filesystem-backed paths Scribe currently believes it created and manages.
+    ManagedPaths []string `json:"managed_paths,omitempty"`
+}
+```
+
+`Paths` should remain for backward compatibility during transition, but implementation should converge on `ManagedPaths` as the projection ledger used by reconcile and remove.
+
 ### State updates
 
-When reconcile heals installs, `state.Installed[name].Paths` and `Tools` should be refreshed to reflect the actual installed projections. This keeps later uninstall and display behavior correct.
+When reconcile heals installs, it should refresh `ManagedPaths` to reflect the actual filesystem-backed projections Scribe currently manages. It must not rewrite `Tools`.
 
-No new persisted field is required for v1 of reconcile if the effective tool set can still be derived from existing `Tools`, `ToolsMode`, and config.
+For unresolved divergent paths that Scribe intentionally leaves in place, do not record them as managed projections. They are conflict residue, not healthy installs.
+
+### Conflict residue
+
+Preserved divergent paths need explicit state so the user is not trapped in an unexplained recurring warning. Add lightweight conflict tracking:
+
+```go
+type ProjectionConflict struct {
+    Tool      string    `json:"tool"`
+    Path      string    `json:"path"`
+    FoundHash string    `json:"found_hash"`
+    SeenAt    time.Time `json:"seen_at"`
+}
+```
+
+Store these per skill as unresolved reconcile conflicts. They are:
+
+- shown in `scribe list` and `scribe sync --json`
+- cleared when the path is removed, normalized, or repaired via `scribe skill repair`
+- ignored by `scribe remove` cleanup except for a warning telling the user the divergent path was intentionally left alone
 
 ## 9. Algorithm Sketch
 
@@ -222,8 +289,9 @@ No new persisted field is required for v1 of reconcile if the effective tool set
 For each `InstalledSkill`:
 
 1. Resolve effective tools using existing tool-resolution logic
-2. Build `expectedTools[name]`
-3. Skip package skills for now or leave them to package-specific logic
+2. Filter to filesystem-backed tools that expose a stable `SkillPath`
+3. Build `expectedTools[name]`
+4. Skip package skills for now or leave them to package-specific logic
 
 ### Inspect current tool paths
 
@@ -249,11 +317,24 @@ For each expected tool:
 
 ### Remove stale installs
 
-For tool paths recorded in state but not in the effective tool set:
+For tool paths recorded in `ManagedPaths` but not in the effective tool set:
 - if path is the expected canonical projection, uninstall it
-- if path now contains divergent content, leave it and emit a warning/conflict rather than deleting user material
+- if path now contains divergent content, leave it and record a projection conflict rather than deleting user material
 
-## 10. Output Design
+## 10. Remove And Cleanup Semantics
+
+`scribe remove` currently uninstalls via tool hooks and then deletes `installed.Paths`. With reconcile, cleanup must distinguish between Scribe-managed projections and preserved divergent residue.
+
+New rule:
+
+- remove tool-managed projections from `ManagedPaths`
+- remove canonical store content
+- clear state entry
+- if unresolved projection conflicts exist, warn that Scribe intentionally left divergent local content untouched and print the paths in `--verbose` or `--json`
+
+This prevents `remove` from accidentally deleting user-owned divergent content that sync preserved on purpose.
+
+## 11. Output Design
 
 Default sync output should stay terse.
 
@@ -275,7 +356,9 @@ If nothing needed repair, omit the line entirely. If only Codex links were recre
 - removed stale installs count
 - reconcile conflicts array
 
-## 11. Testing
+The default text output for a managed drift conflict should point to `scribe skill repair`, not `adopt`.
+
+## 12. Testing
 
 Add table-driven tests covering:
 
@@ -286,32 +369,48 @@ Add table-driven tests covering:
 5. disabled or unavailable tool is not force-installed
 6. stale tool path is removed when no longer expected
 7. stale tool path with divergent content is preserved and reported
+8. pinned `Tools` intent survives a reconcile run even when a tool is temporarily unavailable
+9. non-filesystem-backed tools are skipped by drift inspection without corrupting state
+10. `remove` only deletes `ManagedPaths`, not preserved conflict residue
 
 Workflow tests should verify ordering:
 - adoption scan before registry sync
 - system reconcile after adoption
 - final reconcile after registry install/update
 
-## 12. Migration And Rollout
+## 13. Migration And Rollout
 
-This should ship without state migration.
+This requires a small state migration if `ManagedPaths` and projection conflict tracking are added.
 
 Existing users benefit automatically on next `scribe sync`:
 - missing `~/.codex/skills/*` links are recreated
 - same-hash duplicates are normalized
 - divergent copies are surfaced as conflicts instead of silently ignored
 
-No new command is required. Documentation should update `scribe sync` to mean:
+Migration rule:
+
+- seed `ManagedPaths` from existing `Paths`
+- leave `Tools` unchanged
+- initialize projection conflicts empty
+
+Documentation should update `scribe sync` to mean:
 
 > Keep connected registries, local skills, and installed tool projections in sync.
 
-## 13. Open Questions Deferred
+`scribe skill repair` is new, but it is required to make managed-drift conflicts actionable.
+
+Package note:
+
+- this pass does not make package installs fully drift-healable
+- docs must say that the machine-health guarantee is complete for filesystem-backed skill projections and best-effort for package-backed or external-CLI-managed installs
+
+## 14. Open Questions Deferred
 
 These are intentionally out of scope for this pass:
 
 1. conflict-resolution flags such as `scribe sync --prefer-managed`
 2. auto-merge between canonical and divergent unmanaged tool copies
-3. a dedicated `scribe doctor` or `scribe repair` command
+3. a broader `scribe doctor` command beyond the narrowly scoped `scribe skill repair`
 4. package reconcile behavior for tools that do not use per-skill symlinks
 
 The design should leave room for a future explicit conflict-resolution workflow, but default sync behavior should already satisfy the north star: one command that keeps the machine healthy without surprising data loss.

--- a/docs/superpowers/specs/2026-04-11-sync-system-reconcile-design.md
+++ b/docs/superpowers/specs/2026-04-11-sync-system-reconcile-design.md
@@ -1,0 +1,317 @@
+# Sync As System Reconcile
+
+**Date:** 2026-04-11
+**Status:** Draft
+**Builds on:** 2026-04-10-storage-and-list-tui-design.md
+
+## Summary
+
+Reposition `scribe sync` from "sync connected registries" to "keep the machine in sync." `sync` should reconcile registry-backed skills, adopted local skills, and tool-facing installs into one consistent local system state.
+
+This closes the current gap where Scribe manages a skill in `~/.scribe/skills/<name>/` but does not heal missing or drifted tool installs unless the user explicitly runs `scribe adopt` again. It also fixes Codex autocomplete drift by making `~/.codex/skills/<name>` part of normal sync reconciliation rather than a best-effort side effect of the original install.
+
+## Goals
+
+1. Make `scribe sync` the one command users run to restore a healthy machine state
+2. Heal missing per-tool skill installs for both registry and adopted skills
+3. Detect duplicate or drifted unmanaged copies in tool directories during normal sync
+4. Preserve user data by refusing to auto-overwrite divergent unmanaged content
+5. Ensure Codex-visible installed skills actually appear under `~/.codex/skills/`
+
+## Non-Goals
+
+- Auto-merging divergent tool-local skill copies into the canonical store
+- Three-way merge across multiple unmanaged tool copies
+- Background or daemon-based reconciliation outside explicit `scribe sync`
+- Reworking package install behavior in this pass
+
+---
+
+## 1. Product Positioning
+
+`scribe sync` becomes the machine-health command.
+
+Today, users need to understand several separate concepts:
+- registry sync updates managed skills
+- adopt claims unmanaged skills
+- restore rewinds canonical content
+- missing tool symlinks may require manual repair
+
+That is the wrong mental model. The correct product behavior is: if Scribe believes a skill should exist on this machine, `scribe sync` should make that true everywhere Scribe manages, unless doing so would destroy user-authored divergent content. In that case, `sync` should stop short, preserve the content, and clearly report the conflict.
+
+This aligns with the repo north star in `CLAUDE.md`:
+- convenience first
+- one command that fixes the machine
+- minimal output, but high-signal next actions when intervention is required
+
+## 2. Canonical State Model
+
+The canonical source of truth remains:
+
+1. `~/.scribe/skills/<name>/` for skill content
+2. `state.Installed[name]` for ownership, origin, tools, hashes, and upstream metadata
+
+Tool-facing paths such as `~/.claude/skills/<name>` and `~/.codex/skills/<name>` are derived state. They must be treated as reconcilable projections of the canonical store, not as independent authorities.
+
+Implications:
+
+- Missing tool links are repairable drift, not a user problem
+- Same-content unmanaged duplicates are normalization opportunities, not conflicts
+- Different-content unmanaged duplicates are conflicts because they compete with the canonical projection
+
+## 3. New Sync Responsibility
+
+`scribe sync` should run three phases:
+
+1. **Adoption scan**
+   Detect unmanaged skills that are not yet in Scribe state and offer or auto-adopt them according to `adoption.mode`
+2. **System reconcile**
+   For every installed skill already tracked in state, ensure tool-facing installs match the expected projection from state
+3. **Registry reconcile**
+   Pull upstream registry changes into the canonical store using the existing sync/update logic
+
+This is a change in emphasis, not in user-facing command count. The user still runs `scribe sync`, but it now means "make my system correct."
+
+### Ordering
+
+The preferred order is:
+
+1. resolve active tools
+2. adoption scan/import for unmanaged skills
+3. local system reconcile for all state-managed skills
+4. upstream registry sync/update
+5. final local system reconcile for any newly installed or tool-changed skills
+
+The second reconcile pass matters because registry sync may install new skills, change effective tools, or refresh canonical content. Ending with reconcile ensures the machine is correct after all mutations, not just midway through the run.
+
+## 4. Reconcile Semantics
+
+Introduce a reconcile engine driven from `state.Installed`.
+
+For each installed skill:
+
+1. Resolve its effective target tools from `InstalledSkill.Tools`, `ToolsMode`, config tool enablement, and tool availability
+2. Compute the expected canonical dir: `~/.scribe/skills/<name>/`
+3. For each expected tool path:
+   - if missing: install the symlink or link projection
+   - if already points to canonical content: no-op
+   - if it is a same-hash real copy: replace with the canonical link
+   - if it is different content: emit a reconcile conflict and leave it untouched
+4. For each recorded-but-no-longer-expected tool path:
+   - uninstall it unless doing so would remove divergent unmanaged content not created by Scribe
+
+The default posture is:
+- heal silently when safe
+- never overwrite divergent content silently
+
+### Same-Hash Normalization
+
+If a tool path contains a real directory or file whose effective skill hash matches the canonical store, it is not a meaningful fork. Reconcile should remove it and reinstall the proper symlink.
+
+This covers:
+- a user copying a skill directory into `~/.codex/skills`
+- a broken symlink replaced by a real directory with the same content
+- tools that temporarily materialized a real copy during manual edits and then drifted back to canonical content
+
+### Divergent Conflict
+
+If a tool path for a Scribe-managed skill exists with different content from the canonical store, reconcile should emit a conflict and preserve the path unchanged.
+
+Default sync must not choose winners automatically. The canonical store may be right, or the unmanaged copy may be a user’s unrecorded customization. Overwriting it would violate the local-first trust model.
+
+## 5. Conflict Model
+
+There are now two conflict classes during `sync`:
+
+### A. Adoption conflicts
+
+An unmanaged skill name collides with an existing state entry during the adoption scan. This already exists today and remains unchanged in spirit:
+- same hash: treat as re-link/normalize
+- different hash: report conflict
+
+### B. Reconcile conflicts
+
+A skill already tracked in state encounters divergent content in an expected tool path. This is new.
+
+The conflict payload should include:
+- skill name
+- tool name
+- expected canonical path
+- found path
+- canonical hash
+- found hash
+- whether the found content is a symlink, file, or directory
+
+TTY output should stay compact:
+
+```text
+conflict: recap in codex differs from managed copy
+run `scribe adopt recap` to inspect/resolve
+```
+
+`--verbose` and `--json` can include hashes and paths.
+
+## 6. Codex Installation And Autocomplete
+
+Codex skill autocomplete should be treated as a direct outcome of reconciliation, not a separate install concern.
+
+Codex’s installed-skill path is `~/.codex/skills/<name>`. If a skill is expected to be installed to Codex, `sync` must guarantee that path exists and resolves to the canonical store.
+
+This explicitly does **not** treat `~/.codex/superpowers/skills/` as an installed-skill location. That path can contain source material or sidecar assets, but it is not what Codex indexes for skill discovery. Skills only count as installed for Codex if they reconcile into `~/.codex/skills/`.
+
+Result:
+- if a superpowers skill is state-managed and Codex is an effective tool target, `sync` will recreate the missing `~/.codex/skills/<name>` link
+- if a different real directory appears at that path, `sync` will report a conflict instead of silently hiding the issue
+
+## 7. Relationship Between `adopt` And `sync`
+
+`scribe adopt` remains useful, but its role narrows:
+
+- `sync` is the automatic system reconciler
+- `adopt` is the explicit intake and conflict-resolution command for unmanaged skills
+
+That means:
+- `sync` should still run the adoption scan
+- `adopt` should remain the best place to inspect, preview, and resolve unmanaged-skill conflicts intentionally
+- drift detection for already-managed skills must no longer depend on the user remembering to run `adopt`
+
+In other words: `adopt` becomes a focused maintenance command, not a prerequisite for system health.
+
+## 8. State And API Changes
+
+This design does not require a new ownership model, but it does require explicit reconcile data structures and events.
+
+### New reconcile result types
+
+Add a small reconcile package or sync submodule with concepts like:
+
+```go
+type ActionKind string
+
+const (
+    ActionInstalled   ActionKind = "installed"
+    ActionRelinked    ActionKind = "relinked"
+    ActionRemoved     ActionKind = "removed"
+    ActionConflict    ActionKind = "conflict"
+    ActionUnchanged   ActionKind = "unchanged"
+)
+
+type SkillConflict struct {
+    Name          string
+    Tool          string
+    ExpectedPath  string
+    FoundPath     string
+    CanonicalHash string
+    FoundHash     string
+    FoundType     string
+}
+```
+
+These should be emitted as workflow events so the existing formatter layer can keep UI concerns out of core logic.
+
+### State updates
+
+When reconcile heals installs, `state.Installed[name].Paths` and `Tools` should be refreshed to reflect the actual installed projections. This keeps later uninstall and display behavior correct.
+
+No new persisted field is required for v1 of reconcile if the effective tool set can still be derived from existing `Tools`, `ToolsMode`, and config.
+
+## 9. Algorithm Sketch
+
+### Reconcile expected tools
+
+For each `InstalledSkill`:
+
+1. Resolve effective tools using existing tool-resolution logic
+2. Build `expectedTools[name]`
+3. Skip package skills for now or leave them to package-specific logic
+
+### Inspect current tool paths
+
+For each expected tool:
+
+1. Ask the tool for `SkillPath(name)`
+2. Inspect the path:
+   - nonexistent
+   - symlink to canonical
+   - symlink elsewhere
+   - file
+   - directory
+3. Resolve effective content hash where possible:
+   - use `SKILL.md` hash for directories
+   - if path resolves directly to `SKILL.md`, hash that file
+
+### Apply safe repairs
+
+- nonexistent -> `tool.Install`
+- symlink elsewhere but same canonical hash -> remove and `tool.Install`
+- file/dir same hash -> remove and `tool.Install`
+- different hash -> conflict event, no write
+
+### Remove stale installs
+
+For tool paths recorded in state but not in the effective tool set:
+- if path is the expected canonical projection, uninstall it
+- if path now contains divergent content, leave it and emit a warning/conflict rather than deleting user material
+
+## 10. Output Design
+
+Default sync output should stay terse.
+
+Good default summary:
+
+```text
+syncing system...
+  repaired 3 tool installs
+  1 conflict skipped
+syncing registries...
+  17 skills up to date
+```
+
+If nothing needed repair, omit the line entirely. If only Codex links were recreated, do not call out Codex specifically unless `--verbose` is on. The user cares that the system is healthy, not which internal phase happened.
+
+`--json` should include:
+- repaired installs count
+- relinked installs count
+- removed stale installs count
+- reconcile conflicts array
+
+## 11. Testing
+
+Add table-driven tests covering:
+
+1. missing Codex skill path for a managed skill -> relinked on sync
+2. same-hash real directory in a tool path -> replaced with symlink
+3. different-hash real directory in a tool path -> conflict, no overwrite
+4. adopted local skill with `OriginLocal` still reconciles during sync
+5. disabled or unavailable tool is not force-installed
+6. stale tool path is removed when no longer expected
+7. stale tool path with divergent content is preserved and reported
+
+Workflow tests should verify ordering:
+- adoption scan before registry sync
+- system reconcile after adoption
+- final reconcile after registry install/update
+
+## 12. Migration And Rollout
+
+This should ship without state migration.
+
+Existing users benefit automatically on next `scribe sync`:
+- missing `~/.codex/skills/*` links are recreated
+- same-hash duplicates are normalized
+- divergent copies are surfaced as conflicts instead of silently ignored
+
+No new command is required. Documentation should update `scribe sync` to mean:
+
+> Keep connected registries, local skills, and installed tool projections in sync.
+
+## 13. Open Questions Deferred
+
+These are intentionally out of scope for this pass:
+
+1. conflict-resolution flags such as `scribe sync --prefer-managed`
+2. auto-merge between canonical and divergent unmanaged tool copies
+3. a dedicated `scribe doctor` or `scribe repair` command
+4. package reconcile behavior for tools that do not use per-skill symlinks
+
+The design should leave room for a future explicit conflict-resolution workflow, but default sync behavior should already satisfy the north star: one command that keeps the machine healthy without surprising data loss.

--- a/internal/adopt/adopt_test.go
+++ b/internal/adopt/adopt_test.go
@@ -81,6 +81,7 @@ func (m *mockTool) Uninstall(skillName string) error { return m.uninstallErr }
 func (m *mockTool) SkillPath(skillName string) (string, error) {
 	return filepath.Join(m.name, skillName), nil
 }
+func (m *mockTool) CanonicalTarget(_ string) (string, bool) { return "", false }
 
 // ---------------------------------------------------------------------------
 // TestFindCandidates

--- a/internal/firstrun/adoption_test.go
+++ b/internal/firstrun/adoption_test.go
@@ -22,11 +22,12 @@ type adoptMockTool struct {
 	name string
 }
 
-func (m *adoptMockTool) Name() string                            { return m.name }
-func (m *adoptMockTool) Detect() bool                           { return true }
-func (m *adoptMockTool) Install(_, _ string) ([]string, error)  { return nil, nil }
-func (m *adoptMockTool) Uninstall(_ string) error               { return nil }
-func (m *adoptMockTool) SkillPath(_ string) (string, error)    { return "", nil }
+func (m *adoptMockTool) Name() string                              { return m.name }
+func (m *adoptMockTool) Detect() bool                              { return true }
+func (m *adoptMockTool) Install(_, _ string) ([]string, error)     { return nil, nil }
+func (m *adoptMockTool) Uninstall(_ string) error                  { return nil }
+func (m *adoptMockTool) SkillPath(_ string) (string, error)        { return "", nil }
+func (m *adoptMockTool) CanonicalTarget(_ string) (string, bool)   { return "", false }
 
 var _ tools.Tool = (*adoptMockTool)(nil)
 

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"bytes"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -59,12 +60,10 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 	}
 
 	activeNames := make([]string, 0, len(e.Tools))
-	inspectable := make(map[string]tools.Tool, len(e.Tools))
+	byName := make(map[string]tools.Tool, len(e.Tools))
 	for _, tool := range e.Tools {
 		activeNames = append(activeNames, tool.Name())
-		if supportsProjectionInspect(tool) {
-			inspectable[tool.Name()] = tool
-		}
+		byName[tool.Name()] = tool
 	}
 
 	for name, skill := range st.Installed {
@@ -85,8 +84,12 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 		}
 
 		for _, toolName := range expectedTools {
-			tool, ok := inspectable[toolName]
+			tool, ok := byName[toolName]
 			if !ok {
+				continue
+			}
+			target, inspectable := tool.CanonicalTarget(canonicalDir)
+			if !inspectable {
 				continue
 			}
 			path, err := tool.SkillPath(name)
@@ -95,9 +98,8 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 			}
 			expectedPaths[path] = toolName
 
-			info, err := os.Lstat(path)
-			if err != nil {
-				if errorsIsNotExist(err) {
+			if _, err := os.Lstat(path); err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
 					links, installErr := tool.Install(name, canonicalDir)
 					if installErr != nil {
 						return summary, actions, fmt.Errorf("install %s/%s: %w", toolName, name, installErr)
@@ -112,18 +114,17 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 				return summary, actions, err
 			}
 
-			if pathPointsToCanonical(path, canonicalDir, toolName) {
+			if pathPointsToCanonical(path, target) {
 				newManaged[path] = true
 				actions = append(actions, Action{Kind: ActionUnchanged, Name: name, Tool: toolName, Path: path})
-				_ = info
 				continue
 			}
 
 			foundHash, hashErr := projectionHash(path)
 			if hashErr == nil {
-				wantHash, wantErr := canonicalProjectionHash(canonicalDir, toolName)
+				wantHash, wantErr := projectionHash(target)
 				if wantErr == nil && foundHash == wantHash {
-					if err := os.RemoveAll(path); err != nil && !errorsIsNotExist(err) {
+					if err := os.RemoveAll(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
 						return summary, actions, err
 					}
 					links, installErr := tool.Install(name, canonicalDir)
@@ -157,17 +158,23 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 			if path == "" {
 				continue
 			}
-			if pathPointsToCanonical(path, canonicalDir, inferToolName(path, inspectable, name)) {
-				if err := os.Remove(path); err != nil && !errorsIsNotExist(err) {
+			toolName := inferToolName(path, byName, name)
+			// A stale projection is safe to remove whenever it resolves
+			// back into the canonical store — that guarantees it was Scribe
+			// who put it there. Requiring a matching Tool in byName would
+			// miss the case where the tool has been globally disabled but
+			// its old projection still needs cleanup.
+			if isManagedProjection(path, canonicalDir) {
+				if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
 					return summary, actions, err
 				}
 				summary.Removed++
-				actions = append(actions, Action{Kind: ActionRemoved, Name: name, Path: path})
+				actions = append(actions, Action{Kind: ActionRemoved, Name: name, Tool: toolName, Path: path})
 				continue
 			}
 			foundHash, _ := projectionHash(path)
 			conflict := state.ProjectionConflict{
-				Tool:      inferToolName(path, inspectable, name),
+				Tool:      toolName,
 				Path:      path,
 				FoundHash: foundHash,
 				SeenAt:    now(),
@@ -183,21 +190,16 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 		}
 		sort.Strings(managedPaths)
 		skill.ManagedPaths = managedPaths
+		// Paths is clobbered on every reconcile pass because reconcile is the
+		// source of truth for what projections Scribe currently manages. Any
+		// entries in the previous Paths that are still valid are re-added via
+		// newManaged above; anything missing is legitimately gone.
 		skill.Paths = append([]string(nil), managedPaths...)
 		skill.Conflicts = conflicts
 		st.Installed[name] = skill
 	}
 
 	return summary, actions, nil
-}
-
-func supportsProjectionInspect(tool tools.Tool) bool {
-	switch tool.Name() {
-	case "claude", "cursor", "codex":
-		return true
-	default:
-		return false
-	}
 }
 
 func projectionPaths(skill state.InstalledSkill) []string {
@@ -207,8 +209,8 @@ func projectionPaths(skill state.InstalledSkill) []string {
 	return append([]string(nil), skill.Paths...)
 }
 
-func inferToolName(path string, inspectable map[string]tools.Tool, skillName string) string {
-	for name, tool := range inspectable {
+func inferToolName(path string, byName map[string]tools.Tool, skillName string) string {
+	for name, tool := range byName {
 		toolPath, err := tool.SkillPath(skillName)
 		if err == nil && toolPath == path {
 			return name
@@ -217,66 +219,56 @@ func inferToolName(path string, inspectable map[string]tools.Tool, skillName str
 	return ""
 }
 
-func pathPointsToCanonical(path, canonicalDir, toolName string) bool {
+// pathPointsToCanonical reports whether path already resolves to the canonical
+// target (by symlink, bind mount, or direct equality). Returning true means
+// reconcile can treat the projection as managed and not touch it.
+func pathPointsToCanonical(path, target string) bool {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	targetResolved, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		targetResolved = target
+	}
+	return resolved == targetResolved
+}
+
+// isManagedProjection reports whether path resolves back into the skill's
+// canonical store directory. Used when cleaning up stale projections whose
+// owning tool may no longer be in the active set but whose link clearly
+// originated from Scribe.
+func isManagedProjection(path, canonicalDir string) bool {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		return false
 	}
 	canonicalResolved, err := filepath.EvalSymlinks(canonicalDir)
-	if err == nil && resolved == canonicalResolved {
+	if err != nil {
+		canonicalResolved = canonicalDir
+	}
+	if resolved == canonicalResolved {
 		return true
 	}
-	if err == nil && resolved == filepath.Join(canonicalResolved, "SKILL.md") {
-		return true
-	}
-	if err == nil && resolved == filepath.Join(canonicalResolved, ".cursor.mdc") {
-		return true
-	}
-	if toolName == "" {
-		return false
-	}
-	want, err := canonicalProjectionTarget(canonicalDir, toolName)
+	rel, err := filepath.Rel(canonicalResolved, resolved)
 	if err != nil {
 		return false
 	}
-	wantResolved, err := filepath.EvalSymlinks(want)
-	if err != nil {
-		wantResolved = want
-	}
-	return resolved == wantResolved
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
-func canonicalProjectionTarget(canonicalDir, toolName string) (string, error) {
-	switch toolName {
-	case "claude":
-		return filepath.Join(canonicalDir, "SKILL.md"), nil
-	case "cursor":
-		return filepath.Join(canonicalDir, ".cursor.mdc"), nil
-	case "codex":
-		return canonicalDir, nil
-	default:
-		return "", fmt.Errorf("tool %q has no inspectable projection target", toolName)
-	}
-}
-
-func canonicalProjectionHash(canonicalDir, toolName string) (string, error) {
-	target, err := canonicalProjectionTarget(canonicalDir, toolName)
-	if err != nil {
-		return "", err
-	}
-	return projectionHash(target)
-}
-
+// projectionHash returns a stable content hash for a projection target. Files
+// are hashed directly; directories are walked and a manifest-style hash
+// (relative path + contents) is computed so drift in any subfile is detected.
 func projectionHash(path string) (string, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return "", err
 	}
-	if info.IsDir() {
-		skillFile := filepath.Join(path, "SKILL.md")
-		return fileHash(skillFile)
+	if !info.IsDir() {
+		return fileHash(path)
 	}
-	return fileHash(path)
+	return treeHash(path)
 }
 
 func fileHash(path string) (string, error) {
@@ -287,6 +279,62 @@ func fileHash(path string) (string, error) {
 	data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
 	sum := sha256.Sum256(data)
 	return fmt.Sprintf("%x", sum[:])[:8], nil
+}
+
+// treeHash walks a directory and produces a hash that covers every regular
+// file's relative path, executable bit, and normalized content. This means a
+// drift buried in e.g. scripts/foo.sh is detected instead of silently
+// relinked away.
+func treeHash(root string) (string, error) {
+	h := sha256.New()
+	var entries []treeEntry
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// Skip Scribe internals that live alongside SKILL.md in the
+		// canonical store but are never part of a tool projection.
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		if rel == ".scribe-base.md" || rel == ".cursor.mdc" {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		entries = append(entries, treeEntry{rel: rel, mode: info.Mode().Perm(), path: path})
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].rel < entries[j].rel })
+	for _, e := range entries {
+		data, err := os.ReadFile(e.path)
+		if err != nil {
+			return "", err
+		}
+		data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+		fmt.Fprintf(h, "%s\x00%o\x00%d\x00", e.rel, e.mode, len(data))
+		h.Write(data)
+	}
+	sum := h.Sum(nil)
+	return fmt.Sprintf("%x", sum)[:8], nil
+}
+
+type treeEntry struct {
+	rel  string
+	mode os.FileMode
+	path string
 }
 
 func upsertConflict(conflicts []state.ProjectionConflict, next state.ProjectionConflict) []state.ProjectionConflict {
@@ -311,30 +359,38 @@ func conflictStillPresent(path, wantHash string) bool {
 	return err == nil && got == wantHash
 }
 
-func errorsIsNotExist(err error) bool {
-	return err != nil && (os.IsNotExist(err) || strings.Contains(err.Error(), fs.ErrNotExist.Error()))
-}
-
-func CopyProjectionToCanonical(path, toolName, canonicalDir string) error {
-	switch toolName {
-	case "codex":
+// CopyProjectionToCanonical promotes a tool's on-disk projection back into
+// the canonical store, used by `scribe skill repair --from tool`. The shape
+// is inferred from the tool's CanonicalTarget: if the target is a file,
+// promotion only succeeds when that file is canonicalDir/SKILL.md (Claude);
+// otherwise the projection is derived (e.g. Cursor's generated .cursor.mdc)
+// and promoting it would be overwritten on the next install. Directory
+// targets are copied wholesale.
+func CopyProjectionToCanonical(tool tools.Tool, path, canonicalDir string) error {
+	target, ok := tool.CanonicalTarget(canonicalDir)
+	if !ok {
+		return fmt.Errorf("tool %q cannot be promoted into canonical store", tool.Name())
+	}
+	// Directory projection → copy the whole tree.
+	if filepath.Clean(target) == filepath.Clean(canonicalDir) {
 		return copyDir(path, canonicalDir)
-	case "claude":
+	}
+	// Single-file projection → only SKILL.md is safe to promote.
+	if filepath.Base(target) == "SKILL.md" {
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
 		return tools.WriteCanonicalSkill(canonicalDir, data)
-	default:
-		return fmt.Errorf("tool %q cannot be promoted into canonical store", toolName)
 	}
+	return fmt.Errorf("tool %q projection is derived from canonical store and cannot be promoted back", tool.Name())
 }
 
 func copyDir(src, dst string) error {
 	if err := os.MkdirAll(dst, 0o755); err != nil {
 		return err
 	}
-	return filepath.Walk(src, func(path string, info fs.FileInfo, err error) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -346,14 +402,18 @@ func copyDir(src, dst string) error {
 			return nil
 		}
 		target := filepath.Join(dst, rel)
-		if info.IsDir() {
-			return os.MkdirAll(target, 0o755)
+		info, err := d.Info()
+		if err != nil {
+			return err
 		}
-		return copyFile(path, target)
+		if d.IsDir() {
+			return os.MkdirAll(target, info.Mode().Perm())
+		}
+		return copyFile(path, target, info.Mode().Perm())
 	})
 }
 
-func copyFile(src, dst string) error {
+func copyFile(src, dst string, mode os.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return err
 	}
@@ -362,7 +422,7 @@ func copyFile(src, dst string) error {
 		return err
 	}
 	defer in.Close()
-	out, err := os.Create(dst)
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1,0 +1,374 @@
+package reconcile
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+type ActionKind string
+
+const (
+	ActionInstalled ActionKind = "installed"
+	ActionRelinked  ActionKind = "relinked"
+	ActionRemoved   ActionKind = "removed"
+	ActionConflict  ActionKind = "conflict"
+	ActionUnchanged ActionKind = "unchanged"
+)
+
+type Action struct {
+	Kind ActionKind
+	Name string
+	Tool string
+	Path string
+}
+
+type Summary struct {
+	Installed int
+	Relinked  int
+	Removed   int
+	Conflicts []state.ProjectionConflict
+}
+
+type Engine struct {
+	Tools []tools.Tool
+	Now   func() time.Time
+}
+
+func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
+	var summary Summary
+	var actions []Action
+
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		return summary, nil, err
+	}
+	now := time.Now().UTC
+	if e.Now != nil {
+		now = e.Now
+	}
+
+	activeNames := make([]string, 0, len(e.Tools))
+	inspectable := make(map[string]tools.Tool, len(e.Tools))
+	for _, tool := range e.Tools {
+		activeNames = append(activeNames, tool.Name())
+		if supportsProjectionInspect(tool) {
+			inspectable[tool.Name()] = tool
+		}
+	}
+
+	for name, skill := range st.Installed {
+		if skill.Type == "package" {
+			continue
+		}
+
+		canonicalDir := filepath.Join(storeDir, name)
+		expectedTools := skill.EffectiveTools(activeNames)
+		expectedPaths := make(map[string]string, len(expectedTools))
+		newManaged := make(map[string]bool)
+		var conflicts []state.ProjectionConflict
+
+		for _, conflict := range skill.Conflicts {
+			if conflictStillPresent(conflict.Path, conflict.FoundHash) {
+				conflicts = append(conflicts, conflict)
+			}
+		}
+
+		for _, toolName := range expectedTools {
+			tool, ok := inspectable[toolName]
+			if !ok {
+				continue
+			}
+			path, err := tool.SkillPath(name)
+			if err != nil {
+				continue
+			}
+			expectedPaths[path] = toolName
+
+			info, err := os.Lstat(path)
+			if err != nil {
+				if errorsIsNotExist(err) {
+					links, installErr := tool.Install(name, canonicalDir)
+					if installErr != nil {
+						return summary, actions, fmt.Errorf("install %s/%s: %w", toolName, name, installErr)
+					}
+					for _, link := range links {
+						newManaged[link] = true
+					}
+					summary.Installed++
+					actions = append(actions, Action{Kind: ActionInstalled, Name: name, Tool: toolName, Path: path})
+					continue
+				}
+				return summary, actions, err
+			}
+
+			if pathPointsToCanonical(path, canonicalDir, toolName) {
+				newManaged[path] = true
+				actions = append(actions, Action{Kind: ActionUnchanged, Name: name, Tool: toolName, Path: path})
+				_ = info
+				continue
+			}
+
+			foundHash, hashErr := projectionHash(path)
+			if hashErr == nil {
+				wantHash, wantErr := canonicalProjectionHash(canonicalDir, toolName)
+				if wantErr == nil && foundHash == wantHash {
+					if err := os.RemoveAll(path); err != nil && !errorsIsNotExist(err) {
+						return summary, actions, err
+					}
+					links, installErr := tool.Install(name, canonicalDir)
+					if installErr != nil {
+						return summary, actions, fmt.Errorf("relink %s/%s: %w", toolName, name, installErr)
+					}
+					for _, link := range links {
+						newManaged[link] = true
+					}
+					summary.Relinked++
+					actions = append(actions, Action{Kind: ActionRelinked, Name: name, Tool: toolName, Path: path})
+					continue
+				}
+			}
+
+			conflict := state.ProjectionConflict{
+				Tool:      toolName,
+				Path:      path,
+				FoundHash: foundHash,
+				SeenAt:    now(),
+			}
+			conflicts = upsertConflict(conflicts, conflict)
+			summary.Conflicts = append(summary.Conflicts, conflict)
+			actions = append(actions, Action{Kind: ActionConflict, Name: name, Tool: toolName, Path: path})
+		}
+
+		for _, path := range projectionPaths(skill) {
+			if _, stillExpected := expectedPaths[path]; stillExpected {
+				continue
+			}
+			if path == "" {
+				continue
+			}
+			if pathPointsToCanonical(path, canonicalDir, inferToolName(path, inspectable, name)) {
+				if err := os.Remove(path); err != nil && !errorsIsNotExist(err) {
+					return summary, actions, err
+				}
+				summary.Removed++
+				actions = append(actions, Action{Kind: ActionRemoved, Name: name, Path: path})
+				continue
+			}
+			foundHash, _ := projectionHash(path)
+			conflict := state.ProjectionConflict{
+				Tool:      inferToolName(path, inspectable, name),
+				Path:      path,
+				FoundHash: foundHash,
+				SeenAt:    now(),
+			}
+			conflicts = upsertConflict(conflicts, conflict)
+			summary.Conflicts = append(summary.Conflicts, conflict)
+			actions = append(actions, Action{Kind: ActionConflict, Name: name, Tool: conflict.Tool, Path: path})
+		}
+
+		managedPaths := make([]string, 0, len(newManaged))
+		for path := range newManaged {
+			managedPaths = append(managedPaths, path)
+		}
+		sort.Strings(managedPaths)
+		skill.ManagedPaths = managedPaths
+		skill.Paths = append([]string(nil), managedPaths...)
+		skill.Conflicts = conflicts
+		st.Installed[name] = skill
+	}
+
+	return summary, actions, nil
+}
+
+func supportsProjectionInspect(tool tools.Tool) bool {
+	switch tool.Name() {
+	case "claude", "cursor", "codex":
+		return true
+	default:
+		return false
+	}
+}
+
+func projectionPaths(skill state.InstalledSkill) []string {
+	if len(skill.ManagedPaths) > 0 {
+		return append([]string(nil), skill.ManagedPaths...)
+	}
+	return append([]string(nil), skill.Paths...)
+}
+
+func inferToolName(path string, inspectable map[string]tools.Tool, skillName string) string {
+	for name, tool := range inspectable {
+		toolPath, err := tool.SkillPath(skillName)
+		if err == nil && toolPath == path {
+			return name
+		}
+	}
+	return ""
+}
+
+func pathPointsToCanonical(path, canonicalDir, toolName string) bool {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	canonicalResolved, err := filepath.EvalSymlinks(canonicalDir)
+	if err == nil && resolved == canonicalResolved {
+		return true
+	}
+	if err == nil && resolved == filepath.Join(canonicalResolved, "SKILL.md") {
+		return true
+	}
+	if err == nil && resolved == filepath.Join(canonicalResolved, ".cursor.mdc") {
+		return true
+	}
+	if toolName == "" {
+		return false
+	}
+	want, err := canonicalProjectionTarget(canonicalDir, toolName)
+	if err != nil {
+		return false
+	}
+	wantResolved, err := filepath.EvalSymlinks(want)
+	if err != nil {
+		wantResolved = want
+	}
+	return resolved == wantResolved
+}
+
+func canonicalProjectionTarget(canonicalDir, toolName string) (string, error) {
+	switch toolName {
+	case "claude":
+		return filepath.Join(canonicalDir, "SKILL.md"), nil
+	case "cursor":
+		return filepath.Join(canonicalDir, ".cursor.mdc"), nil
+	case "codex":
+		return canonicalDir, nil
+	default:
+		return "", fmt.Errorf("tool %q has no inspectable projection target", toolName)
+	}
+}
+
+func canonicalProjectionHash(canonicalDir, toolName string) (string, error) {
+	target, err := canonicalProjectionTarget(canonicalDir, toolName)
+	if err != nil {
+		return "", err
+	}
+	return projectionHash(target)
+}
+
+func projectionHash(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		skillFile := filepath.Join(path, "SKILL.md")
+		return fileHash(skillFile)
+	}
+	return fileHash(path)
+}
+
+func fileHash(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum[:])[:8], nil
+}
+
+func upsertConflict(conflicts []state.ProjectionConflict, next state.ProjectionConflict) []state.ProjectionConflict {
+	for i := range conflicts {
+		if conflicts[i].Tool == next.Tool && conflicts[i].Path == next.Path {
+			conflicts[i] = next
+			return conflicts
+		}
+	}
+	return append(conflicts, next)
+}
+
+func conflictStillPresent(path, wantHash string) bool {
+	if path == "" {
+		return false
+	}
+	if wantHash == "" {
+		_, err := os.Lstat(path)
+		return err == nil
+	}
+	got, err := projectionHash(path)
+	return err == nil && got == wantHash
+}
+
+func errorsIsNotExist(err error) bool {
+	return err != nil && (os.IsNotExist(err) || strings.Contains(err.Error(), fs.ErrNotExist.Error()))
+}
+
+func CopyProjectionToCanonical(path, toolName, canonicalDir string) error {
+	switch toolName {
+	case "codex":
+		return copyDir(path, canonicalDir)
+	case "claude":
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return tools.WriteCanonicalSkill(canonicalDir, data)
+	default:
+		return fmt.Errorf("tool %q cannot be promoted into canonical store", toolName)
+	}
+}
+
+func copyDir(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	return filepath.Walk(src, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -1,0 +1,150 @@
+package reconcile_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Naoray/scribe/internal/reconcile"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+func TestReconcileRepairsMissingCodexProjection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", os.Getenv("PATH"))
+
+	canonical, err := tools.WriteToStore("recap", []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}})
+	if err != nil {
+		t.Fatalf("WriteToStore: %v", err)
+	}
+	canonical, _ = filepath.EvalSymlinks(canonical)
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"recap": {Revision: 1, Tools: []string{"codex"}, ToolsMode: state.ToolsModePinned},
+	}}
+
+	engine := reconcile.Engine{Tools: []tools.Tool{tools.CodexTool{}}, Now: func() time.Time { return time.Unix(1, 0).UTC() }}
+	summary, _, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Installed != 1 {
+		t.Fatalf("Installed = %d, want 1", summary.Installed)
+	}
+
+	path := filepath.Join(home, ".codex", "skills", "recap")
+	if resolved, err := filepath.EvalSymlinks(path); err != nil || resolved != canonical {
+		t.Fatalf("codex skill link = %q, %v; want %q", resolved, err, canonical)
+	}
+	if len(st.Installed["recap"].ManagedPaths) != 1 || st.Installed["recap"].ManagedPaths[0] != path {
+		t.Fatalf("ManagedPaths = %v", st.Installed["recap"].ManagedPaths)
+	}
+}
+
+func TestReconcileNormalizesSameHashDirectory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	canonical, err := tools.WriteToStore("recap", []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\nsame\n")}})
+	if err != nil {
+		t.Fatalf("WriteToStore: %v", err)
+	}
+	canonical, _ = filepath.EvalSymlinks(canonical)
+	toolPath := filepath.Join(home, ".codex", "skills", "recap")
+	if err := os.MkdirAll(toolPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(toolPath, "SKILL.md"), []byte("# recap\nsame\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"recap": {Revision: 1, Tools: []string{"codex"}, ToolsMode: state.ToolsModePinned},
+	}}
+	engine := reconcile.Engine{Tools: []tools.Tool{tools.CodexTool{}}, Now: func() time.Time { return time.Unix(1, 0).UTC() }}
+	summary, _, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Relinked != 1 {
+		t.Fatalf("Relinked = %d, want 1", summary.Relinked)
+	}
+	if resolved, err := filepath.EvalSymlinks(toolPath); err != nil || resolved != canonical {
+		t.Fatalf("codex skill link = %q, %v; want %q", resolved, err, canonical)
+	}
+}
+
+func TestReconcilePreservesDivergentDirectoryAsConflict(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if _, err := tools.WriteToStore("recap", []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\ncanonical\n")}}); err != nil {
+		t.Fatalf("WriteToStore: %v", err)
+	}
+	toolPath := filepath.Join(home, ".codex", "skills", "recap")
+	if err := os.MkdirAll(toolPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(toolPath, "SKILL.md"), []byte("# recap\nlocal drift\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"recap": {Revision: 1, Tools: []string{"codex"}, ToolsMode: state.ToolsModePinned},
+	}}
+	engine := reconcile.Engine{Tools: []tools.Tool{tools.CodexTool{}}, Now: func() time.Time { return time.Unix(2, 0).UTC() }}
+	summary, _, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(summary.Conflicts) != 1 {
+		t.Fatalf("Conflicts = %d, want 1", len(summary.Conflicts))
+	}
+	if len(st.Installed["recap"].ManagedPaths) != 0 {
+		t.Fatalf("ManagedPaths = %v, want empty after divergent conflict", st.Installed["recap"].ManagedPaths)
+	}
+	info, err := os.Stat(toolPath)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("toolPath stat = %v, %v; want preserved directory", info, err)
+	}
+}
+
+func TestReconcileRemovesStaleManagedProjection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	canonical, err := tools.WriteToStore("recap", []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}})
+	if err != nil {
+		t.Fatalf("WriteToStore: %v", err)
+	}
+	toolPath := filepath.Join(home, ".codex", "skills", "recap")
+	if err := os.MkdirAll(filepath.Dir(toolPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(canonical, toolPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"recap": {
+			Revision:     1,
+			Tools:        []string{"codex"},
+			ToolsMode:    state.ToolsModePinned,
+			ManagedPaths: []string{toolPath},
+		},
+	}}
+	engine := reconcile.Engine{Tools: nil, Now: func() time.Time { return time.Unix(3, 0).UTC() }}
+	summary, _, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Removed != 1 {
+		t.Fatalf("Removed = %d, want 1", summary.Removed)
+	}
+	if _, err := os.Lstat(toolPath); !os.IsNotExist(err) {
+		t.Fatalf("toolPath still exists: %v", err)
+	}
+}

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -112,6 +112,46 @@ func TestReconcilePreservesDivergentDirectoryAsConflict(t *testing.T) {
 	}
 }
 
+func TestReconcileDetectsCodexSubfileDrift(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	files := []tools.SkillFile{
+		{Path: "SKILL.md", Content: []byte("# recap\ncanonical\n")},
+		{Path: "scripts/run.sh", Content: []byte("#!/bin/sh\necho canonical\n")},
+	}
+	if _, err := tools.WriteToStore("recap", files); err != nil {
+		t.Fatalf("WriteToStore: %v", err)
+	}
+	toolPath := filepath.Join(home, ".codex", "skills", "recap")
+	if err := os.MkdirAll(filepath.Join(toolPath, "scripts"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// Identical SKILL.md — old hash strategy would call these equal.
+	if err := os.WriteFile(filepath.Join(toolPath, "SKILL.md"), []byte("# recap\ncanonical\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile SKILL.md: %v", err)
+	}
+	// Drift buried in a subfile — must be caught by the tree hash.
+	if err := os.WriteFile(filepath.Join(toolPath, "scripts", "run.sh"), []byte("#!/bin/sh\necho drifted\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile scripts/run.sh: %v", err)
+	}
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"recap": {Revision: 1, Tools: []string{"codex"}, ToolsMode: state.ToolsModePinned},
+	}}
+	engine := reconcile.Engine{Tools: []tools.Tool{tools.CodexTool{}}, Now: func() time.Time { return time.Unix(4, 0).UTC() }}
+	summary, _, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Relinked != 0 {
+		t.Fatalf("Relinked = %d, want 0 — subfile drift must not be silently relinked", summary.Relinked)
+	}
+	if len(summary.Conflicts) != 1 {
+		t.Fatalf("Conflicts = %d, want 1 (subfile drift)", len(summary.Conflicts))
+	}
+}
+
 func TestReconcileRemovesStaleManagedProjection(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -49,14 +49,16 @@ const (
 
 // InstalledSkill records everything needed to detect updates and uninstall.
 type InstalledSkill struct {
-	Revision      int           `json:"revision"`
-	InstalledHash string        `json:"installed_hash"`
-	Sources       []SkillSource `json:"sources,omitempty"`
-	InstalledAt   time.Time     `json:"installed_at"`
-	Tools         []string      `json:"tools"`
-	ToolsMode     ToolsMode     `json:"tools_mode,omitempty"`
-	Paths         []string      `json:"paths"`
-	Origin        Origin        `json:"origin,omitempty"`
+	Revision      int                  `json:"revision"`
+	InstalledHash string               `json:"installed_hash"`
+	Sources       []SkillSource        `json:"sources,omitempty"`
+	InstalledAt   time.Time            `json:"installed_at"`
+	Tools         []string             `json:"tools"`
+	ToolsMode     ToolsMode            `json:"tools_mode,omitempty"`
+	Paths         []string             `json:"paths"`
+	ManagedPaths  []string             `json:"managed_paths,omitempty"`
+	Conflicts     []ProjectionConflict `json:"projection_conflicts,omitempty"`
+	Origin        Origin               `json:"origin,omitempty"`
 
 	// Package-specific fields (omitted for regular skills).
 	Type       string    `json:"type,omitempty"`
@@ -73,6 +75,15 @@ type SkillSource struct {
 	Ref        string    `json:"ref"`
 	LastSHA    string    `json:"last_sha"`
 	LastSynced time.Time `json:"last_synced"`
+}
+
+// ProjectionConflict records a divergent tool-facing projection that Scribe
+// intentionally preserved during reconcile.
+type ProjectionConflict struct {
+	Tool      string    `json:"tool"`
+	Path      string    `json:"path"`
+	FoundHash string    `json:"found_hash"`
+	SeenAt    time.Time `json:"seen_at"`
 }
 
 // Legacy structs for migration from older state formats.
@@ -293,6 +304,7 @@ func parseAndMigrate(data []byte) (*State, error) {
 		normalizeBranchSourceSHAs(s)
 		s.SchemaVersion = 4
 	}
+	seedManagedPaths(s)
 
 	return s, nil
 }
@@ -376,6 +388,7 @@ func legacyToSkill(ls legacyInstalledSkill) InstalledSkill {
 		Tools:         ls.Tools,
 		ToolsMode:     ls.ToolsMode,
 		Paths:         ls.Paths,
+		ManagedPaths:  append([]string(nil), ls.Paths...),
 		Origin:        ls.Origin,
 		Type:          ls.Type,
 		InstallCmd:    ls.InstallCmd,
@@ -429,6 +442,15 @@ func normalizeBranchSourceSHAs(s *State) {
 			changed = true
 		}
 		if changed {
+			s.Installed[name] = skill
+		}
+	}
+}
+
+func seedManagedPaths(s *State) {
+	for name, skill := range s.Installed {
+		if len(skill.ManagedPaths) == 0 && len(skill.Paths) > 0 {
+			skill.ManagedPaths = append([]string(nil), skill.Paths...)
 			s.Installed[name] = skill
 		}
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -449,6 +449,11 @@ func normalizeBranchSourceSHAs(s *State) {
 
 func seedManagedPaths(s *State) {
 	for name, skill := range s.Installed {
+		if skill.Type == "package" {
+			// Packages own their own install lifecycle and their Paths
+			// (if any) are command-output, not tool projections.
+			continue
+		}
 		if len(skill.ManagedPaths) == 0 && len(skill.Paths) > 0 {
 			skill.ManagedPaths = append([]string(nil), skill.Paths...)
 			s.Installed[name] = skill

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -865,6 +865,39 @@ func TestMigrationSchemaV4NormalizesBranchBlobSHA(t *testing.T) {
 	}
 }
 
+func TestMigrationSeedsManagedPathsFromPaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".scribe")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(`{
+		"schema_version": 4,
+		"installed": {
+			"recap": {
+				"revision": 1,
+				"installed_hash": "blob-1",
+				"tools": ["codex"],
+				"paths": ["/tmp/.codex/skills/recap"]
+			}
+		}
+	}`), 0o644); err != nil {
+		t.Fatalf("WriteFile state.json: %v", err)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	skill := st.Installed["recap"]
+	if len(skill.ManagedPaths) != 1 || skill.ManagedPaths[0] != "/tmp/.codex/skills/recap" {
+		t.Fatalf("ManagedPaths = %v, want paths copied from legacy Paths", skill.ManagedPaths)
+	}
+}
+
 // TestMigrationSchemaV4Idempotent verifies that a current-schema state passes
 // through unchanged.
 func TestMigrationSchemaV4Idempotent(t *testing.T) {

--- a/internal/sync/events.go
+++ b/internal/sync/events.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/reconcile"
 	"github.com/Naoray/scribe/internal/state"
 )
 
@@ -42,12 +43,12 @@ func (s Status) String() string {
 type SkillStatus struct {
 	Name       string
 	Status     Status
-	Installed  *state.InstalledSkill  // nil if not installed
-	Entry      *manifest.Entry        // catalog entry, nil for StatusExtra
-	LoadoutRef string                 // the ref from the manifest (e.g. "v1.0.0", "main")
+	Installed  *state.InstalledSkill // nil if not installed
+	Entry      *manifest.Entry       // catalog entry, nil for StatusExtra
+	LoadoutRef string                // the ref from the manifest (e.g. "v1.0.0", "main")
 	Maintainer string
 	IsPackage  bool
-	LatestSHA  string                 // resolved SHA for branch-pinned skills; empty if unavailable
+	LatestSHA  string // resolved SHA for branch-pinned skills; empty if unavailable
 }
 
 // DisplayVersion returns the best human-readable version for this skill.
@@ -139,6 +140,15 @@ type SyncCompleteMsg struct {
 	Updated   int
 	Skipped   int
 	Failed    int
+}
+
+type ReconcileConflictMsg struct {
+	Name     string
+	Conflict state.ProjectionConflict
+}
+
+type ReconcileCompleteMsg struct {
+	Summary reconcile.Summary
 }
 
 // LegacyFormatMsg is sent when a registry still uses scribe.toml (TOML format).

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -440,6 +440,7 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 				Tools:         toolNames,
 				ToolsMode:     toolsMode,
 				Paths:         paths,
+				ManagedPaths:  append([]string(nil), paths...),
 			})
 			// Save after each successful install — partial sync is safe.
 			if err := st.Save(); err != nil {

--- a/internal/tools/claude.go
+++ b/internal/tools/claude.go
@@ -68,6 +68,10 @@ func (t ClaudeTool) SkillPath(skillName string) (string, error) {
 	return filepath.Join(skillsDir, skillName), nil
 }
 
+func (t ClaudeTool) CanonicalTarget(canonicalDir string) (string, bool) {
+	return filepath.Join(canonicalDir, "SKILL.md"), true
+}
+
 func claudeSkillsDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/tools/codex.go
+++ b/internal/tools/codex.go
@@ -62,6 +62,10 @@ func (t CodexTool) SkillPath(skillName string) (string, error) {
 	return filepath.Join(skillsDir, skillName), nil
 }
 
+func (t CodexTool) CanonicalTarget(canonicalDir string) (string, bool) {
+	return canonicalDir, true
+}
+
 func codexSkillsDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/tools/command.go
+++ b/internal/tools/command.go
@@ -43,6 +43,13 @@ func (t CommandTool) SkillPath(skillName string) (string, error) {
 	return renderPathTemplate(t.PathTemplate, t.ToolName, skillName, ""), nil
 }
 
+// CanonicalTarget returns ok=false for CommandTool — the projection shape is
+// defined by user-supplied shell templates and Scribe has no way to know
+// which path inside canonicalDir the install step mirrored.
+func (t CommandTool) CanonicalTarget(_ string) (string, bool) {
+	return "", false
+}
+
 func (t CommandTool) Uninstall(skillName string) error {
 	cmd := renderTemplate(t.UninstallCommand, t.ToolName, skillName, "")
 	if err := runShell(cmd); err != nil {

--- a/internal/tools/cursor.go
+++ b/internal/tools/cursor.go
@@ -92,6 +92,10 @@ func (t CursorTool) SkillPath(skillName string) (string, error) {
 	return filepath.Join(workDir, ".cursor", "rules", mdcName), nil
 }
 
+func (t CursorTool) CanonicalTarget(canonicalDir string) (string, bool) {
+	return filepath.Join(canonicalDir, ".cursor.mdc"), true
+}
+
 // generateMDC builds a Cursor .mdc file from a SKILL.md.
 // Maps `description` from frontmatter, strips frontmatter from body.
 func generateMDC(skillMD []byte) []byte {

--- a/internal/tools/gemini.go
+++ b/internal/tools/gemini.go
@@ -34,6 +34,12 @@ func (t GeminiTool) SkillPath(skillName string) (string, error) {
 	return "", fmt.Errorf("gemini: skill path not available (managed by gemini CLI)")
 }
 
+// CanonicalTarget returns ok=false because Gemini owns its skill directory
+// through the CLI; reconcile has no filesystem projection to inspect.
+func (t GeminiTool) CanonicalTarget(_ string) (string, bool) {
+	return "", false
+}
+
 func (t GeminiTool) Uninstall(skillName string) error {
 	// Fail loudly when the gemini CLI is missing from PATH. Silently returning
 	// nil would leave Gemini's side of the install in place while Scribe drops

--- a/internal/tools/store.go
+++ b/internal/tools/store.go
@@ -100,3 +100,21 @@ func WriteToStore(skillName string, files []SkillFile) (string, error) {
 func StoreDir() (string, error) {
 	return paths.StoreDir()
 }
+
+// WriteCanonicalSkill rewrites the canonical SKILL.md content and refreshes the
+// stored merge base to match. Used by repair flows that promote a tool-local
+// single-file projection back into the canonical store.
+func WriteCanonicalSkill(canonicalDir string, skillMD []byte) error {
+	if err := os.MkdirAll(canonicalDir, 0o755); err != nil {
+		return fmt.Errorf("create store dir: %w", err)
+	}
+	skillPath := filepath.Join(canonicalDir, "SKILL.md")
+	if err := os.WriteFile(skillPath, skillMD, 0o644); err != nil {
+		return fmt.Errorf("write canonical skill: %w", err)
+	}
+	basePath := filepath.Join(canonicalDir, ".scribe-base.md")
+	if err := os.WriteFile(basePath, skillMD, 0o644); err != nil {
+		return fmt.Errorf("write canonical base: %w", err)
+	}
+	return nil
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -26,6 +26,11 @@ type Tool interface {
 	// symlink (or link file) to live. Used by adoption to remove the old
 	// real directory before Install replaces it with a symlink.
 	SkillPath(skillName string) (string, error)
+	// CanonicalTarget returns the path inside canonicalDir that this tool's
+	// on-disk projection mirrors (e.g. claude → canonicalDir/SKILL.md; codex
+	// → canonicalDir itself). When ok is false, the tool manages its skills
+	// opaquely (e.g. via a CLI) and reconcile skips drift inspection.
+	CanonicalTarget(canonicalDir string) (path string, ok bool)
 }
 
 // DefaultTools returns the standard set of supported AI tools.

--- a/internal/workflow/formatter.go
+++ b/internal/workflow/formatter.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 )
 
@@ -18,6 +19,8 @@ type Formatter interface {
 	OnSkillSkipped(name string, status sync.SkillStatus)
 	OnSkillError(name string, err error)
 	OnSyncComplete(summary sync.SyncCompleteMsg)
+	OnReconcileConflict(name string, conflict state.ProjectionConflict)
+	OnReconcileComplete(summary sync.ReconcileCompleteMsg)
 	OnLegacyFormat(repo string)
 
 	// Connect lifecycle

--- a/internal/workflow/formatter_json.go
+++ b/internal/workflow/formatter_json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 
+	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 )
 
@@ -14,6 +15,14 @@ type jsonFormatter struct {
 	current    *registryResult
 	summary    sync.SyncCompleteMsg
 	adoption   adoptionResult
+	reconcile  *reconcileResult
+}
+
+type reconcileResult struct {
+	Installed int                        `json:"installed"`
+	Relinked  int                        `json:"relinked"`
+	Removed   int                        `json:"removed"`
+	Conflicts []state.ProjectionConflict `json:"conflicts,omitempty"`
 }
 
 type adoptedSkill struct {
@@ -111,6 +120,22 @@ func (f *jsonFormatter) OnSyncComplete(summary sync.SyncCompleteMsg) {
 		f.registries = append(f.registries, *f.current)
 		f.current = nil
 	}
+}
+
+func (f *jsonFormatter) OnReconcileConflict(_ string, conflict state.ProjectionConflict) {
+	if f.reconcile == nil {
+		f.reconcile = &reconcileResult{}
+	}
+	f.reconcile.Conflicts = append(f.reconcile.Conflicts, conflict)
+}
+
+func (f *jsonFormatter) OnReconcileComplete(msg sync.ReconcileCompleteMsg) {
+	if f.reconcile == nil {
+		f.reconcile = &reconcileResult{}
+	}
+	f.reconcile.Installed += msg.Summary.Installed
+	f.reconcile.Relinked += msg.Summary.Relinked
+	f.reconcile.Removed += msg.Summary.Removed
 }
 
 func (f *jsonFormatter) OnPackageInstallPrompt(name, command, source string) {}
@@ -234,6 +259,9 @@ func (f *jsonFormatter) Flush() error {
 	}
 	if f.adoption.active || f.adoption.Skipped != "" || f.adoption.Conflicts > 0 {
 		out["adoption"] = f.adoption
+	}
+	if f.reconcile != nil {
+		out["reconcile"] = f.reconcile
 	}
 	return json.NewEncoder(f.out).Encode(out)
 }

--- a/internal/workflow/formatter_text.go
+++ b/internal/workflow/formatter_text.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 )
 
@@ -67,6 +68,27 @@ func (f *textFormatter) OnSyncComplete(summary sync.SyncCompleteMsg) {
 
 	if f.multiRegistry {
 		fmt.Fprintln(f.out)
+	}
+}
+
+func (f *textFormatter) OnReconcileConflict(name string, conflict state.ProjectionConflict) {
+	tool := conflict.Tool
+	if tool == "" {
+		tool = "tool"
+	}
+	fmt.Fprintf(f.errOut, "conflict: %s in %s differs from managed copy\n", name, tool)
+	fmt.Fprintf(f.errOut, "run `scribe skill repair %s --tool %s` to resolve\n", name, tool)
+}
+
+func (f *textFormatter) OnReconcileComplete(msg sync.ReconcileCompleteMsg) {
+	if msg.Summary.Installed == 0 && msg.Summary.Relinked == 0 && msg.Summary.Removed == 0 && len(msg.Summary.Conflicts) == 0 {
+		return
+	}
+	if msg.Summary.Installed+msg.Summary.Relinked+msg.Summary.Removed > 0 {
+		fmt.Fprintf(f.out, "repaired %d tool installs\n", msg.Summary.Installed+msg.Summary.Relinked+msg.Summary.Removed)
+	}
+	if len(msg.Summary.Conflicts) > 0 {
+		fmt.Fprintf(f.errOut, "%d conflict(s) skipped\n", len(msg.Summary.Conflicts))
 	}
 }
 

--- a/internal/workflow/formatter_text.go
+++ b/internal/workflow/formatter_text.go
@@ -77,7 +77,7 @@ func (f *textFormatter) OnReconcileConflict(name string, conflict state.Projecti
 		tool = "tool"
 	}
 	fmt.Fprintf(f.errOut, "conflict: %s in %s differs from managed copy\n", name, tool)
-	fmt.Fprintf(f.errOut, "run `scribe skill repair %s --tool %s` to resolve\n", name, tool)
+	fmt.Fprintf(f.errOut, "run `scribe skill repair %s --tool %s --from managed|tool` to resolve\n", name, tool)
 }
 
 func (f *textFormatter) OnReconcileComplete(msg sync.ReconcileCompleteMsg) {

--- a/internal/workflow/runner_test.go
+++ b/internal/workflow/runner_test.go
@@ -78,12 +78,12 @@ func TestSyncSteps_Composition(t *testing.T) {
 		t.Fatal("SyncSteps() returned empty list")
 	}
 
-	// First step should be LoadConfig, last should be SyncSkills
+	// First step should be LoadConfig, last should be the final system reconcile.
 	if steps[0].Name != "LoadConfig" {
 		t.Errorf("expected first step LoadConfig, got %s", steps[0].Name)
 	}
-	if steps[len(steps)-1].Name != "SyncSkills" {
-		t.Errorf("expected last step SyncSkills, got %s", steps[len(steps)-1].Name)
+	if steps[len(steps)-1].Name != "ReconcileSystem" {
+		t.Errorf("expected last step ReconcileSystem, got %s", steps[len(steps)-1].Name)
 	}
 }
 
@@ -95,11 +95,11 @@ func TestSyncTail_Composition(t *testing.T) {
 	}
 
 	// SyncTail is the shared sync suffix reused by connect and create-registry.
-	// It must end with SyncSkills and must NOT contain Adopt (adoption is a
+	// It must end with ReconcileSystem and must NOT contain Adopt (adoption is a
 	// sync-only prelude; connect flows should not trigger adoption).
 	last := tail[len(tail)-1]
-	if last.Name != "SyncSkills" {
-		t.Errorf("expected SyncTail to end with SyncSkills, got %s", last.Name)
+	if last.Name != "ReconcileSystem" {
+		t.Errorf("expected SyncTail to end with ReconcileSystem, got %s", last.Name)
 	}
 
 	for _, s := range tail {

--- a/internal/workflow/runner_test.go
+++ b/internal/workflow/runner_test.go
@@ -78,12 +78,12 @@ func TestSyncSteps_Composition(t *testing.T) {
 		t.Fatal("SyncSteps() returned empty list")
 	}
 
-	// First step should be LoadConfig, last should be the final system reconcile.
+	// First step should be LoadConfig, last should be the post-sync reconcile.
 	if steps[0].Name != "LoadConfig" {
 		t.Errorf("expected first step LoadConfig, got %s", steps[0].Name)
 	}
-	if steps[len(steps)-1].Name != "ReconcileSystem" {
-		t.Errorf("expected last step ReconcileSystem, got %s", steps[len(steps)-1].Name)
+	if steps[len(steps)-1].Name != "ReconcilePost" {
+		t.Errorf("expected last step ReconcilePost, got %s", steps[len(steps)-1].Name)
 	}
 }
 
@@ -95,11 +95,11 @@ func TestSyncTail_Composition(t *testing.T) {
 	}
 
 	// SyncTail is the shared sync suffix reused by connect and create-registry.
-	// It must end with ReconcileSystem and must NOT contain Adopt (adoption is a
+	// It must end with ReconcilePost and must NOT contain Adopt (adoption is a
 	// sync-only prelude; connect flows should not trigger adoption).
 	last := tail[len(tail)-1]
-	if last.Name != "ReconcileSystem" {
-		t.Errorf("expected SyncTail to end with ReconcileSystem, got %s", last.Name)
+	if last.Name != "ReconcilePost" {
+		t.Errorf("expected SyncTail to end with ReconcilePost, got %s", last.Name)
 	}
 
 	for _, s := range tail {

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -29,9 +29,9 @@ func SyncSteps() []Step {
 		{"ResolveFormatter", StepResolveFormatter},
 		{"ResolveTools", StepResolveTools},
 		{"Adopt", StepAdopt},
-		{"ReconcileSystem", StepReconcileSystem},
+		{"ReconcilePre", StepReconcileSystem},
 		{"SyncSkills", StepSyncSkills},
-		{"ReconcileSystem", StepReconcileSystem},
+		{"ReconcilePost", StepReconcileSystem},
 	}
 }
 
@@ -41,7 +41,7 @@ func SyncTail() []Step {
 		{"ResolveFormatter", StepResolveFormatter},
 		{"ResolveTools", StepResolveTools},
 		{"SyncSkills", StepSyncSkills},
-		{"ReconcileSystem", StepReconcileSystem},
+		{"ReconcilePost", StepReconcileSystem},
 	}
 }
 

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Naoray/scribe/internal/config"
 	gh "github.com/Naoray/scribe/internal/github"
 	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/reconcile"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
@@ -28,7 +29,9 @@ func SyncSteps() []Step {
 		{"ResolveFormatter", StepResolveFormatter},
 		{"ResolveTools", StepResolveTools},
 		{"Adopt", StepAdopt},
+		{"ReconcileSystem", StepReconcileSystem},
 		{"SyncSkills", StepSyncSkills},
+		{"ReconcileSystem", StepReconcileSystem},
 	}
 }
 
@@ -38,7 +41,29 @@ func SyncTail() []Step {
 		{"ResolveFormatter", StepResolveFormatter},
 		{"ResolveTools", StepResolveTools},
 		{"SyncSkills", StepSyncSkills},
+		{"ReconcileSystem", StepReconcileSystem},
 	}
+}
+
+func StepReconcileSystem(_ context.Context, b *Bag) error {
+	engine := reconcile.Engine{Tools: b.Tools}
+	summary, actions, err := engine.Run(b.State)
+	if err != nil {
+		return fmt.Errorf("reconcile system: %w", err)
+	}
+	for _, action := range actions {
+		if action.Kind != reconcile.ActionConflict {
+			continue
+		}
+		for _, conflict := range b.State.Installed[action.Name].Conflicts {
+			if conflict.Path == action.Path && conflict.Tool == action.Tool {
+				b.Formatter.OnReconcileConflict(action.Name, conflict)
+				break
+			}
+		}
+	}
+	b.Formatter.OnReconcileComplete(sync.ReconcileCompleteMsg{Summary: summary})
+	return b.State.Save()
 }
 
 func StepLoadConfig(ctx context.Context, b *Bag) error {

--- a/internal/workflow/sync_adopt_test.go
+++ b/internal/workflow/sync_adopt_test.go
@@ -116,6 +116,8 @@ func (m *mockAdoptTool) SkillPath(skillName string) (string, error) {
 	return filepath.Join(m.name, skillName), nil
 }
 
+func (m *mockAdoptTool) CanonicalTarget(_ string) (string, bool) { return "", false }
+
 var _ tools.Tool = (*mockAdoptTool)(nil)
 
 // ---------------------------------------------------------------------------

--- a/internal/workflow/sync_adopt_test.go
+++ b/internal/workflow/sync_adopt_test.go
@@ -42,29 +42,31 @@ type adoptCompleteCall struct {
 }
 
 // No-ops for non-adoption Formatter methods.
-func (r *adoptRecorder) OnRegistryStart(_ string)                               {}
-func (r *adoptRecorder) OnSkillResolved(_ string, _ isync.SkillStatus)          {}
-func (r *adoptRecorder) OnSkillDownloading(_ string)                             {}
-func (r *adoptRecorder) OnSkillInstalled(_ string, _ bool)                      {}
-func (r *adoptRecorder) OnSkillSkipped(_ string, _ isync.SkillStatus)            {}
-func (r *adoptRecorder) OnSkillError(_ string, _ error)                          {}
-func (r *adoptRecorder) OnSyncComplete(_ isync.SyncCompleteMsg)                  {}
-func (r *adoptRecorder) OnLegacyFormat(_ string)                                 {}
-func (r *adoptRecorder) OnConnectDuplicate(_ string)                             {}
-func (r *adoptRecorder) OnConnectSaved(_ string)                                 {}
-func (r *adoptRecorder) OnConnectSyncing()                                       {}
-func (r *adoptRecorder) OnConnectSyncWarning(_ string, _ error)                  {}
-func (r *adoptRecorder) OnPackageInstallPrompt(_, _, _ string)                   {}
-func (r *adoptRecorder) OnPackageApproved(_ string)                              {}
-func (r *adoptRecorder) OnPackageDenied(_ string)                                {}
-func (r *adoptRecorder) OnPackageSkipped(_ string, _ string)                     {}
-func (r *adoptRecorder) OnPackageInstalling(_ string)                            {}
-func (r *adoptRecorder) OnPackageInstalled(_ string)                             {}
-func (r *adoptRecorder) OnPackageUpdating(_ string)                              {}
-func (r *adoptRecorder) OnPackageUpdated(_ string)                               {}
-func (r *adoptRecorder) OnPackageError(_ string, _ error, _ string)              {}
-func (r *adoptRecorder) OnPackageHashMismatch(_, _, _, _ string)                 {}
-func (r *adoptRecorder) Flush() error                                            { return nil }
+func (r *adoptRecorder) OnRegistryStart(_ string)                                 {}
+func (r *adoptRecorder) OnSkillResolved(_ string, _ isync.SkillStatus)            {}
+func (r *adoptRecorder) OnSkillDownloading(_ string)                              {}
+func (r *adoptRecorder) OnSkillInstalled(_ string, _ bool)                        {}
+func (r *adoptRecorder) OnSkillSkipped(_ string, _ isync.SkillStatus)             {}
+func (r *adoptRecorder) OnSkillError(_ string, _ error)                           {}
+func (r *adoptRecorder) OnSyncComplete(_ isync.SyncCompleteMsg)                   {}
+func (r *adoptRecorder) OnReconcileConflict(_ string, _ state.ProjectionConflict) {}
+func (r *adoptRecorder) OnReconcileComplete(_ isync.ReconcileCompleteMsg)         {}
+func (r *adoptRecorder) OnLegacyFormat(_ string)                                  {}
+func (r *adoptRecorder) OnConnectDuplicate(_ string)                              {}
+func (r *adoptRecorder) OnConnectSaved(_ string)                                  {}
+func (r *adoptRecorder) OnConnectSyncing()                                        {}
+func (r *adoptRecorder) OnConnectSyncWarning(_ string, _ error)                   {}
+func (r *adoptRecorder) OnPackageInstallPrompt(_, _, _ string)                    {}
+func (r *adoptRecorder) OnPackageApproved(_ string)                               {}
+func (r *adoptRecorder) OnPackageDenied(_ string)                                 {}
+func (r *adoptRecorder) OnPackageSkipped(_ string, _ string)                      {}
+func (r *adoptRecorder) OnPackageInstalling(_ string)                             {}
+func (r *adoptRecorder) OnPackageInstalled(_ string)                              {}
+func (r *adoptRecorder) OnPackageUpdating(_ string)                               {}
+func (r *adoptRecorder) OnPackageUpdated(_ string)                                {}
+func (r *adoptRecorder) OnPackageError(_ string, _ error, _ string)               {}
+func (r *adoptRecorder) OnPackageHashMismatch(_, _, _, _ string)                  {}
+func (r *adoptRecorder) Flush() error                                             { return nil }
 
 func (r *adoptRecorder) OnAdoptionSkipped(reason string) {
 	r.skipped = append(r.skipped, reason)
@@ -98,8 +100,8 @@ type mockAdoptTool struct {
 	installed  []string
 }
 
-func (m *mockAdoptTool) Name() string { return m.name }
-func (m *mockAdoptTool) Detect() bool { return true }
+func (m *mockAdoptTool) Name() string             { return m.name }
+func (m *mockAdoptTool) Detect() bool             { return true }
 func (m *mockAdoptTool) Uninstall(_ string) error { return nil }
 func (m *mockAdoptTool) Install(skillName, _ string) ([]string, error) {
 	if m.installErr != nil {


### PR DESCRIPTION
## Summary
- add a dedicated reconcile pass that repairs missing or same-hash filesystem-backed tool projections during `scribe sync`
- split managed projection tracking from tool intent in state and preserve divergent tool-local copies as explicit conflicts
- add `scribe skill repair` and conflict-safe `scribe remove` behavior, plus README and plan updates

## Test Plan
- `go test ./internal/state ./internal/reconcile ./internal/workflow ./cmd`
- `go test ./...` *(fails in pre-existing `internal/logo` tests: `TestRenderFull`, `TestRenderCompact`, `TestRenderNoColor`)*
