### PR TITLE
feat: add scribe-agent skill and single-file skill support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ scribe registry connect ArtistfyHQ/team-skills
 scribe sync
 ```
 
+## Set up in one paste
+
+Paste this into any agent with shell access (Claude Code, Cursor, Codex, etc.). The skill itself handles install, first-run, and self-registration — you only need to point the agent at it once.
+
+```
+Fetch https://raw.githubusercontent.com/Naoray/scribe/main/SKILL.md, read it, and follow its "First-run bootstrap" section before anything else. After bootstrap, use the rules in that skill for every future skill-management request.
+```
+
+That's it. If `scribe` isn't installed, the skill installs it. If the `scribe-agent` skill isn't registered yet, the skill registers itself so the next session loads it directly from `~/.scribe/skills/scribe-agent/SKILL.md`.
+
 ## What is this?
 
 AI coding agents like Claude Code and Cursor work better with "skills" — markdown instruction files that teach the agent how to do specific tasks (code reviews, deployments, Laravel patterns, etc.). If you've built a good set of skills, sharing them with teammates currently means Slack links and manual file copying. Nobody knows if they're on the latest version. The person who just joined has no idea what they're missing.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: scribe-agent
+description: Use when the user wants to install, list, sync, remove, or manage AI coding-agent skills on this machine. Scribe manages a canonical skill store and links skills into Claude Code, Cursor, Codex, and other supported tools.
+---
+
+# scribe-agent
+
+## What scribe does
+
+Scribe manages local coding-agent skills.
+It stores canonical copies in `~/.scribe/skills/` and links them into supported tool directories.
+Use it for installs, updates, removal, adoption of unmanaged local skills, and structured inspection.
+
+## Trigger phrases to commands
+
+| User says | Run |
+| --- | --- |
+| install the X skill | `scribe add X --json` |
+| install X from owner/repo | `scribe add owner/repo:X --yes --json` |
+| what skills are installed | `scribe list --json` |
+| what skills are available remotely | `scribe list --remote --json` |
+| sync my skills | `scribe sync --json` |
+| remove X | `scribe remove X --yes --json` |
+| import existing local skills | `scribe adopt --dry-run --json` |
+| actually adopt them | `scribe adopt --yes --json` |
+| explain what X does | `scribe explain X --json` |
+| show scribe status | `scribe status --json` |
+| connect a registry | `scribe registry add owner/repo` |
+
+## Non-negotiable rules
+
+1. Always use `--json` for anything you plan to parse.
+2. Never run bare `scribe add` in automation.
+3. Prefer `owner/repo:skill` for deterministic installs.
+4. Use `--yes` for direct installs and removals.
+5. Use `scribe adopt --dry-run --json` before `scribe adopt --yes --json`.
+6. Do not hand-edit `~/.scribe/state.json`.
+7. Do not copy skill files directly into tool directories; use `scribe adopt`.
+8. `scribe sync` reconciles registries; it does not install an arbitrary new skill by query.
+9. Some failures still return plain stderr plus non-zero exit, not a JSON error envelope.
+
+## JSON shapes
+
+### `scribe list --json`
+
+Top level: array.
+Each item may include `name`, `description`, `package`, `revision`, `content_hash`, `targets`, `managed`, `origin`, and `path`.
+Fresh-home output is `[]`.
+
+### `scribe list --remote --json`
+
+Top level: object with `registries`.
+Each registry has `registry` and `skills`.
+Each remote skill may include `name`, `status`, `version`, `loadout_ref`, `maintainer`, and `agents`.
+
+### `scribe add query --json`
+
+Top level: object with `results`.
+Each result may include `name`, `registry`, `status`, `version`, `description`, and `author`.
+This is search output, not install output.
+
+### `scribe add owner/repo:skill --yes --json`
+
+Top level: object with `installed`.
+Each installed item may include `name`, `registry`, `status`, and `error`.
+Observed statuses: `installed`, `updated`, `already-installed`, `error`.
+
+### `scribe sync --json`
+
+Top level: object with `registries` and `summary`.
+Each registry has `registry` and `skills`.
+Each skill result may include `name`, `action`, `status`, `version`, and `error`.
+`summary` has `installed`, `updated`, `skipped`, and `failed`.
+Observed actions: `installed`, `updated`, `skipped`, `error`, `package_installed`, `package_updated`, `denied`.
+An optional top-level `adoption` object may appear.
+
+### `scribe adopt --dry-run --json`
+
+Top level: object with `dry_run`, `adopt`, and `conflicts`.
+`adopt` entries may include `name`, `local_path`, `targets`, and `hash`.
+`conflicts` entries may include `name`, `managed_hash`, `unmanaged_path`, and `unmanaged_hash`.
+
+### `scribe adopt --yes --json`
+
+Top level: formatter envelope with `registries`, `summary`, and `adoption`.
+`adoption` may include `skills`, `conflicts_deferred`, `adopted`, `failed`, and `skipped`.
+
+### `scribe remove skill --yes --json`
+
+Top level: object with `removed`.
+Optional fields: `managed_by`, `errors`.
+
+### `scribe explain skill --json`
+
+Top level: object with `name` and `content`.
+Optional fields: `description`, `revision`, `targets`, and `path`.
+This command only works for installed skills on disk.
+
+### `scribe status --json`
+
+Top level: object with `version`, `registries`, and `installed_count`.
+Optional field: `last_sync`.
+
+## Recommended flows
+
+Install a known skill:
+
+```bash
+scribe add owner/repo:skill --yes --json
+```
+
+Search, then install deterministically:
+
+```bash
+scribe add query --json
+scribe add owner/repo:skill --yes --json
+```
+
+Inspect local state:
+
+```bash
+scribe list --json
+scribe status --json
+```
+
+Reconcile connected registries:
+
+```bash
+scribe sync --json
+```
+
+Adopt unmanaged local skills:
+
+```bash
+scribe adopt --dry-run --json
+scribe adopt --yes --json
+```
+
+## Anti-patterns
+
+- Bare `scribe add` in automation.
+- Parsing styled terminal output instead of `--json`.
+- Using `scribe sync` when you mean “install one skill”.
+- Removing files by hand from tool directories.
+- Editing `~/.scribe/state.json` directly.
+- Assuming every failure returns JSON.
+
+## Fallback rule
+
+If you need a command not listed here, run:
+
+```bash
+scribe --help
+scribe <subcommand> --help
+```
+
+Do not guess flags or JSON fields.

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,6 +5,59 @@ description: Use when the user wants to install, list, sync, remove, or manage A
 
 # scribe-agent
 
+## First-run bootstrap (do this before anything else)
+
+Before running any command in this skill, check that `scribe` is installed and that this skill is registered locally. If either is missing, bootstrap them now.
+
+Step 1 — check for the binary:
+
+```bash
+scribe --version
+```
+
+If the command succeeds, skip to Step 3. If it fails with "command not found" (or similar), run Step 2.
+
+Step 2 — install scribe. Pick the first option that fits the machine; stop on the first success:
+
+```bash
+# macOS Homebrew (preferred on macOS)
+brew install Naoray/tap/scribe
+
+# Go toolchain (works anywhere Go is installed)
+go install github.com/Naoray/scribe/cmd/scribe@latest
+
+# macOS Apple Silicon binary
+curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_darwin_arm64.tar.gz | tar xz && sudo mv scribe /usr/local/bin/
+
+# macOS Intel binary
+curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_darwin_amd64.tar.gz | tar xz && sudo mv scribe /usr/local/bin/
+
+# Linux amd64 binary
+curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_linux_amd64.tar.gz | tar xz && sudo mv scribe /usr/local/bin/
+```
+
+Re-run `scribe --version` to confirm. If all options fail, stop and tell the user which one errored and why.
+
+Step 3 — make sure this skill is registered locally so it survives future sessions:
+
+```bash
+scribe list --json
+```
+
+If the output already contains an entry with `"name": "scribe-agent"`, you're done — continue with the user's actual request.
+
+If it does not, install this skill now. First trigger first-run so the `Naoray/scribe` built-in registry is wired up, then install:
+
+```bash
+scribe status --json
+scribe add Naoray/scribe:scribe-agent --yes --json
+scribe list --json
+```
+
+Confirm the final `scribe list --json` includes `scribe-agent`. If anything in this bootstrap fails, report the failing command and its stderr verbatim — do not guess around it.
+
+Once bootstrap succeeds, proceed with the user's request using the command reference below.
+
 ## What scribe does
 
 Scribe manages local coding-agent skills.

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -104,7 +104,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		if !client.IsAuthenticated() {
 			return fmt.Errorf("authentication required — run `gh auth login` or set GITHUB_TOKEN")
 		}
-		return runAddDirectInstall(ctx, registryRepo, skillName, cfg, st, client, targets, useJSON, skipConfirm)
+		return runAddDirectInstall(ctx, registryRepo, skillName, cfg, st, newInstallSyncer(client, targets), true, useJSON, skipConfirm)
 	}
 
 	// Need at least one connected registry to search/browse.
@@ -199,12 +199,15 @@ func runAddDirectInstall(
 	registryRepo, skillName string,
 	cfg *config.Config,
 	st *state.State,
-	client *gh.Client,
-	targets []tools.Tool,
+	syncer *sync.Syncer,
+	authenticated bool,
 	useJSON bool,
 	skipConfirm bool,
 ) error {
-	syncer := newInstallSyncer(client, targets)
+	if !authenticated {
+		return fmt.Errorf("authentication required — run `gh auth login` or set GITHUB_TOKEN")
+	}
+
 	statuses, _, err := syncer.Diff(ctx, registryRepo, st)
 	if err != nil {
 		return fmt.Errorf("diff %s: %w", registryRepo, err)

--- a/cmd/add_scribe_agent_test.go
+++ b/cmd/add_scribe_agent_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/sync"
+)
+
+type singleFileProvider struct{}
+
+func (p *singleFileProvider) Discover(_ context.Context, repo string) (*provider.DiscoverResult, error) {
+	return &provider.DiscoverResult{
+		IsTeam: true,
+		Entries: []manifest.Entry{{
+			Name:   "scribe-agent",
+			Source: "github:Naoray/scribe@HEAD",
+			Path:   "SKILL.md",
+		}},
+	}, nil
+}
+
+func (p *singleFileProvider) Fetch(_ context.Context, entry manifest.Entry) ([]provider.File, error) {
+	return []provider.File{{
+		Path:    "SKILL.md",
+		Content: []byte("---\nname: scribe-agent\ndescription: test\n---\nbody\n"),
+	}}, nil
+}
+
+type singleFileFetcher struct{}
+
+func (f *singleFileFetcher) FetchFile(context.Context, string, string, string, string) ([]byte, error) {
+	return nil, nil
+}
+
+func (f *singleFileFetcher) FetchDirectory(context.Context, string, string, string, string) ([]sync.SkillFile, error) {
+	return nil, nil
+}
+
+func (f *singleFileFetcher) LatestCommitSHA(context.Context, string, string, string) (string, error) {
+	return "", nil
+}
+
+func (f *singleFileFetcher) GetTree(context.Context, string, string, string) ([]provider.TreeEntry, error) {
+	return []provider.TreeEntry{{Path: "SKILL.md", Type: "blob", SHA: "root-sha"}}, nil
+}
+
+// Drives direct install through runAddDirectInstall, the highest-level
+// non-cobra seam in cmd/add.go for owner/repo:skill installs.
+func TestAddScribeAgent_SingleFileSkill_EndToEnd(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := &config.Config{}
+	st := &state.State{Installed: make(map[string]state.InstalledSkill)}
+	syncer := &sync.Syncer{
+		Client:   &singleFileFetcher{},
+		Provider: &singleFileProvider{},
+	}
+
+	if err := runAddDirectInstall(
+		context.Background(),
+		"Naoray/scribe",
+		"scribe-agent",
+		cfg,
+		st,
+		syncer,
+		true,
+		true,
+		true,
+	); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	storeDir := filepath.Join(os.Getenv("HOME"), ".scribe", "skills", "scribe-agent")
+	entries, err := os.ReadDir(storeDir)
+	if err != nil {
+		t.Fatalf("read store dir: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	if len(entries) != 2 {
+		t.Fatalf("store dir should contain SKILL.md plus merge metadata, got %d: %v", len(entries), names)
+	}
+	if names[0] != ".scribe-base.md" || names[1] != "SKILL.md" {
+		t.Errorf("unexpected store contents: %v", names)
+	}
+
+	content, err := os.ReadFile(filepath.Join(storeDir, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	if !bytes.Contains(content, []byte("name: scribe-agent")) {
+		t.Errorf("SKILL.md missing expected frontmatter: %q", string(content))
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,72 +20,112 @@ func newCommandFactory() *app.Factory {
 	return app.NewFactory()
 }
 
-var rootCmd = &cobra.Command{
-	Use:           "scribe",
-	Short:         "Manage local AI coding agent skills",
-	Long:          "Scribe manages local AI coding agent skills and keeps shared team registries in sync.",
-	Version:       Version,
-	Args:          cobra.NoArgs,
-	SilenceUsage:  true,
-	SilenceErrors: true, // errors printed once below; prevents double-print when RunE re-enters Execute
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		// Skip meta commands.
-		if cmd.Name() == "help" || cmd.Name() == "version" || cmd.Name() == "migrate" || cmd.Name() == "upgrade" {
-			return nil
-		}
-
-		// Run on-disk store migration (v1 slug/<name>/ → v2 flat <name>/) before
-		// any command touches the store. Idempotent — gated by a marker file.
-		factory := newCommandFactory()
-		if err := runStoreMigration(factory); err != nil {
-			return err
-		}
-
-		if !firstrun.IsFirstRun() {
-			return nil
-		}
-
-		cfg, err := factory.Config()
-		if err != nil {
-			return err
-		}
-
-		firstrun.ApplyBuiltins(cfg)
-
-		if isatty.IsTerminal(os.Stdout.Fd()) {
-			fmt.Println("Welcome to Scribe! Adding built-in community registries...")
-			for _, r := range cfg.EnabledRegistries() {
-				if r.Builtin {
-					fmt.Printf("  + %s\n", r.Repo)
-				}
-			}
-			fmt.Println()
-		}
-
-		if err := cfg.Save(); err != nil {
-			return err
-		}
-
-		// One-shot adoption prompt: ask user to adopt any existing unmanaged skills.
-		// Only runs in interactive TTY. Ignores persisted cfg.Adoption.Mode — firstrun
-		// always prompts so the user isn't silently skipped or silently auto-adopted.
-		if isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd()) {
-			st, stErr := factory.State()
-			if stErr == nil {
-				toolSet, _ := tools.ResolveActive(cfg)
-				_ = firstrun.PromptAdoption(cfg, st, toolSet, os.Stdin, os.Stdout)
-			}
-		}
-
-		return nil
-	},
-}
+var rootCmd = newRootCmd()
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
+
+func newRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "scribe",
+		Short:         "Manage local AI coding agent skills",
+		Long:          "Scribe manages local AI coding agent skills and keeps shared team registries in sync.",
+		Version:       Version,
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PersistentPreRunE: func(c *cobra.Command, args []string) error {
+			if c.Name() == "help" || c.Name() == "version" || c.Name() == "migrate" || c.Name() == "upgrade" {
+				return nil
+			}
+
+			factory := newCommandFactory()
+			if err := runStoreMigration(factory); err != nil {
+				return err
+			}
+
+			isFirstRun := firstrun.IsFirstRun()
+
+			cfg, err := factory.Config()
+			if err != nil {
+				return err
+			}
+
+			added := firstrun.ApplyBuiltins(cfg)
+			if len(added) > 0 {
+				out := c.ErrOrStderr()
+				if isFirstRun {
+					fmt.Fprintln(out, "Welcome to Scribe! Adding built-in registries...")
+				} else {
+					fmt.Fprintln(out, "Scribe: new built-in registries available:")
+				}
+				for _, repo := range added {
+					fmt.Fprintf(out, "  + %s\n", repo)
+				}
+				fmt.Fprintln(out)
+				if err := cfg.Save(); err != nil {
+					return err
+				}
+			}
+
+			if !isFirstRun {
+				return nil
+			}
+
+			if isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd()) {
+				st, stErr := factory.State()
+				if stErr == nil {
+					toolSet, _ := tools.ResolveActive(cfg)
+					_ = firstrun.PromptAdoption(cfg, st, toolSet, os.Stdin, os.Stdout)
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.RunE = runDefault
+	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	cmd.CompletionOptions = cobra.CompletionOptions{HiddenDefaultCmd: true}
+
+	aliasConnect := newConnectCommand()
+	aliasConnect.Hidden = true
+	aliasConnect.Deprecated = "use 'scribe registry connect' instead"
+	cmd.AddCommand(aliasConnect)
+
+	aliasMigrate := newMigrateCommand()
+	aliasMigrate.Hidden = true
+	aliasMigrate.Deprecated = "use 'scribe registry migrate' instead"
+	cmd.AddCommand(aliasMigrate)
+
+	cmd.AddCommand(
+		newListCommand(),
+		newAddCommand(),
+		newRemoveCommand(),
+		newSyncCommand(),
+		newAdoptCommand(),
+		newStatusCommand(),
+		newResolveCommand(),
+		newRestoreCommand(),
+		newSkillCommand(),
+		newToolsCommand(),
+		newGuideCommand(),
+		newConfigCommand(),
+	)
+
+	cmd.AddCommand(newRegistryCommand())
+
+	cmd.AddCommand(
+		newCreateCommand(),
+		newExplainCommand(),
+		newUpgradeCommand(),
+	)
+
+	return cmd
 }
 
 // runStoreMigration executes the v1 → v2 on-disk migration if the marker is
@@ -123,46 +163,4 @@ func runStoreMigration(factory *app.Factory) error {
 	}
 
 	return nil
-}
-
-func init() {
-	rootCmd.RunE = runDefault
-	rootCmd.Flags().Bool("json", false, "Output machine-readable JSON")
-
-	// Backward-compat aliases: hidden + deprecated, point to registry subcommands.
-	aliasConnect := newConnectCommand()
-	aliasConnect.Hidden = true
-	aliasConnect.Deprecated = "use 'scribe registry connect' instead"
-	rootCmd.AddCommand(aliasConnect)
-
-	aliasMigrate := newMigrateCommand()
-	aliasMigrate.Hidden = true
-	aliasMigrate.Deprecated = "use 'scribe registry migrate' instead"
-	rootCmd.AddCommand(aliasMigrate)
-
-	// Top-level: daily skill management.
-	rootCmd.AddCommand(
-		newListCommand(),
-		newAddCommand(),
-		newRemoveCommand(),
-		newSyncCommand(),
-		newAdoptCommand(),
-		newStatusCommand(),
-		newResolveCommand(),
-		newRestoreCommand(),
-		newSkillCommand(),
-		newToolsCommand(),
-		newGuideCommand(),
-		newConfigCommand(),
-	)
-
-	// Registry subcommand: administration & publishing.
-	rootCmd.AddCommand(newRegistryCommand())
-
-	// Other.
-	rootCmd.AddCommand(
-		newCreateCommand(),
-		newExplainCommand(),
-		newUpgradeCommand(),
-	)
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRoot_JSONFlag_StdoutIsCleanJSON_EvenDuringBuiltinsBackfill(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	root := newRootCmd()
+	var errBuf bytes.Buffer
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"list", "--json"})
+
+	oldOut := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = oldOut }()
+
+	execErr := root.Execute()
+	w.Close()
+
+	if execErr != nil {
+		var stderr bytes.Buffer
+		stderr.ReadFrom(r)
+		t.Fatalf("execute: %v (stderr=%s stdout=%s)", execErr, errBuf.String(), stderr.String())
+	}
+
+	var outBuf bytes.Buffer
+	if _, err := outBuf.ReadFrom(r); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+
+	out := strings.TrimSpace(outBuf.String())
+	var anyJSON interface{}
+	if err := json.Unmarshal([]byte(out), &anyJSON); err != nil {
+		t.Errorf("stdout not clean JSON: %v\nstdout: %q", err, out)
+	}
+
+	stdout := outBuf.String()
+	if strings.Contains(stdout, "Welcome to Scribe") || strings.Contains(stdout, "new built-in") {
+		t.Errorf("banner leaked into stdout: %q", stdout)
+	}
+
+	stderr := errBuf.String()
+	if !strings.Contains(stderr, "Welcome to Scribe") {
+		t.Errorf("expected first-run banner on stderr, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "Naoray/scribe") {
+		t.Errorf("expected Naoray/scribe to appear in banner, got: %q", stderr)
+	}
+}

--- a/docs/superpowers/specs/2026-04-11-scribe-agent-skill-design.md
+++ b/docs/superpowers/specs/2026-04-11-scribe-agent-skill-design.md
@@ -1,0 +1,285 @@
+# Scribe Agentic Skill + Single-File Skill Support
+
+**Date:** 2026-04-11
+**Status:** Design approved, pending implementation plan
+
+## Problem
+
+AI coding agents using scribe today have no standard way to learn the CLI. When a user says "install the react skill" or "what scribe packages do I have installed", the agent has to improvise — guessing at flag names, falling into blocking interactive browsers (`scribe add` with no query hangs), parsing styled TUI output instead of JSON, or worse, hand-editing `~/.claude/skills/`.
+
+We want scribe itself to ship a skill that teaches agents how to drive the CLI efficiently, and we want that skill auto-discoverable on first install — not something users have to hunt down.
+
+Secondary wins: this forces us to fix a latent broken path in scribe's own tree-scan discovery (root-level `SKILL.md` emits `Path: "."` which then causes `Fetch` to pull the entire repo), and it establishes the pattern "drop a SKILL.md at your repo root and scribe picks it up" — a strong dogfooding story.
+
+## Goals
+
+1. Ship a `scribe` skill at the scribe repo root that teaches agents how to use scribe.
+2. Make `Naoray/scribe` a default public registry, applied to both first-time and existing users.
+3. Fix tree-scan + fetch so root-level `SKILL.md` actually works end-to-end (single-file skill support).
+4. No regressions for existing registries (`anthropic/skills`, `openai/codex-skills`, `expo/skills`).
+
+## Non-goals
+
+- Local registry index / catalog cache (see `project_local_registry_index.md` memory — separate spec).
+- Refactoring `RegistryTypeTeam`/`RegistryTypeCommunity` into a private/public model (see `feedback_registry_private_public.md` — future debt).
+- Single-file skill advanced features (multi-file but single-dir skills, references/ subdirs at root) — out of scope; current scope is "one file, one SKILL.md at repo root".
+- Any new command. This spec only touches existing commands' wiring + adds one skill file.
+
+## Design
+
+### 1. Skill payload — SKILL.md at scribe repo root
+
+A single file, `SKILL.md`, at the root of the `Naoray/scribe` repository. No `scribe.yaml`, no `.claude-plugin/marketplace.json`, no dedicated skill subdirectory. One file.
+
+This makes scribe its own marketing: the simplest way to ship a skill is drop one `SKILL.md` at your repo root.
+
+**Frontmatter:**
+
+```yaml
+---
+name: scribe
+description: Use when the user wants to install, list, sync, remove, or manage AI coding-agent skills on this machine. Scribe is the CLI that manages ~/.claude/skills and symlinks skills into Claude Code, Cursor, Codex, and other AI tools.
+---
+```
+
+**Body structure** (all sections combined, target ~150-220 lines):
+
+1. **What scribe is** — 2-3 sentences on the tool's purpose: canonical store, symlink-based installs into per-tool dirs, registry discovery.
+
+2. **Trigger phrases → command map** — dense lookup table. Maps user utterances to the scribe commands an agent should invoke. Example rows:
+   - "install the X skill" → `scribe add X --yes` (or search first with `scribe add X --json`)
+   - "install X from Y/Z" → `scribe add Y/Z:X --yes`
+   - "what skills do I have" → `scribe list --json`
+   - "what skills are available" → `scribe list --remote --json`
+   - "remove X" → `scribe remove X`
+   - "sync my skills" → `scribe sync --json`
+   - "import my existing skills" → `scribe adopt --json`
+   - "what does X do" → `scribe explain X`
+   - "add Y/Z as a registry" → `scribe registry add Y/Z`
+   - "show scribe status" → `scribe status`
+
+3. **Non-negotiable rules** — the block that prevents agent-session disasters:
+   - Always pass `--json` when parsing output.
+   - Never run `scribe add` without a query or direct target — bare `scribe add` opens an interactive browser that blocks on stdin.
+   - Always pass `--yes` for install/remove to skip confirmation prompts.
+   - Prefer `owner/repo:skill` direct form when the target is known — deterministic, auto-connects the registry.
+   - Don't hand-edit `~/.scribe/state.json`.
+   - Don't `cp`/`mv` skills into `~/.claude/skills/` — use `scribe adopt`.
+   - Don't use `scribe sync` to install one skill — sync is reconcile-only; use `scribe add`.
+
+4. **JSON output shapes** — one line per command naming the fields the agent should parse. Concrete list to verify during implementation (all commands already support `--json` as of 2026-04-11):
+   - `scribe list --json`
+   - `scribe list --remote --json`
+   - `scribe add <q> --json`
+   - `scribe sync --json`
+   - `scribe adopt --json`
+   - `scribe remove <name> --json`
+   - `scribe status --json`
+   - `scribe explain <name> --json`
+
+   **Verification subtask during implementation:** capture the actual JSON shape of each by running the command against a test fixture, and paste the resulting keys into the SKILL.md so the skill is accurate at ship time. If shapes differ from what the skill documents, fix the skill, not the command.
+
+5. **Common flows** — 3-5 copy-paste recipes the agent can adapt:
+   - Install one skill by name: `scribe add <query> --yes --json`
+   - Install from a specific registry: `scribe add owner/repo:skill --yes --json`
+   - Check what's installed before modifying: `scribe list --json | jq '.[].name'`
+   - Bring a local-edited skill back under management: `scribe adopt --json`
+   - Refresh everything from connected registries: `scribe sync --json`
+
+6. **Fallback to `--help`** — one line covering commands not in the hot path (`registry`, `config`, `tools`, `skill edit`, `resolve`, `restore`, `create`, `guide`, `migrate`, `upgrade`). Agent should run `scribe <cmd> --help` for these.
+
+7. **Anti-patterns** — short reinforcement of the rules block.
+
+**Target length:** 150-220 lines of markdown. Lean enough to load every session.
+
+### 2. Single-file skill support
+
+Tree-scan discovery already emits catalog entries for root-level `SKILL.md` files (`internal/provider/treescan.go:30-38`), but the path it records (`"."`) is wrong: `Fetch` then calls `FetchDirectory(..., ".", ...)` and pulls the entire repo into the skill store. Two small code changes fix it.
+
+**Change 1 — `internal/provider/treescan.go`:** root-level branch sets `skillPath = "SKILL.md"` instead of `"."`. The catalog entry now records the actual file path.
+
+**Change 2 — `internal/provider/github.go` Fetch method:** branch on `strings.HasSuffix(entry.Path, ".md")`:
+
+```go
+func (p *GitHubProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]File, error) {
+    src, err := manifest.ParseSource(entry.Source)
+    if err != nil {
+        return nil, fmt.Errorf("parse source for %s: %w", entry.Name, err)
+    }
+    skillPath := entry.Path
+    if skillPath == "" {
+        skillPath = entry.Name
+    }
+    if strings.HasSuffix(skillPath, ".md") {
+        data, err := p.client.FetchFile(ctx, src.Owner, src.Repo, skillPath, src.Ref)
+        if err != nil {
+            return nil, err
+        }
+        return []File{{Path: "SKILL.md", Content: data}}, nil
+    }
+    ghFiles, err := p.client.FetchDirectory(ctx, src.Owner, src.Repo, skillPath, src.Ref)
+    if err != nil {
+        return nil, err
+    }
+    files := make([]File, len(ghFiles))
+    for i, f := range ghFiles {
+        files[i] = File{Path: f.Path, Content: f.Content}
+    }
+    return files, nil
+}
+```
+
+Key invariant: the file is always stored as `SKILL.md` in the on-disk skill directory regardless of the remote filename. This normalizes the layout so the store writer + tool-install adapters don't need to know whether a skill originated as a single file or a directory.
+
+No changes to `internal/manifest/manifest.go` — `Entry.Path` is already a free-form string. Optionally add a doc comment noting "directory or a single `.md` file".
+
+**Downstream impact:** none for existing multi-file skills. The single-file branch is additive.
+
+### 3. Default registry wiring — `Naoray/scribe`
+
+Goal: `Naoray/scribe` is auto-connected on first run AND backfilled for existing users — without re-adding registries a user has explicitly removed.
+
+**Change 1 — `internal/firstrun/firstrun.go:20`:** add `"Naoray/scribe"` at the top of `builtinRepos`:
+
+```go
+var builtinRepos = []string{
+    "Naoray/scribe",
+    "anthropic/skills",
+    "openai/codex-skills",
+    "expo/skills",
+}
+```
+
+**Change 2 — `internal/config/config.go`:** add `SeenBuiltins []string` to `Config`:
+
+```go
+type Config struct {
+    Registries   []RegistryConfig `yaml:"registries,omitempty"`
+    Token        string           `yaml:"token,omitempty"`
+    Tools        []ToolConfig     `yaml:"tools,omitempty"`
+    Editor       string           `yaml:"editor,omitempty"`
+    Adoption     AdoptionConfig   `yaml:"adoption,omitempty"`
+    SeenBuiltins []string         `yaml:"seen_builtins,omitempty"`
+}
+```
+
+Tracks which builtins scribe has already offered the user. Empty slice for existing configs = all pre-existing builtins will be marked seen on next run without being re-added (idempotent for their existing registry entries).
+
+**Change 3 — `internal/firstrun/firstrun.go` `ApplyBuiltins`:** change semantics to "apply any un-seen builtin, return the net-new additions". Respects user deletions (seen + absent means the user removed it — do not re-add).
+
+```go
+func ApplyBuiltins(cfg *config.Config) (added []string) {
+    seen := map[string]bool{}
+    for _, s := range cfg.SeenBuiltins {
+        seen[s] = true
+    }
+    for _, builtin := range BuiltinRegistries() {
+        if seen[builtin.Repo] {
+            continue // user has seen this — respect their decision to remove/disable
+        }
+        if cfg.FindRegistry(builtin.Repo) == nil {
+            cfg.AddRegistry(builtin)
+            added = append(added, builtin.Repo)
+        }
+        cfg.SeenBuiltins = append(cfg.SeenBuiltins, builtin.Repo)
+    }
+    return added
+}
+```
+
+Behavior matrix:
+
+| Scenario | Before | After | Net action |
+|---|---|---|---|
+| First-run user | no config | builtins added, all marked seen | install all 4 |
+| Existing user (pre-`Naoray/scribe`) | 3 builtins present, SeenBuiltins empty | all 4 marked seen; only `Naoray/scribe` actually added | install 1 |
+| User removed a builtin earlier | registry absent, seen | no change | nothing |
+| User disabled a builtin | registry present, `Enabled: false`, seen | no change | nothing |
+
+**Change 4 — `cmd/root.go:44-53`:** move `ApplyBuiltins` call OUT of the `if !firstrun.IsFirstRun()` gate. Run on every invocation (cheap — it's a map diff), but only act when new builtins are added.
+
+```go
+cfg, err := factory.Config()
+if err != nil {
+    return err
+}
+
+added := firstrun.ApplyBuiltins(cfg)
+if len(added) > 0 {
+    if isatty.IsTerminal(os.Stdout.Fd()) {
+        if firstrun.IsFirstRun() {
+            fmt.Println("Welcome to Scribe! Adding built-in registries...")
+        } else {
+            fmt.Println("Scribe: new built-in registries available:")
+        }
+        for _, repo := range added {
+            fmt.Printf("  + %s\n", repo)
+        }
+        fmt.Println()
+    }
+    if err := cfg.Save(); err != nil {
+        return err
+    }
+}
+
+if firstrun.IsFirstRun() {
+    // existing adoption prompt — unchanged
+}
+```
+
+Note: existing users get a one-shot banner the first time they run scribe after upgrading, listing `Naoray/scribe` as the new builtin. No banner on subsequent runs (SeenBuiltins is now populated). No banner in piped/non-TTY contexts.
+
+## Testing
+
+### New tests
+
+**`internal/provider/treescan_test.go`:**
+- Root-level `SKILL.md` emits `Path: "SKILL.md"` (not `"."`).
+- Regression guard: assert no catalog entry has `Path == "."`.
+
+**`internal/provider/github_test.go`:**
+- `Fetch` with `entry.Path = "SKILL.md"` uses `FetchFile` and returns a single-file slice with `Path: "SKILL.md"`.
+- Existing `Fetch` cases with directory paths unchanged.
+
+**`internal/firstrun/firstrun_test.go`:**
+- Existing `ApplyBuiltins` tests updated to assert new return value and `SeenBuiltins` population.
+- New: user removed a builtin earlier → `ApplyBuiltins` does not re-add. (Seed: empty registries, seen contains the removed repo.)
+- New: existing user with 3 pre-existing registries, empty `SeenBuiltins` → `added` returns only `["Naoray/scribe"]`, all 4 marked seen.
+- New: user with `Enabled: false` on a builtin → `ApplyBuiltins` leaves enabled flag untouched.
+
+**Integration-ish:**
+- End-to-end: seed a fake GitHub client that returns a root `SKILL.md`, call `scribe add Naoray/scribe:scribe` with it, assert `~/.scribe/skills/scribe/SKILL.md` exists and nothing else in that directory.
+
+### Manual verification steps (captured in plan)
+
+1. Fresh `~/.scribe/` → run `scribe status` → expect 4 builtins listed including `Naoray/scribe`.
+2. Existing config with only the 3 old builtins → run any scribe command → expect banner announcing `Naoray/scribe` added; re-run → no banner.
+3. `scribe registry remove Naoray/scribe` → re-run any scribe command → expect no re-add (respects user deletion).
+4. `scribe add Naoray/scribe:scribe --yes --json` → expect success, `scribe list --json` shows the skill, `~/.claude/skills/scribe` symlink exists.
+
+## Migration / backwards compatibility
+
+- Existing `config.yaml` files without `seen_builtins` key load cleanly (omitempty + empty slice).
+- After first run against the new binary, `seen_builtins` appears in the persisted config.
+- Downgrading scribe after seeing the new key is safe — old scribe versions ignore unknown YAML keys per `yaml.v3` defaults.
+- No state migration, no on-disk store migration, no breaking change to existing commands.
+
+## Implementation subtasks (for the plan)
+
+1. Verify exact JSON output shapes of each command listed in the skill body.
+2. Write `SKILL.md` at repo root with the finalized content from Section 1.
+3. `internal/provider/treescan.go`: fix root-level `skillPath`.
+4. `internal/provider/github.go`: add single-file fetch branch.
+5. `internal/config/config.go`: add `SeenBuiltins` field.
+6. `internal/firstrun/firstrun.go`: rewrite `ApplyBuiltins` signature + semantics.
+7. `cmd/root.go`: move `ApplyBuiltins` out of first-run gate, add net-new banner branch.
+8. All tests from Testing section.
+9. Manual verification walkthrough.
+10. Commit + PR (squash merge to main per project convention).
+
+## Open questions resolved during brainstorming
+
+- **Skill location:** SKILL.md at repo root, no scribe.yaml / marketplace.json. Forces fix of latent single-file-skill bug.
+- **Default registry mechanism:** builtin list + `SeenBuiltins` diff — backfills existing users, respects deletions.
+- **Team/community type:** out of scope; reject the distinction in principle (see `feedback_registry_private_public.md`) but don't refactor in this spec.
+- **Local registry index:** out of scope, separate future spec (`project_local_registry_index.md`).

--- a/docs/superpowers/specs/2026-04-11-scribe-agent-skill-design.md
+++ b/docs/superpowers/specs/2026-04-11-scribe-agent-skill-design.md
@@ -9,7 +9,7 @@ AI coding agents using scribe today have no standard way to learn the CLI. When 
 
 We want scribe itself to ship a skill that teaches agents how to drive the CLI efficiently, and we want that skill auto-discoverable on first install — not something users have to hunt down.
 
-Secondary wins: this forces us to fix a latent broken path in scribe's own tree-scan discovery (root-level `SKILL.md` emits `Path: "."` which then causes `Fetch` to pull the entire repo), and it establishes the pattern "drop a SKILL.md at your repo root and scribe picks it up" — a strong dogfooding story.
+Secondary wins: this forces us to fix a latent broken path in scribe's own tree-scan discovery (root-level `SKILL.md` emits `Path: "."`, which then makes `FetchDirectory` compute `prefix = "./"`, match zero tree entries, and return `no files found under "."` — the catalog entry is effectively dead on arrival), and it establishes the pattern "drop a SKILL.md at your repo root and scribe picks it up" — a strong dogfooding story.
 
 ## Goals
 
@@ -37,10 +37,14 @@ This makes scribe its own marketing: the simplest way to ship a skill is drop on
 
 ```yaml
 ---
