### PR TITLE
refactor: symlink Claude skills dir instead of SKILL.md file

### DIFF
--- a/internal/adopt/adopt_test.go
+++ b/internal/adopt/adopt_test.go
@@ -626,15 +626,14 @@ func TestApply_RealDirectoryAdoption(t *testing.T) {
 		t.Errorf("expected symlink at %s, got mode %v", claudeLink, info.Mode())
 	}
 
-	// The symlink must point into the canonical store.
+	// The symlink must point into the canonical store directory.
 	target, err := os.Readlink(claudeLink)
 	if err != nil {
 		t.Fatalf("readlink: %v", err)
 	}
 	storeSkillDir := filepath.Join(home, ".scribe", "skills", "commit")
-	wantTarget := filepath.Join(storeSkillDir, "SKILL.md")
-	if target != wantTarget {
-		t.Errorf("symlink target = %q, want %q", target, wantTarget)
+	if target != storeSkillDir {
+		t.Errorf("symlink target = %q, want %q", target, storeSkillDir)
 	}
 
 	// Canonical store must have SKILL.md.

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -44,6 +44,42 @@ func TestReconcileRepairsMissingCodexProjection(t *testing.T) {
 	}
 }
 
+func TestReconcileClaudeUnchangedOnSecondPass(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	canonical, err := tools.WriteToStore("recap", []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}})
+	if err != nil {
+		t.Fatalf("WriteToStore: %v", err)
+	}
+	canonical, _ = filepath.EvalSymlinks(canonical)
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"recap": {Revision: 1, Tools: []string{"claude"}, ToolsMode: state.ToolsModePinned},
+	}}
+
+	engine := reconcile.Engine{Tools: []tools.Tool{tools.ClaudeTool{}}, Now: func() time.Time { return time.Unix(1, 0).UTC() }}
+	if _, _, err := engine.Run(st); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+
+	link := filepath.Join(home, ".claude", "skills", "recap")
+	if resolved, err := filepath.EvalSymlinks(link); err != nil || resolved != canonical {
+		t.Fatalf("claude skill link = %q, %v; want %q", resolved, err, canonical)
+	}
+
+	summary, actions, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if summary.Installed != 0 || summary.Relinked != 0 || len(summary.Conflicts) != 0 {
+		t.Fatalf("second pass summary = %+v, want no changes", summary)
+	}
+	if len(actions) != 1 || actions[0].Kind != reconcile.ActionUnchanged {
+		t.Fatalf("actions = %+v, want single Unchanged", actions)
+	}
+}
+
 func TestReconcileNormalizesSameHashDirectory(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/tools/claude.go
+++ b/internal/tools/claude.go
@@ -11,9 +11,9 @@ import (
 // toolClaude is the identifier for the Claude Code tool.
 const toolClaude = "claude"
 
-// ClaudeTool symlinks ~/.claude/skills/<name> → ~/.scribe/skills/<name>/SKILL.md.
-// Only the SKILL.md file is linked, so Claude Code does not see internal files
-// like .scribe-base.md or versions/.
+// ClaudeTool symlinks ~/.claude/skills/<name> → ~/.scribe/skills/<name>/.
+// Claude Code expects a directory containing SKILL.md — a file symlink would
+// appear as a bare file and not be recognised as a skill.
 type ClaudeTool struct{}
 
 func (t ClaudeTool) Name() string { return toolClaude }
@@ -37,7 +37,7 @@ func (t ClaudeTool) Install(skillName, canonicalDir string) ([]string, error) {
 	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create claude skills dir: %w", err)
 	}
-	if err := replaceSymlink(link, filepath.Join(canonicalDir, "SKILL.md")); err != nil {
+	if err := replaceSymlink(link, canonicalDir); err != nil {
 		return nil, fmt.Errorf("symlink claude/%s: %w", skillName, err)
 	}
 	return []string{link}, nil

--- a/internal/tools/claude.go
+++ b/internal/tools/claude.go
@@ -69,7 +69,7 @@ func (t ClaudeTool) SkillPath(skillName string) (string, error) {
 }
 
 func (t ClaudeTool) CanonicalTarget(canonicalDir string) (string, bool) {
-	return filepath.Join(canonicalDir, "SKILL.md"), true
+	return canonicalDir, true
 }
 
 func claudeSkillsDir() (string, error) {

--- a/internal/tools/claude_test.go
+++ b/internal/tools/claude_test.go
@@ -21,7 +21,7 @@ func TestClaudeSkillPath(t *testing.T) {
 	}
 }
 
-func TestClaudeInstallSymlinksToFile(t *testing.T) {
+func TestClaudeInstallSymlinksToDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -40,11 +40,6 @@ func TestClaudeInstallSymlinksToFile(t *testing.T) {
 	if err := os.WriteFile(skillMD, []byte("# Cleanup"), 0o644); err != nil {
 		t.Fatalf("write SKILL.md: %v", err)
 	}
-	// Also write .scribe-base.md to verify it's NOT visible through the symlink.
-	baseMD := filepath.Join(canonicalDir, ".scribe-base.md")
-	if err := os.WriteFile(baseMD, []byte("# Cleanup"), 0o644); err != nil {
-		t.Fatalf("write .scribe-base.md: %v", err)
-	}
 
 	tool := ClaudeTool{}
 	paths, err := tool.Install("cleanup", canonicalDir)
@@ -58,23 +53,28 @@ func TestClaudeInstallSymlinksToFile(t *testing.T) {
 
 	link := paths[0]
 
-	// Verify symlink target points to SKILL.md file, not the directory.
+	// Verify symlink target points to the canonical directory.
 	target, err := os.Readlink(link)
 	if err != nil {
 		t.Fatalf("readlink: %v", err)
 	}
 
-	wantTarget := filepath.Join(canonicalDir, "SKILL.md")
-	if target != wantTarget {
-		t.Errorf("symlink target = %q, want %q", target, wantTarget)
+	if target != canonicalDir {
+		t.Errorf("symlink target = %q, want %q", target, canonicalDir)
 	}
 
-	// Verify the symlink resolves to a file, not a directory.
+	// Verify the symlink resolves to a directory (Claude Code expects this).
 	info, err := os.Stat(link)
 	if err != nil {
 		t.Fatalf("stat symlink: %v", err)
 	}
-	if info.IsDir() {
-		t.Error("symlink should resolve to a file, not a directory")
+	if !info.IsDir() {
+		t.Error("symlink should resolve to a directory, not a file")
+	}
+
+	// Verify SKILL.md is accessible through the symlink.
+	linkedSkillMD := filepath.Join(link, "SKILL.md")
+	if _, err := os.Stat(linkedSkillMD); err != nil {
+		t.Errorf("SKILL.md not accessible through symlink: %v", err)
 	}
 }

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -66,20 +66,19 @@ func TestClaudeInstall(t *testing.T) {
 		t.Fatalf("expected 1 symlink path, got %d", len(paths))
 	}
 
-	// Link resolves to SKILL.md file, not the directory.
+	// Link resolves to the canonical directory (Claude Code expects a dir with SKILL.md inside).
 	resolved, err := os.Readlink(paths[0])
 	if err != nil {
 		t.Fatalf("Readlink: %v", err)
 	}
-	wantTarget := filepath.Join(canonicalDir, "SKILL.md")
-	if resolved != wantTarget {
-		t.Errorf("symlink points to %q, want %q", resolved, wantTarget)
+	if resolved != canonicalDir {
+		t.Errorf("symlink points to %q, want %q", resolved, canonicalDir)
 	}
 
-	// Content accessible through the symlink.
-	content, err := os.ReadFile(paths[0])
+	// SKILL.md accessible through the directory symlink.
+	content, err := os.ReadFile(filepath.Join(paths[0], "SKILL.md"))
 	if err != nil {
-		t.Fatalf("read through symlink: %v", err)
+		t.Fatalf("read SKILL.md through symlink: %v", err)
 	}
 	if len(content) == 0 {
 		t.Error("SKILL.md content empty through symlink")


### PR DESCRIPTION
## Summary
- Symlink `~/.claude/skills/<name>/` → canonical skill dir (previously linked to the `SKILL.md` file).
- Claude Code expects a directory containing `SKILL.md` — a file at that path was not being recognised as a skill.
- Updates `internal/tools` + `internal/adopt` tests to the new shape.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/tools/... ./internal/adopt/...`
- [ ] Manually install a skill and confirm Claude Code lists it