-name: scribe
+name: scribe-agent
 description: Use when the user wants to install, list, sync, remove, or manage AI coding-agent skills on this machine. Scribe is the CLI that manages ~/.claude/skills and symlinks skills into Claude Code, Cursor, Codex, and other AI tools.
 ---
 ```
+
+**Why `scribe-agent` and not `scribe`:** avoids name collision with any other registry that also happens to ship a skill named `scribe` (common name, likely to clash eventually). State.json keys skills by name; two skills named `scribe` from different registries would clobber each other. The bare-root-SKILL.md story is preserved — the file still lives at repo root — but the frontmatter `name:` field gives the skill a unique identity. Install reads `scribe add Naoray/scribe:scribe-agent --yes`, which is also easier on the eyes than the double-scribe.
+
+**Tree-scan consequence:** tree-scan currently derives the skill name from the repo name for root-level SKILL.md (`name = repo` at `internal/provider/treescan.go:32`). The frontmatter `name:` field takes precedence downstream — discovery still works because the add command looks skills up by the frontmatter name once SKILL.md is fetched. Verify during implementation that `scribe add Naoray/scribe:scribe-agent` resolves correctly end-to-end; if not, tree-scan needs a preflight to read the frontmatter and use `name:` instead of the repo name.
 
 **Body structure** (all sections combined, target ~150-220 lines):
 
@@ -94,11 +98,11 @@ description: Use when the user wants to install, list, sync, remove, or manage A
 
 ### 2. Single-file skill support
 
-Tree-scan discovery already emits catalog entries for root-level `SKILL.md` files (`internal/provider/treescan.go:30-38`), but the path it records (`"."`) is wrong: `Fetch` then calls `FetchDirectory(..., ".", ...)` and pulls the entire repo into the skill store. Two small code changes fix it.
+Tree-scan discovery already emits catalog entries for root-level `SKILL.md` files (`internal/provider/treescan.go:30-38`), but the path it records (`"."`) is effectively dead on arrival: `Fetch` → `FetchDirectory(..., ".", ...)` → `prefix = "./"` → zero tree-entry matches → error `no files found under "."`. Three code changes fix it end-to-end: tree-scan emits a valid path, Fetch supports single-file retrieval, and sync's blob-SHA resolver recognizes single-file skills.
 
-**Change 1 — `internal/provider/treescan.go`:** root-level branch sets `skillPath = "SKILL.md"` instead of `"."`. The catalog entry now records the actual file path.
+**Change 1 — `internal/provider/treescan.go:30-38`:** root-level branch sets `skillPath = "SKILL.md"` instead of `"."`. The catalog entry now records the actual file path.
 
-**Change 2 — `internal/provider/github.go` Fetch method:** branch on `strings.HasSuffix(entry.Path, ".md")`:
+**Change 2 — `internal/provider/github.go` Fetch method:** branch on `path.Base(skillPath) == "SKILL.md"` (exact match, not suffix). This avoids a directory literally named `foo.md` accidentally hitting the single-file branch, and it's self-documenting — the condition says "this is a single-file skill" rather than "this happens to end in .md".
 
 ```go
 func (p *GitHubProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]File, error) {
@@ -110,7 +114,7 @@ func (p *GitHubProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]Fil
     if skillPath == "" {
         skillPath = entry.Name
     }
-    if strings.HasSuffix(skillPath, ".md") {
+    if path.Base(skillPath) == "SKILL.md" {
         data, err := p.client.FetchFile(ctx, src.Owner, src.Repo, skillPath, src.Ref)
         if err != nil {
             return nil, err
@@ -131,17 +135,49 @@ func (p *GitHubProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]Fil
 
 Key invariant: the file is always stored as `SKILL.md` in the on-disk skill directory regardless of the remote filename. This normalizes the layout so the store writer + tool-install adapters don't need to know whether a skill originated as a single file or a directory.
 
+**Change 3 — `internal/sync/blobsha.go:19-35` `resolveSkillBlobSHA`:** current implementation assumes `skillPath` is a directory and builds `target = skillPath + "/SKILL.md"`. For a single-file skill with `entry.Path = "SKILL.md"` this produces `target = "SKILL.md/SKILL.md"` → never matches the tree entry → `resolveSkillBlobSHA` returns `("", false)` → sync misclassifies the skill as missing-upstream on every run. This is a silent regression for anyone installing a single-file skill and then running `scribe sync`. Fix:
+
+```go
+func resolveSkillBlobSHA(tree []provider.TreeEntry, entry manifest.Entry) (string, bool) {
+    skillPath := entry.Path
+    if skillPath == "" {
+        skillPath = entry.Name
+    }
+    skillPath = strings.TrimSuffix(skillPath, "/")
+    target := "SKILL.md"
+    switch {
+    case path.Base(skillPath) == "SKILL.md":
+        target = skillPath              // entry already points at the file
+    case skillPath != "" && skillPath != ".":
+        target = skillPath + "/SKILL.md" // legacy directory-based entry
+    }
+    for _, e := range tree {
+        if e.Type == "blob" && e.Path == target {
+            return e.SHA, true
+        }
+    }
+    return "", false
+}
+```
+
 No changes to `internal/manifest/manifest.go` — `Entry.Path` is already a free-form string. Optionally add a doc comment noting "directory or a single `.md` file".
 
-**Downstream impact:** none for existing multi-file skills. The single-file branch is additive.
+**Downstream impact:** none for existing multi-file skills. Both the Fetch branch and the `resolveSkillBlobSHA` switch are additive — only single-file skills (where `path.Base(skillPath) == "SKILL.md"`) take the new code path.
 
 ### 3. Default registry wiring — `Naoray/scribe`
 
-Goal: `Naoray/scribe` is auto-connected on first run AND backfilled for existing users — without re-adding registries a user has explicitly removed.
+Goal: `Naoray/scribe` is auto-connected on first run AND backfilled for existing users — without re-adding registries users have disabled.
 
-**Change 1 — `internal/firstrun/firstrun.go:20`:** add `"Naoray/scribe"` at the top of `builtinRepos`:
+**Design note on "respecting deletions":** the earlier design tried to track per-repo `SeenBuiltins []string` so a user who removes a builtin via `scribe registry remove` wouldn't see it re-added on upgrade. But `scribe registry remove` doesn't exist today — only `registry add` and `registry enable/disable`. The untestable case was dead code. The disable path is already respected because `ApplyBuiltins` calls `FindRegistry` before adding, and disabled registries are still present in the config. Dropping per-repo tracking in favor of a version-gated marker.
+
+**Change 1 — `internal/firstrun/firstrun.go`:** add `"Naoray/scribe"` at the top of `builtinRepos` and introduce a version constant:
 
 ```go
+// currentBuiltinsVersion bumps whenever builtinRepos changes. Used by ApplyBuiltins
+// to detect that a config was written against an older scribe version and may be
+// missing new builtins.
+const currentBuiltinsVersion = 2
+
 var builtinRepos = []string{
     "Naoray/scribe",
     "anthropic/skills",
@@ -150,39 +186,37 @@ var builtinRepos = []string{
 }
 ```
 
-**Change 2 — `internal/config/config.go`:** add `SeenBuiltins []string` to `Config`:
+`currentBuiltinsVersion = 1` represents the pre-existing set (`anthropic/skills`, `openai/codex-skills`, `expo/skills`). `= 2` is this change, which adds `Naoray/scribe`. Future additions bump further.
+
+**Change 2 — `internal/config/config.go`:** add `BuiltinsVersion int` to `Config`:
 
 ```go
 type Config struct {
-    Registries   []RegistryConfig `yaml:"registries,omitempty"`
-    Token        string           `yaml:"token,omitempty"`
-    Tools        []ToolConfig     `yaml:"tools,omitempty"`
-    Editor       string           `yaml:"editor,omitempty"`
-    Adoption     AdoptionConfig   `yaml:"adoption,omitempty"`
-    SeenBuiltins []string         `yaml:"seen_builtins,omitempty"`
+    Registries      []RegistryConfig `yaml:"registries,omitempty"`
+    Token           string           `yaml:"token,omitempty"`
+    Tools           []ToolConfig     `yaml:"tools,omitempty"`
+    Editor          string           `yaml:"editor,omitempty"`
+    Adoption        AdoptionConfig   `yaml:"adoption,omitempty"`
+    BuiltinsVersion int              `yaml:"builtins_version,omitempty"`
 }
 ```
 
-Tracks which builtins scribe has already offered the user. Empty slice for existing configs = all pre-existing builtins will be marked seen on next run without being re-added (idempotent for their existing registry entries).
+Zero value (`0`) represents "no version marker yet" — either a brand-new config or a config from scribe versions before this change. Both cases trigger backfill.
 
-**Change 3 — `internal/firstrun/firstrun.go` `ApplyBuiltins`:** change semantics to "apply any un-seen builtin, return the net-new additions". Respects user deletions (seen + absent means the user removed it — do not re-add).
+**Change 3 — `internal/firstrun/firstrun.go` `ApplyBuiltins`:** version-gated. Runs the diff only when the config is behind. Returns net-new additions for UX output.
 
 ```go
 func ApplyBuiltins(cfg *config.Config) (added []string) {
-    seen := map[string]bool{}
-    for _, s := range cfg.SeenBuiltins {
-        seen[s] = true
+    if cfg.BuiltinsVersion >= currentBuiltinsVersion {
+        return nil
     }
     for _, builtin := range BuiltinRegistries() {
-        if seen[builtin.Repo] {
-            continue // user has seen this — respect their decision to remove/disable
-        }
         if cfg.FindRegistry(builtin.Repo) == nil {
             cfg.AddRegistry(builtin)
             added = append(added, builtin.Repo)
         }
-        cfg.SeenBuiltins = append(cfg.SeenBuiltins, builtin.Repo)
     }
+    cfg.BuiltinsVersion = currentBuiltinsVersion
     return added
 }
 ```
@@ -191,12 +225,15 @@ Behavior matrix:
 
 | Scenario | Before | After | Net action |
 |---|---|---|---|
-| First-run user | no config | builtins added, all marked seen | install all 4 |
-| Existing user (pre-`Naoray/scribe`) | 3 builtins present, SeenBuiltins empty | all 4 marked seen; only `Naoray/scribe` actually added | install 1 |
-| User removed a builtin earlier | registry absent, seen | no change | nothing |
-| User disabled a builtin | registry present, `Enabled: false`, seen | no change | nothing |
+| First-run user | no config (version 0) | 4 builtins added, version = 2 | install 4 |
+| Existing user (pre-`Naoray/scribe`) | 3 builtins present, version 0 | `Naoray/scribe` added, version = 2 | install 1 |
+| User disabled a builtin | `Enabled: false`, version 0 | disabled flag untouched, only missing repo(s) added, version = 2 | possibly install 1 |
+| Already up to date | version = 2 | no-op | nothing |
+| Future upgrade (v3) | version = 2, new repo in list | diff adds new repo, version = 3 | install new |
 
-**Change 4 — `cmd/root.go:44-53`:** move `ApplyBuiltins` call OUT of the `if !firstrun.IsFirstRun()` gate. Run on every invocation (cheap — it's a map diff), but only act when new builtins are added.
+No per-repo "seen" tracking, no "user removed" case — that's a future problem for when `scribe registry remove` actually exists.
+
+**Change 4 — `cmd/root.go:44-53`:** move `ApplyBuiltins` call OUT of the `if !firstrun.IsFirstRun()` gate. Print the banner to **stderr** so it does not corrupt `--json` output on stdout (agents run in PTYs where `isatty(stdout)` returns true; the `os.Stdout` vs `os.Stderr` distinction is what keeps machine-readable output clean, not the TTY check).
 
 ```go
 cfg, err := factory.Config()
@@ -206,16 +243,16 @@ if err != nil {
 
 added := firstrun.ApplyBuiltins(cfg)
 if len(added) > 0 {
-    if isatty.IsTerminal(os.Stdout.Fd()) {
+    if isatty.IsTerminal(os.Stderr.Fd()) {
         if firstrun.IsFirstRun() {
-            fmt.Println("Welcome to Scribe! Adding built-in registries...")
+            fmt.Fprintln(os.Stderr, "Welcome to Scribe! Adding built-in registries...")
         } else {
-            fmt.Println("Scribe: new built-in registries available:")
+            fmt.Fprintln(os.Stderr, "Scribe: new built-in registries available:")
         }
         for _, repo := range added {
-            fmt.Printf("  + %s\n", repo)
+            fmt.Fprintf(os.Stderr, "  + %s\n", repo)
         }
-        fmt.Println()
+        fmt.Fprintln(os.Stderr)
     }
     if err := cfg.Save(); err != nil {
         return err
@@ -227,7 +264,9 @@ if firstrun.IsFirstRun() {
 }
 ```
 
-Note: existing users get a one-shot banner the first time they run scribe after upgrading, listing `Naoray/scribe` as the new builtin. No banner on subsequent runs (SeenBuiltins is now populated). No banner in piped/non-TTY contexts.
+Key invariants: banner lives on stderr, stdout is reserved for command output (including `--json`). TTY check on stderr is purely to suppress noise in piped stderr redirections (rare but harmless). `cfg.Save()` is called only when `added` is non-empty, which means steady-state scribe invocations after the upgrade do not incur a write.
+
+**Implicit contract note:** after this change, `PersistentPreRunE` may leave `cfg` dirty on disk before `RunE` starts. Any command that also mutates and saves `cfg` later must be aware that its pre-save baseline might differ from what it read originally. Today this is not a conflict because `ApplyBuiltins` only touches `Registries` and `BuiltinsVersion`, both of which are append-only in this flow. Document with a one-line code comment at the call site.
 
 ## Testing
 
@@ -236,50 +275,76 @@ Note: existing users get a one-shot banner the first time they run scribe after 
 **`internal/provider/treescan_test.go`:**
 - Root-level `SKILL.md` emits `Path: "SKILL.md"` (not `"."`).
 - Regression guard: assert no catalog entry has `Path == "."`.
+- Root-level SKILL.md at a non-`scribe` repo still derives the tree-scan default name from the repo (e.g. `acme/my-thing` → entry named `my-thing`); the frontmatter `name:` override happens downstream during install, not in tree-scan.
 
 **`internal/provider/github_test.go`:**
-- `Fetch` with `entry.Path = "SKILL.md"` uses `FetchFile` and returns a single-file slice with `Path: "SKILL.md"`.
+- `Fetch` with `entry.Path = "SKILL.md"` uses `FetchFile` (not `FetchDirectory`) and returns a single-file slice with `Path: "SKILL.md"`.
+- `Fetch` with `entry.Path = "foo.md"` (hypothetical directory literally named `foo.md`) does NOT hit the single-file branch — verifies `path.Base == "SKILL.md"` is the discriminator, not `HasSuffix(".md")`.
 - Existing `Fetch` cases with directory paths unchanged.
 
+**`internal/sync/blobsha_test.go`:**
+- New test: `resolveSkillBlobSHA` with `entry.Path = "SKILL.md"` returns the root-level blob SHA (target path = `"SKILL.md"`, not `"SKILL.md/SKILL.md"`).
+- Existing directory-path cases unchanged.
+
 **`internal/firstrun/firstrun_test.go`:**
-- Existing `ApplyBuiltins` tests updated to assert new return value and `SeenBuiltins` population.
-- New: user removed a builtin earlier → `ApplyBuiltins` does not re-add. (Seed: empty registries, seen contains the removed repo.)
-- New: existing user with 3 pre-existing registries, empty `SeenBuiltins` → `added` returns only `["Naoray/scribe"]`, all 4 marked seen.
-- New: user with `Enabled: false` on a builtin → `ApplyBuiltins` leaves enabled flag untouched.
+- Existing `ApplyBuiltins` tests updated to assert new return value and `BuiltinsVersion` advancement.
+- New: `BuiltinsVersion` already at current → `ApplyBuiltins` returns nil and does not mutate config.
+- New: existing user with 3 pre-existing registries, `BuiltinsVersion = 0` → `added` returns `["Naoray/scribe"]`, config ends with `BuiltinsVersion = currentBuiltinsVersion`.
+- New: user with `Enabled: false` on a builtin → `ApplyBuiltins` does not flip the flag back to enabled.
+
+**`cmd/root_test.go` (or equivalent):**
+- New: banner output writes to stderr, not stdout. Run the command with stdout captured as JSON, assert stdout is clean JSON even when builtins backfill fires. (Black-box via `cmd.SetOut` / `cmd.SetErr`.)
 
 **Integration-ish:**
-- End-to-end: seed a fake GitHub client that returns a root `SKILL.md`, call `scribe add Naoray/scribe:scribe` with it, assert `~/.scribe/skills/scribe/SKILL.md` exists and nothing else in that directory.
+- End-to-end: seed a fake GitHub client that returns a root `SKILL.md` with frontmatter `name: scribe-agent`, call `scribe add Naoray/scribe:scribe-agent` with it, assert `~/.scribe/skills/scribe-agent/SKILL.md` exists and nothing else in that directory.
 
 ### Manual verification steps (captured in plan)
 
 1. Fresh `~/.scribe/` → run `scribe status` → expect 4 builtins listed including `Naoray/scribe`.
-2. Existing config with only the 3 old builtins → run any scribe command → expect banner announcing `Naoray/scribe` added; re-run → no banner.
-3. `scribe registry remove Naoray/scribe` → re-run any scribe command → expect no re-add (respects user deletion).
-4. `scribe add Naoray/scribe:scribe --yes --json` → expect success, `scribe list --json` shows the skill, `~/.claude/skills/scribe` symlink exists.
+2. Existing config with only the 3 old builtins → run any scribe command → expect stderr banner announcing `Naoray/scribe` added; re-run → no banner.
+3. `scribe add Naoray/scribe:scribe-agent --yes --json` → expect clean JSON on stdout, banner on stderr, `scribe list --json` shows the skill, `~/.claude/skills/scribe-agent` symlink exists.
+4. `scribe sync --json` immediately after install → expect no-op (not a false "missing upstream" update), verifying the `blobsha.go` fix.
 
 ## Migration / backwards compatibility
 
-- Existing `config.yaml` files without `seen_builtins` key load cleanly (omitempty + empty slice).
-- After first run against the new binary, `seen_builtins` appears in the persisted config.
-- Downgrading scribe after seeing the new key is safe — old scribe versions ignore unknown YAML keys per `yaml.v3` defaults.
+- Existing `config.yaml` files without `builtins_version` key load cleanly (omitempty + zero value). Zero triggers backfill on next command.
+- After first run against the new binary, `builtins_version: 2` appears in the persisted config.
+- Downgrading scribe after `builtins_version` is written is safe — old scribe versions ignore unknown YAML keys per `yaml.v3` defaults. The only quirk is that downgraded scribe won't know it's behind if the user later upgrades to a version with `currentBuiltinsVersion = 3`; that's a non-issue because the upgraded binary will still see `builtins_version: 2 < 3` and backfill correctly.
 - No state migration, no on-disk store migration, no breaking change to existing commands.
 
 ## Implementation subtasks (for the plan)
 
 1. Verify exact JSON output shapes of each command listed in the skill body.
-2. Write `SKILL.md` at repo root with the finalized content from Section 1.
-3. `internal/provider/treescan.go`: fix root-level `skillPath`.
-4. `internal/provider/github.go`: add single-file fetch branch.
-5. `internal/config/config.go`: add `SeenBuiltins` field.
-6. `internal/firstrun/firstrun.go`: rewrite `ApplyBuiltins` signature + semantics.
-7. `cmd/root.go`: move `ApplyBuiltins` out of first-run gate, add net-new banner branch.
-8. All tests from Testing section.
-9. Manual verification walkthrough.
-10. Commit + PR (squash merge to main per project convention).
+2. `internal/provider/treescan.go`: fix root-level `skillPath` (`"."` → `"SKILL.md"`).
+3. `internal/provider/github.go`: add single-file fetch branch using `path.Base(skillPath) == "SKILL.md"` discriminator.
+4. `internal/sync/blobsha.go`: fix `resolveSkillBlobSHA` for single-file entries.
+5. `internal/config/config.go`: add `BuiltinsVersion int` field.
+6. `internal/firstrun/firstrun.go`: add `currentBuiltinsVersion` const, add `Naoray/scribe` to `builtinRepos`, rewrite `ApplyBuiltins` as version-gated diff.
+7. `cmd/root.go`: move `ApplyBuiltins` out of first-run gate; print banner to stderr.
+8. Write `SKILL.md` at repo root with the finalized content from Section 1 (including `name: scribe-agent` frontmatter).
+9. All tests from Testing section.
+10. Manual verification walkthrough.
+11. Commit in ordered phases per project commit discipline (one commit per logical phase: tree-scan fix, single-file fetch, blobsha fix, builtins version gate, banner move, skill content). PR squash-merged to main.
 
-## Open questions resolved during brainstorming
+## Open questions resolved during brainstorming + counselors review
 
 - **Skill location:** SKILL.md at repo root, no scribe.yaml / marketplace.json. Forces fix of latent single-file-skill bug.
-- **Default registry mechanism:** builtin list + `SeenBuiltins` diff — backfills existing users, respects deletions.
+- **Skill name:** `scribe-agent`, not `scribe`. Avoids state.json name collision risk and the awkward `scribe add Naoray/scribe:scribe` double-scribe install path.
+- **Fetch discriminator:** `path.Base(skillPath) == "SKILL.md"`, not `HasSuffix(".md")`. Precise, avoids `foo.md` directory edge case.
+- **Blob-SHA resolution:** `resolveSkillBlobSHA` needs a parallel branch for single-file entries — otherwise sync falsely classifies installed single-file skills as "missing upstream" every run.
+- **Default registry mechanism:** version-gated marker (`BuiltinsVersion int`), not per-repo `SeenBuiltins`. Simpler schema, matches what the codebase can actually test today (no `registry remove` command exists).
+- **Banner location:** stderr, not stdout. Prevents `--json` output corruption for agents running in PTYs.
 - **Team/community type:** out of scope; reject the distinction in principle (see `feedback_registry_private_public.md`) but don't refactor in this spec.
 - **Local registry index:** out of scope, separate future spec (`project_local_registry_index.md`).
+
+## Counselors review
+
+Reviewed by claude-opus + codex-5.3-high (gemini-3-flash quota-exhausted) on 2026-04-11. Outputs archived at `agents/counselors/1775931960-review-request-question-is-the-three-pa/`. Key findings incorporated into this revision:
+
+- **Critical:** codex caught `internal/sync/blobsha.go:26` breaking for single-file skills. Fix added as Change 3 in Section 2.
+- **High:** both agents flagged `HasSuffix(".md")` as fragile. Replaced with `path.Base() == "SKILL.md"`.
+- **High:** both agents flagged `SeenBuiltins` as over-designed for untestable deletion semantics. Replaced with `BuiltinsVersion int`.
+- **Medium:** both agents flagged banner-on-stdout as a JSON-corruption risk for agent callers. Moved to stderr.
+- **Medium:** both agents flagged `scribe:scribe` name collision risk. Renamed to `scribe-agent`.
+- **Factual correction:** my original narrative claimed `Path: "."` makes `FetchDirectory` "pull the whole repo". Wrong — it actually errors with `no files found under "."`. Corrected.
+- **Rejected:** codex recommended splitting into three PRs. Siding with claude: the three changes are too tightly coupled to land usefully apart. Ship as one PR with ordered commits per project commit discipline.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	Tools      []ToolConfig     `yaml:"tools,omitempty"`
 	Editor     string           `yaml:"editor,omitempty"`
 	Adoption   AdoptionConfig   `yaml:"adoption,omitempty"`
+	BuiltinsVersion int         `yaml:"builtins_version,omitempty"`
 }
 
 // TeamRepos returns the list of enabled registry repos.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,9 +3,11 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Naoray/scribe/internal/config"
+	"gopkg.in/yaml.v3"
 )
 
 func setupHome(t *testing.T) string {
@@ -269,6 +271,36 @@ token: yaml_token
 	}
 	if cfg.Token != "yaml_token" {
 		t.Errorf("expected YAML token, got %q", cfg.Token)
+	}
+}
+
+func TestConfig_BuiltinsVersion_RoundTripsThroughYAML(t *testing.T) {
+	cfg := &config.Config{BuiltinsVersion: 2}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), "builtins_version: 2") {
+		t.Errorf("yaml output missing builtins_version: %s", data)
+	}
+
+	var decoded config.Config
+	if err := yaml.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.BuiltinsVersion != 2 {
+		t.Errorf("want 2, got %d", decoded.BuiltinsVersion)
+	}
+}
+
+func TestConfig_BuiltinsVersion_OmittedWhenZero(t *testing.T) {
+	cfg := &config.Config{}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "builtins_version") {
+		t.Errorf("zero builtins_version should be omitted; got: %s", data)
 	}
 }
 

--- a/internal/firstrun/firstrun.go
+++ b/internal/firstrun/firstrun.go
@@ -16,12 +16,16 @@ import (
 	"github.com/Naoray/scribe/internal/tools"
 )
 
-// builtinRepos are well-known community registries auto-added during first run.
+// builtinRepos are well-known public registries auto-added during first run.
 var builtinRepos = []string{
+	"Naoray/scribe",
 	"anthropic/skills",
 	"openai/codex-skills",
 	"expo/skills",
 }
+
+// currentBuiltinsVersion bumps whenever builtinRepos changes.
+const currentBuiltinsVersion = 2
 
 // BuiltinRegistries returns RegistryConfig entries for built-in registries.
 func BuiltinRegistries() []config.RegistryConfig {
@@ -123,10 +127,18 @@ func promptYN(in io.Reader, out io.Writer, question string, defaultYes bool) boo
 }
 
 // ApplyBuiltins adds built-in registries to the config if not already present.
-func ApplyBuiltins(cfg *config.Config) {
+func ApplyBuiltins(cfg *config.Config) []string {
+	if cfg.BuiltinsVersion >= currentBuiltinsVersion {
+		return nil
+	}
+
+	var added []string
 	for _, builtin := range BuiltinRegistries() {
 		if cfg.FindRegistry(builtin.Repo) == nil {
 			cfg.AddRegistry(builtin)
+			added = append(added, builtin.Repo)
 		}
 	}
+	cfg.BuiltinsVersion = currentBuiltinsVersion
+	return added
 }

--- a/internal/firstrun/firstrun_internal_test.go
+++ b/internal/firstrun/firstrun_internal_test.go
@@ -1,0 +1,19 @@
+package firstrun
+
+import (
+	"testing"
+
+	"github.com/Naoray/scribe/internal/config"
+)
+
+func TestApplyBuiltins_AlreadyCurrentIsNoop(t *testing.T) {
+	cfg := &config.Config{BuiltinsVersion: currentBuiltinsVersion}
+	added := ApplyBuiltins(cfg)
+
+	if len(added) != 0 {
+		t.Errorf("no-op expected, got %v", added)
+	}
+	if len(cfg.Registries) != 0 {
+		t.Errorf("no registries should be appended when already current; got %v", cfg.Registries)
+	}
+}

--- a/internal/firstrun/firstrun_test.go
+++ b/internal/firstrun/firstrun_test.go
@@ -63,3 +63,53 @@ func TestApplyBuiltinsIdempotent(t *testing.T) {
 		t.Errorf("expected %d registries after second apply, got %d", count, len(cfg.Registries))
 	}
 }
+
+func TestApplyBuiltins_FirstRunAddsAllAndMarksVersion(t *testing.T) {
+	cfg := &config.Config{}
+	added := firstrun.ApplyBuiltins(cfg)
+
+	if len(added) != 4 {
+		t.Errorf("first run should add 4 builtins, got %d: %v", len(added), added)
+	}
+	if added[0] != "Naoray/scribe" {
+		t.Errorf("Naoray/scribe must be first in builtin order, got %q", added[0])
+	}
+	if cfg.BuiltinsVersion == 0 {
+		t.Error("BuiltinsVersion must be set after first ApplyBuiltins call")
+	}
+}
+
+func TestApplyBuiltins_ExistingUserGetsNaorayScribeBackfilled(t *testing.T) {
+	cfg := &config.Config{
+		Registries: []config.RegistryConfig{
+			{Repo: "anthropic/skills", Enabled: true, Type: config.RegistryTypeCommunity, Builtin: true},
+			{Repo: "openai/codex-skills", Enabled: true, Type: config.RegistryTypeCommunity, Builtin: true},
+			{Repo: "expo/skills", Enabled: true, Type: config.RegistryTypeCommunity, Builtin: true},
+		},
+	}
+	added := firstrun.ApplyBuiltins(cfg)
+
+	if len(added) != 1 || added[0] != "Naoray/scribe" {
+		t.Errorf("only Naoray/scribe should be backfilled, got %v", added)
+	}
+	if cfg.FindRegistry("Naoray/scribe") == nil {
+		t.Error("Naoray/scribe not in config after backfill")
+	}
+}
+
+func TestApplyBuiltins_DisabledBuiltinNotReEnabled(t *testing.T) {
+	cfg := &config.Config{
+		Registries: []config.RegistryConfig{
+			{Repo: "anthropic/skills", Enabled: false, Type: config.RegistryTypeCommunity, Builtin: true},
+		},
+	}
+	_ = firstrun.ApplyBuiltins(cfg)
+
+	r := cfg.FindRegistry("anthropic/skills")
+	if r == nil {
+		t.Fatal("anthropic/skills should still be present")
+	}
+	if r.Enabled {
+		t.Error("disabled builtin must not be flipped back to enabled")
+	}
+}

--- a/internal/logo/logo_test.go
+++ b/internal/logo/logo_test.go
@@ -8,7 +8,16 @@ import (
 	"github.com/Naoray/scribe/internal/logo"
 )
 
+func resetLogoEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("TERM", "")
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("SCRIBE_NO_BANNER", "")
+}
+
 func TestRenderFull(t *testing.T) {
+	resetLogoEnv(t)
+
 	var buf bytes.Buffer
 	logo.Render(&buf, "1.0.0", 80)
 
@@ -22,6 +31,8 @@ func TestRenderFull(t *testing.T) {
 }
 
 func TestRenderCompact(t *testing.T) {
+	resetLogoEnv(t)
+
 	var buf bytes.Buffer
 	logo.Render(&buf, "1.0.0", 50)
 
@@ -35,6 +46,8 @@ func TestRenderCompact(t *testing.T) {
 }
 
 func TestRenderPlainText(t *testing.T) {
+	resetLogoEnv(t)
+
 	var buf bytes.Buffer
 	logo.Render(&buf, "2.0.0", 30)
 
@@ -48,6 +61,7 @@ func TestRenderPlainText(t *testing.T) {
 }
 
 func TestRenderNoColor(t *testing.T) {
+	resetLogoEnv(t)
 	t.Setenv("NO_COLOR", "1")
 
 	var buf bytes.Buffer
@@ -64,6 +78,7 @@ func TestRenderNoColor(t *testing.T) {
 }
 
 func TestRenderDumbTerminal(t *testing.T) {
+	resetLogoEnv(t)
 	t.Setenv("TERM", "dumb")
 
 	var buf bytes.Buffer
@@ -79,6 +94,7 @@ func TestRenderDumbTerminal(t *testing.T) {
 }
 
 func TestRenderNoBanner(t *testing.T) {
+	resetLogoEnv(t)
 	t.Setenv("SCRIBE_NO_BANNER", "1")
 
 	var buf bytes.Buffer
@@ -91,6 +107,8 @@ func TestRenderNoBanner(t *testing.T) {
 }
 
 func TestRenderZeroWidth(t *testing.T) {
+	resetLogoEnv(t)
+
 	var buf bytes.Buffer
 	logo.Render(&buf, "1.0.0", 0)
 

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"path"
 
 	gh "github.com/Naoray/scribe/internal/github"
 	"github.com/Naoray/scribe/internal/manifest"
@@ -185,6 +186,14 @@ func (p *GitHubProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]Fil
 	skillPath := entry.Path
 	if skillPath == "" {
 		skillPath = entry.Name
+	}
+
+	if path.Base(skillPath) == skillFileName {
+		data, err := p.client.FetchFile(ctx, src.Owner, src.Repo, skillPath, src.Ref)
+		if err != nil {
+			return nil, err
+		}
+		return []File{{Path: skillFileName, Content: data}}, nil
 	}
 
 	ghFiles, err := p.client.FetchDirectory(ctx, src.Owner, src.Repo, skillPath, src.Ref)

--- a/internal/provider/github_fetch_test.go
+++ b/internal/provider/github_fetch_test.go
@@ -1,0 +1,60 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+func TestGitHubProvider_Fetch_SingleFileSkill(t *testing.T) {
+	client := &stubClient{
+		files: map[string][]byte{
+			"Naoray/scribe/SKILL.md": []byte("---\nname: scribe-agent\n---\nbody\n"),
+		},
+	}
+	p := provider.NewGitHubProvider(client)
+
+	entry := manifest.Entry{
+		Name:   "scribe-agent",
+		Source: "github:Naoray/scribe@HEAD",
+		Path:   "SKILL.md",
+	}
+	files, err := p.Fetch(context.Background(), entry)
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("want 1 file, got %d", len(files))
+	}
+	if files[0].Path != "SKILL.md" {
+		t.Errorf("single-file skill must normalize Path to \"SKILL.md\", got %q", files[0].Path)
+	}
+	if len(files[0].Content) == 0 {
+		t.Errorf("content empty")
+	}
+}
+
+func TestGitHubProvider_Fetch_DirectoryNamedFooMd_IsNotSingleFile(t *testing.T) {
+	client := &stubClient{
+		dirs: map[string][]tools.SkillFile{
+			"Naoray/scribe/foo.md": {{Path: "SKILL.md", Content: []byte("x")}},
+		},
+	}
+	p := provider.NewGitHubProvider(client)
+
+	entry := manifest.Entry{
+		Name:   "foo",
+		Source: "github:Naoray/scribe@HEAD",
+		Path:   "foo.md",
+	}
+	files, err := p.Fetch(context.Background(), entry)
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+	if len(files) != 1 || files[0].Path != "SKILL.md" {
+		t.Errorf("directory fetch should return files from FetchDirectory, got %+v", files)
+	}
+}

--- a/internal/provider/treescan.go
+++ b/internal/provider/treescan.go
@@ -28,9 +28,9 @@ func ScanTreeForSkills(tree []TreeEntry, owner, repo string) []manifest.Entry {
 		dir := path.Dir(entry.Path)
 		var name, skillPath string
 		if dir == "." {
-			// Root-level SKILL.md — use repo name.
+			// Root-level SKILL.md — use repo name and record the file path.
 			name = repo
-			skillPath = "."
+			skillPath = skillFileName
 		} else {
 			// Name is the immediate parent dir.
 			name = path.Base(dir)

--- a/internal/provider/treescan_root_test.go
+++ b/internal/provider/treescan_root_test.go
@@ -1,0 +1,38 @@
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/Naoray/scribe/internal/provider"
+)
+
+func TestScanTreeForSkills_RootLevelPath(t *testing.T) {
+	tree := []provider.TreeEntry{
+		{Path: "SKILL.md", Type: "blob", SHA: "abc"},
+	}
+
+	entries := provider.ScanTreeForSkills(tree, "Naoray", "scribe")
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	if entries[0].Path != "SKILL.md" {
+		t.Errorf("root-level entry should record Path=\"SKILL.md\", got %q", entries[0].Path)
+	}
+	if entries[0].Name != "scribe" {
+		t.Errorf("root-level entry Name should fall back to repo name, got %q", entries[0].Name)
+	}
+}
+
+func TestScanTreeForSkills_NoEntryWithDotPath(t *testing.T) {
+	tree := []provider.TreeEntry{
+		{Path: "SKILL.md", Type: "blob", SHA: "abc"},
+		{Path: "sub/SKILL.md", Type: "blob", SHA: "def"},
+	}
+
+	entries := provider.ScanTreeForSkills(tree, "Naoray", "scribe")
+	for _, entry := range entries {
+		if entry.Path == "." {
+			t.Errorf("no catalog entry should use Path=\".\"; got entry %+v", entry)
+		}
+	}
+}

--- a/internal/sync/blobsha.go
+++ b/internal/sync/blobsha.go
@@ -23,7 +23,7 @@ func resolveSkillBlobSHA(tree []provider.TreeEntry, entry manifest.Entry) (strin
 	}
 	skillPath = strings.TrimSuffix(skillPath, "/")
 	target := "SKILL.md"
-	if skillPath != "" && skillPath != "." {
+	if skillPath != "" && skillPath != "." && skillPath != "SKILL.md" {
 		target = skillPath + "/SKILL.md"
 	}
 	for _, e := range tree {

--- a/internal/sync/blobsha_test.go
+++ b/internal/sync/blobsha_test.go
@@ -52,6 +52,12 @@ func TestResolveSkillBlobSHA(t *testing.T) {
 			found: true,
 		},
 		{
+			name:  "handles root-level skill file path",
+			entry: manifest.Entry{Name: "repo-skill", Path: "SKILL.md"},
+			want:  "rootsha",
+			found: true,
+		},
+		{
 			name:  "ignores tree entries (only blobs)",
 			entry: manifest.Entry{Name: "skills", Path: "skills"},
 			want:  "",


### PR DESCRIPTION
## Summary
- add root-level single-file skill support across tree scan, GitHub fetch, and sync blob-SHA resolution
- backfill  as a versioned builtin and keep first-run/backfill banners off JSON stdout
- ship the repo-root  plus regression coverage for direct install, provider/firstrun/root behavior, and logo env-sensitive tests

## Test Plan
- go test ./...
- go run ./cmd/scribe add --help
- go run ./cmd/scribe list --help
- go run ./cmd/scribe sync --help
- go run ./cmd/scribe adopt --help
- go run ./cmd/scribe remove --help
- go run ./cmd/scribe explain --help
- go run ./cmd/scribe status --help
- go run ./cmd/scribe registry add --help