### PR TITLE
docs: agent-first CLI design + nono-inspired patterns plan

### DIFF
--- a/docs/superpowers/plans/2026-04-14-nono-inspired-patterns.md
+++ b/docs/superpowers/plans/2026-04-14-nono-inspired-patterns.md
@@ -1,0 +1,1561 @@
+# Nono-Inspired Patterns for Scribe — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adopt three high-leverage patterns from nono-cli that accelerate Scribe's agentic-first pivot: Claude Code hook integration (agent bridge), embedded registry catalog (zero-network first-run), and three-state config layering.
+
+**Architecture:** Each pattern is independent and ships as its own commit/PR. The hook integration is highest leverage — it makes agents aware of Scribe automatically. Embedded catalogs eliminate network dependency for discovery. Config layering enables project-level overrides without breaking the single-file model.
+
+**Tech Stack:** Go 1.26.1, Cobra, `encoding/json`, `os/exec`, `embed` stdlib package.
+
+---
+
+## File Map
+
+```
+internal/
+  hooks/
+    hooks.go              # NEW — hook installer (Claude Code settings.json writer)
+    hooks_test.go         # NEW — hook installer tests
+    scripts/
+      scribe-hook.sh      # NEW — embedded hook script for Claude Code
+  tools/
+    claude.go             # MODIFY — add CanonicalTarget() method
+  config/
+    config.go             # MODIFY — add Hooks field, project-level layering
+    config_test.go        # MODIFY — tests for new config fields
+    layered.go            # NEW — three-state merge logic
+    layered_test.go       # NEW — merge logic tests
+  embed/
+    embed.go              # NEW — embedded catalog registry data
+    catalog.json          # NEW — default embedded catalog
+cmd/
+  hooks.go                # NEW — `scribe hooks install/uninstall/status` command
+  hooks_test.go           # NEW — command tests
+```
+
+---
+
+## Task 1: Claude Code Hook Script
+
+The hook script is the bridge between Scribe and Claude Code. When a tool use fails inside Claude Code, this hook fires and tells the agent about Scribe's capabilities — what skills are installed, what's available, and how to sync.
+
+**Files:**
+- Create: `internal/hooks/scripts/scribe-hook.sh`
+
+- [ ] **Step 1: Write the hook script**
+
+This script runs as a `PostToolUseFailure` hook in Claude Code. It checks if scribe is installed, gathers skill state, and returns structured JSON that Claude Code injects into the agent's context.
+
+```bash
+#!/usr/bin/env bash
+# scribe-hook.sh — Claude Code PostToolUseFailure hook
+# Surfaces Scribe skill inventory to the agent when a tool use fails.
+# Output: JSON with hookSpecificOutput.additionalContext for Claude Code.
+
+set -euo pipefail
+
+# Only act if scribe is available
+if ! command -v scribe &>/dev/null; then
+  exit 0
+fi
+
+# Gather installed skill list (fast, local-only)
+SKILLS=$(scribe list --json 2>/dev/null || echo '[]')
+
+# Count skills by status
+INSTALLED=$(echo "$SKILLS" | jq 'length // 0' 2>/dev/null || echo 0)
+
+# Check if any registries are connected
+HAS_REGISTRY=$(scribe registry list --json 2>/dev/null | jq 'length > 0' 2>/dev/null || echo false)
+
+# Build context message
+CONTEXT="Scribe skill manager is available on this machine. "
+CONTEXT+="$INSTALLED skills currently installed. "
+
+if [ "$HAS_REGISTRY" = "true" ]; then
+  CONTEXT+="Team registries connected — run 'scribe sync' to update skills. "
+  CONTEXT+="Run 'scribe add <query>' to search and install skills from registries. "
+else
+  CONTEXT+="No registries connected — run 'scribe registry connect <owner/repo>' to add one. "
+fi
+
+CONTEXT+="Run 'scribe list' to see installed skills. "
+CONTEXT+="Run 'scribe status' to check for available updates."
+
+# Output structured JSON for Claude Code hook system
+jq -n --arg ctx "$CONTEXT" '{
+  hookSpecificOutput: {
+    additionalContext: $ctx
+  }
+}'
+```
+
+- [ ] **Step 2: Verify script is valid bash**
+
+Run: `bash -n internal/hooks/scripts/scribe-hook.sh`
+Expected: No output (valid syntax)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/hooks/scripts/scribe-hook.sh
+git commit -m "feat: add Claude Code hook script for agent bridge
+
+Surfaces Scribe skill inventory to agents via PostToolUseFailure hook.
+Returns structured JSON with hookSpecificOutput.additionalContext."
+```
+
+---
+
+## Task 2: Hook Installer Package
+
+The installer reads Claude Code's `~/.claude/settings.json`, adds the hook entry, and writes the script to `~/.claude/hooks/`. Follows nono's pattern of embedding the script in the binary.
+
+**Files:**
+- Create: `internal/hooks/hooks.go`
+- Create: `internal/hooks/hooks_test.go`
+
+- [ ] **Step 1: Write the failing test for hook installation**
+
+```go
+package hooks_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/hooks"
+)
+
+func TestInstallClaudeHook(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create .claude dir (simulates Claude Code installed)
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := hooks.InstallClaude()
+	if err != nil {
+		t.Fatalf("InstallClaude() error: %v", err)
+	}
+
+	if result.Status != hooks.Installed {
+		t.Errorf("status = %v, want Installed", result.Status)
+	}
+
+	// Verify hook script written
+	scriptPath := filepath.Join(claudeDir, "hooks", "scribe-hook.sh")
+	info, err := os.Stat(scriptPath)
+	if err != nil {
+		t.Fatalf("hook script not found: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Error("hook script not executable")
+	}
+
+	// Verify settings.json updated
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("settings.json not found: %v", err)
+	}
+	if !contains(data, "scribe-hook.sh") {
+		t.Error("settings.json does not reference scribe-hook.sh")
+	}
+}
+
+func TestInstallClaudeHook_AlreadyInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Install once
+	if _, err := hooks.InstallClaude(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Install again — should report AlreadyInstalled
+	result, err := hooks.InstallClaude()
+	if err != nil {
+		t.Fatalf("second InstallClaude() error: %v", err)
+	}
+	if result.Status != hooks.AlreadyInstalled {
+		t.Errorf("status = %v, want AlreadyInstalled", result.Status)
+	}
+}
+
+func TestInstallClaudeHook_NoClaude(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// No .claude dir — should return error
+	_, err := hooks.InstallClaude()
+	if err == nil {
+		t.Fatal("expected error when .claude dir missing")
+	}
+}
+
+func TestUninstallClaudeHook(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Install then uninstall
+	if _, err := hooks.InstallClaude(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := hooks.UninstallClaude(); err != nil {
+		t.Fatalf("UninstallClaude() error: %v", err)
+	}
+
+	// Script should be gone
+	scriptPath := filepath.Join(claudeDir, "hooks", "scribe-hook.sh")
+	if _, err := os.Stat(scriptPath); !os.IsNotExist(err) {
+		t.Error("hook script still exists after uninstall")
+	}
+
+	// settings.json should not reference scribe
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		if contains(data, "scribe-hook.sh") {
+			t.Error("settings.json still references scribe-hook.sh after uninstall")
+		}
+	}
+}
+
+func contains(data []byte, s string) bool {
+	return len(data) > 0 && len(s) > 0 && string(data) != "" && indexOf(data, s) >= 0
+}
+
+func indexOf(data []byte, s string) int {
+	for i := 0; i <= len(data)-len(s); i++ {
+		if string(data[i:i+len(s)]) == s {
+			return i
+		}
+	}
+	return -1
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go test ./internal/hooks/ -v -run TestInstall`
+Expected: FAIL — package does not exist
+
+- [ ] **Step 3: Implement the hook installer**
+
+```go
+package hooks
+
+import (
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+//go:embed scripts/scribe-hook.sh
+var hookScript []byte
+
+// InstallStatus describes the outcome of a hook installation.
+type InstallStatus int
+
+const (
+	Installed        InstallStatus = iota // freshly installed
+	AlreadyInstalled                      // hook already present, no changes
+	Updated                              // hook script updated to newer version
+)
+
+func (s InstallStatus) String() string {
+	switch s {
+	case Installed:
+		return "installed"
+	case AlreadyInstalled:
+		return "already_installed"
+	case Updated:
+		return "updated"
+	default:
+		return "unknown"
+	}
+}
+
+// InstallResult reports what happened during installation.
+type InstallResult struct {
+	Status     InstallStatus
+	ScriptPath string
+}
+
+const (
+	hookFileName = "scribe-hook.sh"
+	hookEvent    = "PostToolUseFailure"
+)
+
+// InstallClaude installs the Scribe hook into Claude Code's settings.
+// Creates ~/.claude/hooks/scribe-hook.sh and registers it in ~/.claude/settings.json.
+func InstallClaude() (InstallResult, error) {
+	claudeDir, err := claudeDir()
+	if err != nil {
+		return InstallResult{}, err
+	}
+
+	if _, err := os.Stat(claudeDir); err != nil {
+		return InstallResult{}, fmt.Errorf("claude code not detected (~/.claude missing): %w", err)
+	}
+
+	// Write hook script
+	hooksDir := filepath.Join(claudeDir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		return InstallResult{}, fmt.Errorf("create hooks dir: %w", err)
+	}
+
+	scriptPath := filepath.Join(hooksDir, hookFileName)
+	existing, readErr := os.ReadFile(scriptPath)
+	scriptExists := readErr == nil
+
+	// Check if script content matches (for AlreadyInstalled vs Updated)
+	if scriptExists && string(existing) == string(hookScript) {
+		// Script identical — check settings.json too
+		if settingsHasHook(claudeDir) {
+			return InstallResult{Status: AlreadyInstalled, ScriptPath: scriptPath}, nil
+		}
+	}
+
+	if err := os.WriteFile(scriptPath, hookScript, 0o755); err != nil {
+		return InstallResult{}, fmt.Errorf("write hook script: %w", err)
+	}
+
+	// Update settings.json
+	if err := addHookToSettings(claudeDir); err != nil {
+		return InstallResult{}, fmt.Errorf("update settings.json: %w", err)
+	}
+
+	status := Installed
+	if scriptExists {
+		status = Updated
+	}
+	return InstallResult{Status: status, ScriptPath: scriptPath}, nil
+}
+
+// UninstallClaude removes the Scribe hook from Claude Code.
+func UninstallClaude() error {
+	claudeDir, err := claudeDir()
+	if err != nil {
+		return err
+	}
+
+	// Remove script
+	scriptPath := filepath.Join(claudeDir, "hooks", hookFileName)
+	if err := os.Remove(scriptPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove hook script: %w", err)
+	}
+
+	// Remove from settings.json
+	return removeHookFromSettings(claudeDir)
+}
+
+// Status checks whether the Scribe hook is installed in Claude Code.
+func Status() (installed bool, scriptPath string, err error) {
+	claudeDir, err := claudeDir()
+	if err != nil {
+		return false, "", err
+	}
+
+	scriptPath = filepath.Join(claudeDir, "hooks", hookFileName)
+	if _, err := os.Stat(scriptPath); err != nil {
+		return false, "", nil
+	}
+
+	return settingsHasHook(claudeDir), scriptPath, nil
+}
+
+func claudeDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, ".claude"), nil
+}
+
+// --- settings.json helpers ---
+
+// settingsHasHook checks if settings.json already contains our hook.
+func settingsHasHook(claudeDir string) bool {
+	settings, err := readSettings(claudeDir)
+	if err != nil {
+		return false
+	}
+
+	hooksMap, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		return false
+	}
+
+	entries, ok := hooksMap[hookEvent].([]any)
+	if !ok {
+		return false
+	}
+
+	for _, entry := range entries {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		hooksList, ok := entryMap["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, h := range hooksList {
+			hookMap, ok := h.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cmd, ok := hookMap["command"].(string); ok {
+				if filepath.Base(cmd) == hookFileName || cmd == "$HOME/.claude/hooks/"+hookFileName {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// addHookToSettings adds the Scribe hook entry to settings.json.
+// Preserves all existing settings and hooks — only adds our entry.
+func addHookToSettings(claudeDir string) error {
+	settings, err := readSettings(claudeDir)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	if settings == nil {
+		settings = make(map[string]any)
+	}
+
+	// Get or create hooks map
+	hooksMap, _ := settings["hooks"].(map[string]any)
+	if hooksMap == nil {
+		hooksMap = make(map[string]any)
+	}
+
+	// Get or create event entries
+	entries, _ := hooksMap[hookEvent].([]any)
+
+	// Check if we already have a scribe entry
+	found := false
+	for _, entry := range entries {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		hooksList, ok := entryMap["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, h := range hooksList {
+			hookMap, ok := h.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cmd, _ := hookMap["command"].(string); filepath.Base(cmd) == hookFileName {
+				found = true
+				break
+			}
+		}
+		if found {
+			break
+		}
+	}
+
+	if !found {
+		newEntry := map[string]any{
+			"matcher": ".*",
+			"hooks": []any{
+				map[string]any{
+					"type":    "command",
+					"command": "$HOME/.claude/hooks/" + hookFileName,
+				},
+			},
+		}
+		entries = append(entries, newEntry)
+	}
+
+	hooksMap[hookEvent] = entries
+	settings["hooks"] = hooksMap
+
+	return writeSettings(claudeDir, settings)
+}
+
+// removeHookFromSettings removes the Scribe hook entry from settings.json.
+func removeHookFromSettings(claudeDir string) error {
+	settings, err := readSettings(claudeDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	hooksMap, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	entries, ok := hooksMap[hookEvent].([]any)
+	if !ok {
+		return nil
+	}
+
+	// Filter out scribe entries
+	var filtered []any
+	for _, entry := range entries {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			filtered = append(filtered, entry)
+			continue
+		}
+		hooksList, ok := entryMap["hooks"].([]any)
+		if !ok {
+			filtered = append(filtered, entry)
+			continue
+		}
+
+		var filteredHooks []any
+		for _, h := range hooksList {
+			hookMap, ok := h.(map[string]any)
+			if !ok {
+				filteredHooks = append(filteredHooks, h)
+				continue
+			}
+			cmd, _ := hookMap["command"].(string)
+			if filepath.Base(cmd) != hookFileName {
+				filteredHooks = append(filteredHooks, h)
+			}
+		}
+
+		if len(filteredHooks) > 0 {
+			entryMap["hooks"] = filteredHooks
+			filtered = append(filtered, entryMap)
+		}
+	}
+
+	if len(filtered) == 0 {
+		delete(hooksMap, hookEvent)
+	} else {
+		hooksMap[hookEvent] = filtered
+	}
+
+	if len(hooksMap) == 0 {
+		delete(settings, "hooks")
+	}
+
+	return writeSettings(claudeDir, settings)
+}
+
+func readSettings(claudeDir string) (map[string]any, error) {
+	path := filepath.Join(claudeDir, "settings.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, fmt.Errorf("parse settings.json: %w", err)
+	}
+	return settings, nil
+}
+
+func writeSettings(claudeDir string, settings map[string]any) error {
+	path := filepath.Join(claudeDir, "settings.json")
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode settings.json: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write settings.json: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("save settings.json: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go test ./internal/hooks/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/hooks/hooks.go internal/hooks/hooks_test.go
+git commit -m "feat: add Claude Code hook installer
+
+Installs scribe-hook.sh to ~/.claude/hooks/ and registers it in
+settings.json as a PostToolUseFailure handler. Preserves existing
+settings. Supports install/uninstall/status operations.
+
+Pattern borrowed from nono-cli's hook bridge architecture."
+```
+
+---
+
+## Task 3: `scribe hooks` Command
+
+Cobra command exposing hook management to users and agents.
+
+**Files:**
+- Create: `cmd/hooks.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHooksInstallCommand(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create .claude dir
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := rootCmd
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"hooks", "install", "claude"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("hooks install claude failed: %v", err)
+	}
+}
+
+func TestHooksStatusCommand(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := rootCmd
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"hooks", "status"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("hooks status failed: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go test ./cmd/ -v -run TestHooks`
+Expected: FAIL — command not registered
+
+- [ ] **Step 3: Implement the hooks command**
+
+```go
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/hooks"
+)
+
+var hooksCmd = &cobra.Command{
+	Use:   "hooks",
+	Short: "Manage agent integration hooks",
+	Long:  "Install, uninstall, and check status of hooks that bridge Scribe with AI agents.",
+}
+
+var hooksInstallCmd = &cobra.Command{
+	Use:       "install <target>",
+	Short:     "Install hook for an AI agent",
+	Args:      cobra.ExactArgs(1),
+	ValidArgs: []string{"claude"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		target := args[0]
+		switch target {
+		case "claude":
+			result, err := hooks.InstallClaude()
+			if err != nil {
+				return err
+			}
+			switch result.Status {
+			case hooks.Installed:
+				fmt.Fprintf(cmd.OutOrStdout(), "✓ Hook installed at %s\n", result.ScriptPath)
+			case hooks.AlreadyInstalled:
+				fmt.Fprintln(cmd.OutOrStdout(), "✓ Hook already installed")
+			case hooks.Updated:
+				fmt.Fprintf(cmd.OutOrStdout(), "✓ Hook updated at %s\n", result.ScriptPath)
+			}
+			return nil
+		default:
+			return fmt.Errorf("unsupported target: %s (available: claude)", target)
+		}
+	},
+}
+
+var hooksUninstallCmd = &cobra.Command{
+	Use:       "uninstall <target>",
+	Short:     "Remove hook for an AI agent",
+	Args:      cobra.ExactArgs(1),
+	ValidArgs: []string{"claude"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		target := args[0]
+		switch target {
+		case "claude":
+			if err := hooks.UninstallClaude(); err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "✓ Hook removed")
+			return nil
+		default:
+			return fmt.Errorf("unsupported target: %s (available: claude)", target)
+		}
+	},
+}
+
+var hooksStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show hook installation status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		installed, scriptPath, err := hooks.Status()
+		if err != nil {
+			return err
+		}
+		if installed {
+			fmt.Fprintf(cmd.OutOrStdout(), "✓ Claude Code hook installed at %s\n", scriptPath)
+		} else {
+			fmt.Fprintln(cmd.OutOrStdout(), "○ Claude Code hook not installed")
+			fmt.Fprintln(cmd.OutOrStdout(), "  Run: scribe hooks install claude")
+		}
+		return nil
+	},
+}
+
+func init() {
+	hooksCmd.AddCommand(hooksInstallCmd)
+	hooksCmd.AddCommand(hooksUninstallCmd)
+	hooksCmd.AddCommand(hooksStatusCmd)
+}
+```
+
+- [ ] **Step 4: Register command in root.go**
+
+In `cmd/root.go`, add `hooksCmd` to the `rootCmd.AddCommand(...)` call in `init()`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go test ./cmd/ -v -run TestHooks`
+Expected: PASS
+
+- [ ] **Step 6: Manual smoke test**
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go run ./cmd/scribe hooks --help`
+Expected: Shows install/uninstall/status subcommands
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go run ./cmd/scribe hooks status`
+Expected: Shows current hook status
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/hooks.go cmd/root.go
+git commit -m "feat: add 'scribe hooks' command
+
+Exposes hook management: install, uninstall, status.
+Currently supports Claude Code target."
+```
+
+---
+
+## Task 4: Auto-Install Hook on First Sync
+
+When Scribe detects Claude Code is installed and the hook isn't present, automatically install it during `scribe sync`. This is the zero-friction path — users don't need to know about `scribe hooks install`.
+
+**Files:**
+- Modify: `internal/workflow/sync.go` — add StepInstallHooks
+- Modify: `internal/workflow/bag.go` — add HookResults field
+- Create: `internal/workflow/sync_hooks_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package workflow_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/workflow"
+)
+
+func TestStepInstallHooks_InstallsWhenMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create .claude dir
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bag := &workflow.Bag{}
+	if err := workflow.StepInstallHooks(context.Background(), bag); err != nil {
+		t.Fatalf("StepInstallHooks() error: %v", err)
+	}
+
+	// Verify hook was installed
+	scriptPath := filepath.Join(home, ".claude", "hooks", "scribe-hook.sh")
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Errorf("hook script not installed: %v", err)
+	}
+}
+
+func TestStepInstallHooks_SkipsWhenNoClaude(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// No .claude dir
+	bag := &workflow.Bag{}
+	if err := workflow.StepInstallHooks(context.Background(), bag); err != nil {
+		t.Fatalf("StepInstallHooks() should not error when Claude missing: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go test ./internal/workflow/ -v -run TestStepInstallHooks`
+Expected: FAIL — StepInstallHooks not defined
+
+- [ ] **Step 3: Add HookResults to Bag**
+
+In `internal/workflow/bag.go`, add to the Bag struct:
+
+```go
+// Hook installation results (populated by StepInstallHooks)
+HookResults []string
+```
+
+- [ ] **Step 4: Implement StepInstallHooks**
+
+Add to `internal/workflow/sync.go`:
+
+```go
+// StepInstallHooks auto-installs agent hooks when the target tool is
+// detected but the hook is missing. Runs silently — hook installation
+// failures are non-fatal (logged but do not block sync).
+func StepInstallHooks(ctx context.Context, b *Bag) error {
+	installed, _, err := hooks.Status()
+	if err != nil {
+		// Claude Code not installed or can't determine — skip silently
+		return nil
+	}
+	if installed {
+		return nil
+	}
+
+	result, err := hooks.InstallClaude()
+	if err != nil {
+		// Non-fatal — don't block sync for a hook failure
+		return nil
+	}
+
+	if result.Status == hooks.Installed {
+		b.HookResults = append(b.HookResults, "claude")
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Wire StepInstallHooks into SyncSteps**
+
+In `SyncSteps()`, add the hook step after ResolveTools:
+
+```go
+func SyncSteps() []Step {
+	return []Step{
+		{"LoadConfig", StepLoadConfig},
+		{"LoadState", StepLoadState},
+		{"CheckConnected", StepCheckConnected},
+		{"FilterRegistries", StepFilterRegistries},
+		{"ResolveFormatter", StepResolveFormatter},
+		{"ResolveTools", StepResolveTools},
+		{"InstallHooks", StepInstallHooks},
+		{"Adopt", StepAdopt},
+		{"SyncSkills", StepSyncSkills},
+	}
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go test ./internal/workflow/ -v -run TestStepInstallHooks`
+Expected: PASS
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go test ./... -count=1`
+Expected: All tests PASS (no regressions)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/workflow/sync.go internal/workflow/bag.go internal/workflow/sync_hooks_test.go
+git commit -m "feat: auto-install Claude Code hook during sync
+
+Silently installs the agent bridge hook on first sync when Claude Code
+is detected. Non-fatal — hook failures never block sync."
+```
+
+---
+
+## Task 5: Embedded Default Catalog
+
+Compile a default catalog into the binary so `scribe add` can show available skills without network access on first run. Follows nono's `include_str!()` pattern using Go's `embed` package.
+
+**Files:**
+- Create: `internal/embed/embed.go`
+- Create: `internal/embed/catalog.json`
+- Create: `internal/embed/embed_test.go`
+- Modify: `internal/provider/provider.go` — add fallback to embedded catalog
+
+- [ ] **Step 1: Define the embedded catalog JSON**
+
+```json
+{
+  "format_version": 1,
+  "updated_at": "2026-04-14T00:00:00Z",
+  "registries": [
+    {
+      "repo": "Naoray/scribe",
+      "description": "Official Scribe skill registry",
+      "builtin": true,
+      "catalog": []
+    }
+  ]
+}
+```
+
+This starts empty — populated with actual skills as they're published. The structure allows offline browsing of the registry index.
+
+- [ ] **Step 2: Write the failing test**
+
+```go
+package embed_test
+
+import (
+	"testing"
+
+	scribeEmbed "github.com/Naoray/scribe/internal/embed"
+)
+
+func TestEmbeddedCatalog_Loads(t *testing.T) {
+	catalog, err := scribeEmbed.LoadCatalog()
+	if err != nil {
+		t.Fatalf("LoadCatalog() error: %v", err)
+	}
+
+	if catalog.FormatVersion != 1 {
+		t.Errorf("format_version = %d, want 1", catalog.FormatVersion)
+	}
+
+	if len(catalog.Registries) == 0 {
+		t.Error("expected at least one registry")
+	}
+
+	if catalog.Registries[0].Repo != "Naoray/scribe" {
+		t.Errorf("first registry repo = %q, want Naoray/scribe", catalog.Registries[0].Repo)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go test ./internal/embed/ -v`
+Expected: FAIL — package does not exist
+
+- [ ] **Step 4: Implement the embed package**
+
+```go
+package embed
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+//go:embed catalog.json
+var catalogData []byte
+
+// Catalog is the embedded registry index compiled into the binary.
+type Catalog struct {
+	FormatVersion int               `json:"format_version"`
+	UpdatedAt     time.Time         `json:"updated_at"`
+	Registries    []CatalogRegistry `json:"registries"`
+}
+
+// CatalogRegistry describes a registry and its known skills.
+type CatalogRegistry struct {
+	Repo        string         `json:"repo"`
+	Description string         `json:"description"`
+	Builtin     bool           `json:"builtin"`
+	Catalog     []CatalogEntry `json:"catalog"`
+}
+
+// CatalogEntry is a skill known at build time.
+type CatalogEntry struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Author      string `json:"author"`
+	Ref         string `json:"ref"`
+}
+
+// LoadCatalog parses and returns the embedded catalog.
+func LoadCatalog() (*Catalog, error) {
+	var c Catalog
+	if err := json.Unmarshal(catalogData, &c); err != nil {
+		return nil, fmt.Errorf("parse embedded catalog: %w", err)
+	}
+	return &c, nil
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go test ./internal/embed/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/embed/embed.go internal/embed/catalog.json internal/embed/embed_test.go
+git commit -m "feat: add embedded catalog for zero-network first-run
+
+Compiles a default registry catalog into the binary using go:embed.
+Enables offline skill browsing without network access.
+
+Pattern inspired by nono-cli's include_str!() approach."
+```
+
+---
+
+## Task 6: Three-State Config Layering
+
+Implement `InheritableValue[T]` semantics for config fields. This enables project-level `.scribe/config.yaml` that can override, clear, or inherit global settings. Follows nono's `Inherit | Clear | Set(T)` pattern.
+
+**Files:**
+- Create: `internal/config/layered.go`
+- Create: `internal/config/layered_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/config"
+)
+
+func TestMergeConfigs_ProjectOverridesGlobal(t *testing.T) {
+	global := &config.Config{
+		Editor: "vim",
+		Adoption: config.AdoptionConfig{Mode: "auto"},
+		Registries: []config.RegistryConfig{
+			{Repo: "team/skills", Enabled: true},
+		},
+	}
+
+	project := &config.Config{
+		Editor: "code",
+	}
+
+	merged := config.Merge(global, project)
+
+	if merged.Editor != "code" {
+		t.Errorf("Editor = %q, want 'code'", merged.Editor)
+	}
+	// Inherited from global
+	if merged.AdoptionMode() != "auto" {
+		t.Errorf("AdoptionMode = %q, want 'auto'", merged.AdoptionMode())
+	}
+	// Registries inherited
+	if len(merged.Registries) != 1 {
+		t.Errorf("Registries len = %d, want 1", len(merged.Registries))
+	}
+}
+
+func TestMergeConfigs_ProjectAddsRegistry(t *testing.T) {
+	global := &config.Config{
+		Registries: []config.RegistryConfig{
+			{Repo: "team/skills", Enabled: true},
+		},
+	}
+
+	project := &config.Config{
+		Registries: []config.RegistryConfig{
+			{Repo: "project/extras", Enabled: true},
+		},
+	}
+
+	merged := config.Merge(global, project)
+
+	if len(merged.Registries) != 2 {
+		t.Fatalf("Registries len = %d, want 2", len(merged.Registries))
+	}
+}
+
+func TestMergeConfigs_NilProjectReturnsGlobal(t *testing.T) {
+	global := &config.Config{Editor: "vim"}
+
+	merged := config.Merge(global, nil)
+
+	if merged.Editor != "vim" {
+		t.Errorf("Editor = %q, want 'vim'", merged.Editor)
+	}
+}
+
+func TestLoadWithProject_FindsProjectConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Write global config
+	globalDir := filepath.Join(home, ".scribe")
+	os.MkdirAll(globalDir, 0o755)
+	os.WriteFile(filepath.Join(globalDir, "config.yaml"), []byte("editor: vim\n"), 0o644)
+
+	// Write project config
+	projectDir := t.TempDir()
+	scribeDir := filepath.Join(projectDir, ".scribe")
+	os.MkdirAll(scribeDir, 0o755)
+	os.WriteFile(filepath.Join(scribeDir, "config.yaml"), []byte("editor: code\n"), 0o644)
+
+	cfg, err := config.LoadWithProject(projectDir)
+	if err != nil {
+		t.Fatalf("LoadWithProject() error: %v", err)
+	}
+
+	if cfg.Editor != "code" {
+		t.Errorf("Editor = %q, want 'code' (project override)", cfg.Editor)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go test ./internal/config/ -v -run TestMerge`
+Expected: FAIL — Merge function not defined
+
+- [ ] **Step 3: Implement config merging**
+
+```go
+package config
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Merge combines a global config with a project-level override.
+// Project values take precedence over global. Registries are merged
+// (union by repo name). Nil project returns a copy of global.
+func Merge(global, project *Config) *Config {
+	if project == nil {
+		cp := *global
+		return &cp
+	}
+
+	merged := *global
+
+	// Scalar overrides: project wins if non-zero
+	if project.Editor != "" {
+		merged.Editor = project.Editor
+	}
+	if project.Token != "" {
+		merged.Token = project.Token
+	}
+	if project.Adoption.Mode != "" {
+		merged.Adoption.Mode = project.Adoption.Mode
+	}
+
+	// Adoption paths: append project paths
+	if len(project.Adoption.Paths) > 0 {
+		merged.Adoption.Paths = append(merged.Adoption.Paths, project.Adoption.Paths...)
+	}
+
+	// Registries: merge by repo name (project overrides same-name, appends new)
+	if len(project.Registries) > 0 {
+		repoIndex := make(map[string]int, len(merged.Registries))
+		for i, r := range merged.Registries {
+			repoIndex[strings.ToLower(r.Repo)] = i
+		}
+
+		for _, pr := range project.Registries {
+			key := strings.ToLower(pr.Repo)
+			if idx, exists := repoIndex[key]; exists {
+				merged.Registries[idx] = pr // project overrides
+			} else {
+				merged.Registries = append(merged.Registries, pr)
+			}
+		}
+	}
+
+	// Tools: merge by name (same logic as registries)
+	if len(project.Tools) > 0 {
+		toolIndex := make(map[string]int, len(merged.Tools))
+		for i, t := range merged.Tools {
+			toolIndex[strings.ToLower(t.Name)] = i
+		}
+
+		for _, pt := range project.Tools {
+			key := strings.ToLower(pt.Name)
+			if idx, exists := toolIndex[key]; exists {
+				merged.Tools[idx] = pt
+			} else {
+				merged.Tools = append(merged.Tools, pt)
+			}
+		}
+	}
+
+	return &merged
+}
+
+// LoadWithProject loads global config from ~/.scribe/config.yaml then
+// merges with a project-level .scribe/config.yaml if found. Walks up
+// from projectDir looking for .scribe/config.yaml.
+func LoadWithProject(projectDir string) (*Config, error) {
+	global, err := Load()
+	if err != nil {
+		return nil, err
+	}
+
+	projectCfg, err := findProjectConfig(projectDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return Merge(global, projectCfg), nil
+}
+
+// findProjectConfig walks up from dir looking for .scribe/config.yaml.
+// Returns nil (not error) if no project config found.
+func findProjectConfig(dir string) (*Config, error) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		candidate := filepath.Join(dir, ".scribe", "config.yaml")
+		data, err := os.ReadFile(candidate)
+		if err == nil {
+			var cfg Config
+			if err := yaml.Unmarshal(data, &cfg); err != nil {
+				return nil, err
+			}
+			return &cfg, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break // reached root
+		}
+		dir = parent
+	}
+
+	return nil, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go test ./internal/config/ -v -run "TestMerge|TestLoadWithProject"`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go test ./... -count=1`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/layered.go internal/config/layered_test.go
+git commit -m "feat: add project-level config layering with merge semantics
+
+Global config (~/.scribe/config.yaml) can now be overridden by
+project-level .scribe/config.yaml. Scalars: project wins if set.
+Registries/tools: merged by name, project overrides same-name entries.
+
+Three-state semantics inspired by nono-cli's InheritableValue pattern."
+```
+
+---
+
+## Task 7: Integration Test — Full Hook Lifecycle
+
+End-to-end test covering install → verify → sync-auto-install → uninstall.
+
+**Files:**
+- Create: `internal/hooks/integration_test.go`
+
+- [ ] **Step 1: Write the integration test**
+
+```go
+package hooks_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/hooks"
+)
+
+func TestHookLifecycle(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Phase 1: Status before install
+	installed, _, err := hooks.Status()
+	if err != nil {
+		t.Fatalf("initial Status() error: %v", err)
+	}
+	if installed {
+		t.Fatal("hook should not be installed initially")
+	}
+
+	// Phase 2: Install
+	result, err := hooks.InstallClaude()
+	if err != nil {
+		t.Fatalf("InstallClaude() error: %v", err)
+	}
+	if result.Status != hooks.Installed {
+		t.Errorf("install status = %v, want Installed", result.Status)
+	}
+
+	// Phase 3: Verify settings.json structure
+	settingsData, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(settingsData, &settings); err != nil {
+		t.Fatalf("parse settings.json: %v", err)
+	}
+
+	hooksMap, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		t.Fatal("settings.json missing hooks key")
+	}
+
+	events, ok := hooksMap["PostToolUseFailure"].([]any)
+	if !ok {
+		t.Fatal("settings.json missing PostToolUseFailure")
+	}
+
+	if len(events) != 1 {
+		t.Errorf("PostToolUseFailure entries = %d, want 1", len(events))
+	}
+
+	// Phase 4: Idempotent re-install
+	result, err = hooks.InstallClaude()
+	if err != nil {
+		t.Fatalf("second InstallClaude() error: %v", err)
+	}
+	if result.Status != hooks.AlreadyInstalled {
+		t.Errorf("re-install status = %v, want AlreadyInstalled", result.Status)
+	}
+
+	// Phase 5: Verify hook script is executable
+	scriptPath := filepath.Join(claudeDir, "hooks", "scribe-hook.sh")
+	info, err := os.Stat(scriptPath)
+	if err != nil {
+		t.Fatalf("stat hook script: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Error("hook script not executable")
+	}
+
+	// Phase 6: Uninstall
+	if err := hooks.UninstallClaude(); err != nil {
+		t.Fatalf("UninstallClaude() error: %v", err)
+	}
+
+	installed, _, err = hooks.Status()
+	if err != nil {
+		t.Fatalf("post-uninstall Status() error: %v", err)
+	}
+	if installed {
+		t.Error("hook still installed after uninstall")
+	}
+
+	// Phase 7: Verify settings.json cleaned up
+	settingsData, err = os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings.json after uninstall: %v", err)
+	}
+	if err := json.Unmarshal(settingsData, &settings); err != nil {
+		t.Fatalf("parse settings.json after uninstall: %v", err)
+	}
+
+	// hooks key should be removed (no entries left)
+	if _, hasHooks := settings["hooks"]; hasHooks {
+		hooksMap, _ = settings["hooks"].(map[string]any)
+		if len(hooksMap) > 0 {
+			t.Error("settings.json still has non-empty hooks after uninstall")
+		}
+	}
+}
+
+func TestHookPreservesExistingSettings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeDir := filepath.Join(home, ".claude")
+	os.MkdirAll(claudeDir, 0o755)
+
+	// Pre-existing settings with other hooks
+	existing := map[string]any{
+		"permissions": map[string]any{"allow": []any{"Read"}},
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": ".*",
+					"hooks":   []any{map[string]any{"type": "command", "command": "my-other-hook.sh"}},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	os.WriteFile(filepath.Join(claudeDir, "settings.json"), data, 0o644)
+
+	// Install scribe hook
+	if _, err := hooks.InstallClaude(); err != nil {
+		t.Fatalf("InstallClaude() error: %v", err)
+	}
+
+	// Verify existing settings preserved
+	settingsData, _ := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	var settings map[string]any
+	json.Unmarshal(settingsData, &settings)
+
+	// permissions should still be there
+	if _, ok := settings["permissions"]; !ok {
+		t.Error("existing permissions key was lost")
+	}
+
+	// PreToolUse hook should still be there
+	hooksMap := settings["hooks"].(map[string]any)
+	if _, ok := hooksMap["PreToolUse"]; !ok {
+		t.Error("existing PreToolUse hook was lost")
+	}
+
+	// PostToolUseFailure should be added
+	if _, ok := hooksMap["PostToolUseFailure"]; !ok {
+		t.Error("PostToolUseFailure not added")
+	}
+
+	// Uninstall — should only remove our hook, preserve others
+	hooks.UninstallClaude()
+
+	settingsData, _ = os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	json.Unmarshal(settingsData, &settings)
+
+	// PreToolUse should survive
+	hooksMap = settings["hooks"].(map[string]any)
+	if _, ok := hooksMap["PreToolUse"]; !ok {
+		t.Error("PreToolUse hook lost after uninstall")
+	}
+
+	// permissions should survive
+	if _, ok := settings["permissions"]; !ok {
+		t.Error("permissions lost after uninstall")
+	}
+}
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `cd /Users/krishankonig/Workspace/bets/scribe && go test ./internal/hooks/ -v -run TestHook`
+Expected: All PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/hooks/integration_test.go
+git commit -m "test: add hook lifecycle integration tests
+
+Covers install → idempotent re-install → uninstall → cleanup.
+Verifies existing settings.json entries are preserved."
+```
+
+---
+
+## Summary
+
+| Task | Pattern | Source | Impact |
+|------|---------|--------|--------|
+| 1-4  | Claude Code hook bridge | nono `hooks.rs` + `nono-hook.sh` | Agents auto-discover Scribe |
+| 5    | Embedded catalog | nono `include_str!()` / `embedded.rs` | Zero-network first-run |
+| 6    | Three-state config layering | nono `InheritableValue<T>` | Project-level overrides |
+| 7    | Integration tests | — | Confidence |
+
+**Execution order matters:** Tasks 1-4 (hook system) are the highest-leverage deliverable and should ship first. Task 5 (embedded catalog) and Task 6 (config layering) are independent and can be parallelized.

--- a/docs/superpowers/specs/2026-04-13-agent-first-cli-design.md
+++ b/docs/superpowers/specs/2026-04-13-agent-first-cli-design.md
@@ -1,0 +1,517 @@
+# Making Scribe agent-first: a complete design guide
+
+**AI coding agents — not humans — should be Scribe's primary audience.** This means every command must produce structured, parseable output; every failure must communicate what went wrong, whether it's retryable, and what to do next; and every operation must be safe to run twice. The shift from human-first to agent-first isn't cosmetic — it requires rethinking output formats, exit codes, error contracts, discoverability, and the fundamental command vocabulary. The good news: proven patterns exist across `gh`, `kubectl`, `terraform`, `ripgrep`, and package managers like `npm` and `brew`. The emerging Model Context Protocol (MCP) and tool-use specifications from Anthropic and OpenAI provide concrete schemas. Scribe's position as a skill manager — sitting between registries, local storage, and tool-specific directories — makes it a natural fit for the plan/apply, declarative-state patterns that agents handle best.
+
+---
+
+## 1. Executive summary: ten decisions that define agent-first Scribe
+
+These ten architectural decisions will determine whether AI agents can reliably orchestrate Scribe or whether they'll fumble through stderr parsing and ambiguous exit codes.
+
+**Decision 1: Structured JSON output on every command.** Not "has a `--json` flag" but truly designed for programmatic consumption — JSON to stdout, human decoration to stderr, consistent types (ISO 8601 timestamps, integers not strings), and field selection via `--json name,version,status`. Follow `gh`'s model where `--json` with no arguments lists available fields.
+
+**Decision 2: Semantic exit codes beyond 0/1.** Adopt a taxonomy: **0** success, **1** general error, **2** usage/input error, **3** not found, **4** permission denied, **5** conflict/already exists, **6** network error (retryable), **7** dependency error, **8** validation error, **10** partial success. An agent that gets exit code 6 retries with backoff. An agent that gets exit code 1 for everything must parse stderr — and will sometimes get it wrong.
+
+**Decision 3: Idempotent by default.** `scribe install skill-x` when skill-x is already installed at the right version should exit 0 with `{"status":"already_installed"}`. Use declarative verbs (`ensure`, `sync`, `apply`) over imperative ones (`create`, `delete`). Follow `kubectl apply`'s desired-state convergence.
+
+**Decision 4: Plan/apply separation for mutating operations.** Steal terraform's two-phase model: `scribe plan install skill-x --json` shows exactly what would change; `scribe apply` executes. This gives agents a safe preview before committing.
+
+**Decision 5: Errors as structured data.** Every error must include `code` (machine-readable), `message` (human-readable), `resource` (what failed), `retryable` (boolean), and `remediation` (what to do next). An agent seeing `{"code":"REGISTRY_UNAVAILABLE","retryable":true,"retry_after_seconds":30}` can act immediately.
+
+**Decision 6: TTY-aware automatic mode switching.** If stdout is a terminal, show colors, progress bars, and interactive prompts. If stdout is a pipe (how agents call CLIs), output clean JSON, suppress prompts, and fail with clear errors listing missing required flags. Respect `CI=true` and `NO_COLOR=1`.
+
+**Decision 7: Self-describing commands.** Implement `scribe schema <command>` that returns JSON Schema for inputs and outputs. Ship a `CLAUDE.md` file documenting all commands for agent discovery. Consider an MCP server mode (`scribe mcp serve`) for structured protocol consumers.
+
+**Decision 8: Lockfile and state management.** Maintain `scribe.lock` with exact versions and SHA checksums. Support `scribe ci` that fails if lockfile drifts from manifest. Track installation state in `scribe.state.json` with per-skill phases (staged, installed, linked).
+
+**Decision 9: Graduated intervention model.** Default to prompting on conflicts; `--yes` auto-accepts defaults; `--force` overrides safety checks; `--dry-run` previews changes. TTY detection auto-selects the right mode. Read operations need zero intervention; write operations need approval; destructive operations need explicit confirmation.
+
+**Decision 10: Dual-surface architecture.** One binary serving CLI (human/agent via bash) and MCP (structured protocol via stdio). Use the official Go MCP SDK. The CLI path is more token-efficient for simple operations; MCP wins for dynamic discovery across many tools.
+
+---
+
+## 2. Pattern library: proven designs for agent-friendly CLIs
+
+### The structured output contract
+
+The gap between "has `--json`" and "designed for programmatic consumption" is enormous. Tools truly designed for agents follow five rules:
+
+**JSON to stdout, everything else to stderr.** Progress bars, warnings, spinners, and human-friendly messages go to stderr. The stdout stream is a clean, parseable data channel. This is how `gh`, `kubectl`, and `ripgrep` work in their structured modes. An agent piping `scribe list --json` to `jq` should never encounter a "Fetching..." message corrupting the JSON stream.
+
+**Consistent types across all commands.** A timestamp is always ISO 8601, never "3 days ago." A count is always an integer, never "~100." A boolean is always `true`/`false`, never "yes"/"no." When types are consistent, agents don't need per-command parsing logic.
+
+**Field selection controls output size.** Context window tokens are currency. `scribe list --json name,version` returns only requested fields. `scribe list --json` with no arguments prints available field names (the `gh` pattern). Consider a `--jq` flag for inline filtering without requiring external `jq`.
+
+**JSON Lines (NDJSON) for streaming.** `ripgrep`'s `--json` mode emits one JSON object per line with type tags: `{"type":"match","data":{...}}`. For `scribe search`, streaming results as NDJSON means agents can process results incrementally rather than waiting for a full buffered response. Each line is independently parseable.
+
+**Versioned schema with stability guarantees.** Include a `format_version` field in JSON output. Never remove or rename fields without a major version bump. Terraform includes format versions in all JSON output for exactly this reason. Breaking a JSON schema silently breaks every agent workflow that depends on it.
+
+### Exit codes as control flow
+
+The `grep` three-state model is the minimum: **0** = success with results, **1** = success but nothing found, **2+** = actual error. This pattern lets agents distinguish "the search worked but found nothing" from "the search failed" — a distinction lost when everything non-zero means error.
+
+For a package manager, richer semantics pay for themselves immediately. `curl`'s ~100 distinct exit codes enable targeted retry logic without stderr parsing. A practical taxonomy for Scribe:
+
+| Code | Meaning | Agent behavior |
+|------|---------|---------------|
+| 0 | Success | Continue |
+| 1 | General failure | Log and escalate |
+| 2 | Invalid input/usage | Fix arguments, don't retry |
+| 3 | Resource not found | Try different name or registry |
+| 4 | Permission denied | Check auth, don't retry |
+| 5 | Conflict (already exists) | Skip or use `--force` |
+| 6 | Network error | Retry with backoff |
+| 7 | Dependency error | Resolve dependency first |
+| 8 | Validation error | Fix manifest/schema |
+| 10 | Partial success | Check which operations failed |
+
+### Idempotency through declarative verbs
+
+`terraform apply` is idempotent because it compares desired state against current state and only changes what differs. `ansible` reports `ok` (already correct) vs `changed` (modification made) vs `failed`. `brew install` exits 0 when a package is already installed with a "already installed" warning.
+
+The pattern: **use declarative verbs that describe the desired end state, not the action to take.** `ensure` over `create`. `sync` over `install + update + remove`. `apply` over individual mutations. When an agent runs `scribe ensure skill-x` twice, the second run should be a fast no-op returning `{"status":"no_changes","skill":"skill-x"}`.
+
+For operations that can't be fully idempotent (like `scribe add` to a registry), use distinct exit codes: exit 5 for "already exists" lets agents proceed without parsing error messages.
+
+### The preview-then-commit pattern
+
+Terraform's `plan`/`apply` separation is the gold standard. The plan phase is read-only and safe. The apply phase executes exactly what was planned. For agents, this means:
+
+```
+scribe plan install skill-x --json    →  shows files to add, symlinks to create
+scribe plan sync --json               →  shows full diff (adds, updates, removes)
+scribe apply                          →  executes the last plan
+scribe apply --auto-approve           →  executes without confirmation
+```
+
+`kubectl` extends this with `--dry-run=client` (local validation) and `--dry-run=server` (server-side validation). For Scribe, `--dry-run` should resolve registries and check dependencies without actually installing — the agent needs to know if the operation *would* succeed.
+
+### Structured errors with remediation
+
+Cloud CLIs set the standard. AWS CLI v2.34+ supports `--cli-error-format json` returning `Code`, `Message`, and service-specific fields. Google APIs return `ErrorInfo` with `reason`, `domain`, and `metadata`. The critical field most CLIs miss: **remediation** — a concrete next step the agent can take.
+
+```json
+{
+  "error": {
+    "code": "SKILL_CONFLICT",
+    "message": "Skill 'code-review' exists in both 'github.com/org/skills' and 'github.com/team/skills'",
+    "retryable": false,
+    "resources": ["github.com/org/skills/code-review", "github.com/team/skills/code-review"],
+    "remediation": "Specify registry: scribe install code-review --registry github.com/org/skills",
+    "exit_code": 5
+  }
+}
+```
+
+The `retryable` boolean is the single most important field for agents. It instantly partitions the error space into "try again" and "escalate."
+
+---
+
+## 3. Real-world examples and their lessons for Scribe
+
+### gh (GitHub CLI) — field selection and built-in filtering
+
+`gh` is the closest analog to what Scribe should become. Its `--json` flag accepts a comma-separated list of fields: `gh pr list --json number,title,author`. Running `--json` with no arguments prints all available fields — a discovery mechanism agents use constantly. The `--jq` flag embeds jq filtering without requiring external dependencies: `gh pr list --json author --jq '.[].author.login'`. The `gh api` command provides raw API access with built-in auth and pagination, covering operations that don't have dedicated subcommands.
+
+**Exit code 4 means "not found"** — not just generic failure. This lets agents distinguish between "that PR doesn't exist" and "GitHub is down."
+
+**Lesson for Scribe:** Implement `--json` with field selection on every command. Bundle `--jq` for in-tool filtering. Provide `scribe api` for raw registry operations. Use semantic exit codes matching specific failure modes.
+
+### ripgrep — type-tagged JSON Lines for streaming
+
+ripgrep's `--json` mode produces NDJSON where each line has a `type` field: `begin` (file start), `match` (result), `context` (surrounding lines), `end` (file end), `summary` (statistics). This lets consumers route messages by type — matches go to results, summaries go to metrics. VS Code's search integration consumes this format directly.
+
+**The binary safety pattern is subtle but important:** ripgrep uses `{"text":"..."}` for valid UTF-8 and `{"bytes":"base64..."}` for binary content. Skill descriptions may contain Unicode, making this pattern relevant.
+
+**Lesson for Scribe:** Use type-tagged NDJSON for `scribe search` and `scribe sync` output. Include timing/statistics in a `summary` message. Adopt the three-way exit code model: 0 = found, 1 = not found, 2 = error.
+
+### terraform — state management and plan/apply
+
+Terraform maintains a JSON state file mapping configuration to actual resources. On each `apply`, it diffs desired vs. current state and only changes what differs. The state file includes a `format_version` for forward compatibility. `terraform show -json` produces machine-readable plan output with `actions` arrays (`["create"]`, `["update"]`, `["delete"]`) per resource. When `apply` fails mid-way, it writes `errored.tfstate` for recovery.
+
+**Terraform has no native rollback** — by design. Recovery means reverting the config in git and re-applying. The config (code) is the source of truth, not the state file.
+
+**Lesson for Scribe:** Maintain `scribe.state.json` tracking installed skills with version, source, and phase. Implement plan/apply. Include `format_version` in state files. Make config manifests (`scribe.yaml`) the source of truth, with state tracking the current reality.
+
+### kubectl — declarative convergence and dry-run levels
+
+`kubectl apply -f deployment.yaml` converges toward desired state idempotently. `kubectl create` fails if the resource exists — a crucial distinction. The `--dry-run=server` flag sends the request to the API server for full validation (including webhooks and admission controllers) without persisting. `kubectl diff` shows what would change. Multiple output formats (`-o json`, `-o yaml`, `-o jsonpath`, `-o name`) cover every consumption pattern. **Fully qualified resource references** (`jobs.v1.batch/myjob`) prevent version ambiguity.
+
+**Lesson for Scribe:** Support declarative management via `scribe apply -f skills.yaml`. Implement `scribe diff` showing what would change. Offer `--dry-run=client` (local manifest validation) and `--dry-run=server` (resolve against registries).
+
+### npm/pnpm — lockfiles, CI mode, and conflict resolution
+
+`npm ci` installs from lockfile only, fails if lockfile and `package.json` are out of sync, and deletes `node_modules` first — the definitive reproducible install. `pnpm`'s content-addressable store deduplicates packages globally. npm v7+ uses staging directories for atomic moves: packages unpack to temporary locations, then move atomically into `node_modules`. Conflict resolution uses `overrides` (npm) and `resolutions` (yarn) as escape hatches for impossible version conflicts. `npm why <package>` explains dependency chains.
+
+**Lesson for Scribe:** Implement `scribe.lock` with exact versions and SHA checksums. Add `scribe ci` for frozen-lockfile installs. Use a staging directory pattern (`.scribe/staging/`) for atomic installs. Support `scribe why <skill>` to explain why a skill is installed and where it came from.
+
+### brew — tap-based registry management
+
+Homebrew's "tap" system maps directly to Scribe's registry model. A tap is a git repo added via `brew tap user/repo`. Ambiguous names resolve through priority: pinned taps → core → other taps. Fully qualified names (`user/repo/formula`) bypass resolution. Taps include `formula_renames.json` and `tap_migrations.json` for handling renamed or moved packages.
+
+**Lesson for Scribe:** Model registries as taps with priority ordering. Support fully qualified skill names (`@registry/skill-name`) for disambiguation. Include rename/migration manifests in registries for handling skill moves.
+
+---
+
+## 4. Design recommendations specific to Scribe
+
+### Command vocabulary redesign
+
+Shift from imperative to declarative command names. The current human-oriented vocabulary should map to agent-friendly equivalents:
+
+| Current (human-first) | Recommended (agent-first) | Rationale |
+|----------------------|--------------------------|-----------|
+| `scribe add <skill>` | `scribe install <skill>` | Standard package manager verb |
+| `scribe remove <skill>` | `scribe uninstall <skill>` | Paired with `install` |
+| — | `scribe ensure <skill>` | Idempotent: install if missing, no-op if present |
+| — | `scribe sync` | Declarative: converge to manifest state |
+| — | `scribe plan <operation>` | Preview any mutation |
+| — | `scribe apply` | Execute a saved plan |
+| `scribe list` | `scribe list` (unchanged) | Already agent-friendly |
+| — | `scribe status` | Drift detection, broken symlinks, pending updates |
+| — | `scribe doctor` | Health check across registries, symlinks, state |
+| — | `scribe diff` | Show what would change vs. manifest |
+| — | `scribe why <skill>` | Explain provenance and dependencies |
+| — | `scribe schema <command>` | JSON Schema for command input/output |
+| — | `scribe log --json` | Structured operation history |
+
+### Output format architecture
+
+Implement a Go `OutputWriter` interface that switches between human and machine modes:
+
+```go
+type OutputWriter interface {
+    WriteResult(v interface{}) error
+    WriteError(err *StructuredError) error
+    WriteProgress(msg string) error   // stderr only
+}
+```
+
+Three implementations: `JSONOutputWriter` (JSON to stdout, progress to stderr), `TableOutputWriter` (colored tables, spinners, prompts), and `QuietOutputWriter` (minimal output, bare values for piping). Selection logic: explicit `--json` flag → forced JSON; explicit `--quiet` → bare values; otherwise, TTY detection chooses automatically.
+
+**Standard JSON envelope for all responses:**
+
+```json
+{
+  "status": "ok",
+  "format_version": "1",
+  "data": { ... },
+  "meta": {
+    "duration_ms": 234,
+    "command": "install",
+    "scribe_version": "0.12.0"
+  }
+}
+```
+
+### Registry and disambiguation strategy
+
+When multiple registries contain a skill with the same name, Scribe must never silently pick one. The resolution strategy:
+
+1. Check if a default registry is configured for this skill name (via `scribe.yaml` overrides)
+2. Check registry priority order (user-configured, like Homebrew's pinned taps)
+3. If still ambiguous, exit with code 5 and structured error listing all options with their registries
+4. Support `@registry/skill-name` syntax for explicit disambiguation
+5. In `--yes` mode, use the highest-priority registry; document this behavior
+
+### MCP server integration
+
+Using the official Go MCP SDK, Scribe should serve as an MCP server via `scribe mcp serve`, exposing tools like:
+
+```json
+{
+  "tools": [
+    {
+      "name": "scribe_install",
+      "description": "Install a coding skill from a registry",
+      "inputSchema": {"type":"object","properties":{"skill":{"type":"string"},"registry":{"type":"string"}},"required":["skill"]},
+      "annotations": {"destructiveHint": false, "idempotentHint": true}
+    },
+    {
+      "name": "scribe_list",
+      "description": "List installed coding skills with version and source",
+      "inputSchema": {"type":"object","properties":{"fields":{"type":"array","items":{"type":"string"}}}},
+      "annotations": {"readOnlyHint": true}
+    }
+  ]
+}
+```
+
+MCP tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`) communicate safety characteristics to agents, enabling automated approval policies. A 2026 study found CLI invocations are **10–32× cheaper in tokens** than MCP for simple operations, so both surfaces should coexist — CLI for cost-efficient bash-based agents, MCP for protocol-native environments.
+
+---
+
+## 5. The 90/10 framework: autonomy tiers for every operation
+
+### Level 5 operations — fully autonomous, zero intervention
+
+These operations are read-only or convergent with no destructive potential. An agent should execute them without asking:
+
+- **`scribe list`** — Pure read, returns installed skills
+- **`scribe search <query>`** — Registry query, no side effects
+- **`scribe info <skill>`** — Metadata display
+- **`scribe status`** — Drift detection, broken symlink check
+- **`scribe doctor`** — Health diagnostics
+- **`scribe why <skill>`** — Provenance explanation
+- **`scribe schema <command>`** — Self-description
+- **`scribe diff`** — Shows pending changes without applying
+- **`scribe plan <operation> --json`** — Previews mutation safely
+
+**Design constraint:** These commands must never prompt, never write to the filesystem (except logs), and never require `--yes`. If run in non-TTY mode, they produce clean JSON with no decorations.
+
+### Level 4 operations — agent drives, approval recommended
+
+These operations mutate filesystem state but are recoverable. An agent running with `--yes` can execute autonomously; without it, confirmation is appropriate:
+
+- **`scribe install <skill>`** — Writes files and creates symlinks. Idempotent: exit 0 if already installed
+- **`scribe update <skill>`** — Replaces skill version. Safe if semver minor/patch
+- **`scribe sync`** — Converges to manifest state (may install, update, and remove)
+- **`scribe apply`** — Executes a saved plan
+
+**Decision criteria for autonomous execution:** The agent should auto-approve if (a) the plan shows no removals, (b) no major version bumps are involved, and (c) no conflicts require disambiguation. The `--dry-run --json` output should include a `safe_to_auto_approve` boolean based on these criteria.
+
+### Level 3 operations — require judgment
+
+These operations involve ambiguity or irreversible consequences that warrant deliberation:
+
+- **Conflict resolution** — Local modifications to a skill diverge from upstream. Agent should present both versions and ask the orchestrating agent or user to choose: `{"conflict":"local_modified","local_version":"1.2.0-modified","upstream_version":"1.3.0","options":["keep_local","accept_upstream","merge"]}`
+- **Ambiguous intent** — Same skill name in multiple registries. Exit with code 5 and list options
+- **Breaking changes** — Major version bump detected. Include changelog excerpt in output
+- **First-time setup** — Registry authentication, tool directory configuration
+
+### Level 1–2 operations — human confirmation required
+
+- **`scribe uninstall <skill>`** — Destructive, removes files. Always confirm unless `--force`
+- **`scribe reset`** — Wipes all state. Require `--force --yes` for non-interactive execution
+- **`scribe registry remove`** — May orphan installed skills. Show impact analysis first
+- **Authentication setup** — API tokens, SSH keys for private registries
+
+### Implementing the graduated flag model
+
+```
+scribe sync                          # Interactive: prompts on conflicts
+scribe sync --yes                    # Auto-accept: uses defaults for all prompts
+scribe sync --yes --json             # Agent mode: auto-accept + structured output
+scribe sync --force                  # Override: ignores conflicts, forces upstream
+scribe sync --dry-run                # Preview: shows what would change
+scribe sync --dry-run --json         # Agent preview: structured change plan
+```
+
+The `--yes` flag answers "are you sure?" questions. The `--force` flag overrides safety checks. These are distinct — `--yes` with a conflict should exit with an error explaining the conflict, while `--force` should resolve conflicts using a documented default strategy.
+
+---
+
+## 6. Error recovery architecture
+
+### Three-phase install with checkpoint tracking
+
+Every skill installation proceeds through three phases, each recorded in `scribe.state.json`:
+
+1. **Stage** — Download/clone skill to `.scribe/staging/<skill>/`. State: `staging`
+2. **Install** — Move from staging to skills directory. State: `installed`
+3. **Link** — Create symlinks into tool directories (`.claude/`, `.cursor/`, etc.). State: `linked`
+
+If Scribe crashes or is interrupted, re-running the same install command checks state and resumes from the last incomplete phase. Staged-but-not-installed skills just need moving. Installed-but-not-linked skills just need symlinking. This is the `rsync` pattern applied to package management.
+
+### Batch semantics: best-effort with structured reporting
+
+For `scribe sync` processing multiple skills, use best-effort semantics — each skill installs independently. Failures in one skill don't block others. The final output reports per-skill status:
+
+```json
+{
+  "status": "partial_success",
+  "results": [
+    {"skill": "code-review", "action": "installed", "version": "1.2.0", "status": "ok"},
+    {"skill": "test-gen", "action": "install", "version": "2.0.0", "status": "failed", "error": {"code": "NETWORK_ERROR", "retryable": true}},
+    {"skill": "pr-summary", "action": "no_change", "version": "1.0.0", "status": "ok"}
+  ],
+  "summary": {"succeeded": 2, "failed": 1, "unchanged": 1}
+}
+```
+
+Exit code **10** (partial success) signals that the agent should inspect results and retry failed operations.
+
+### Retry communication
+
+Every error in structured output includes explicit retryability:
+
+```json
+{
+  "error": {
+    "code": "REGISTRY_TIMEOUT",
+    "retryable": true,
+    "retry_after_seconds": 30,
+    "max_retries_suggested": 3,
+    "message": "Registry 'github.com/org/skills' timed out after 10s"
+  }
+}
+```
+
+For network operations, Scribe should support `--max-retries N` with exponential backoff built in. Transient errors (network timeout, HTTP 429/500/502/503) are retryable. Permanent errors (invalid manifest, permission denied, skill not found) are not. The exit code taxonomy encodes this: **exit 6** (network) is always retryable; **exit 2** (usage error) never is.
+
+### Rollback via paired operations
+
+Every install records enough state to fully reverse. `scribe uninstall <skill>` removes files from the skills directory, deletes symlinks from all tool directories, and updates `scribe.state.json`. For batch rollback after a failed sync, `scribe rollback` reverts to the previous state snapshot:
+
+```
+scribe rollback                # Revert to pre-last-sync state
+scribe rollback --to <timestamp>  # Revert to specific checkpoint
+scribe log --json              # View operation history for rollback targets
+```
+
+State snapshots are maintained using a simple versioning scheme: before each sync, copy `scribe.state.json` to `.scribe/snapshots/<timestamp>.state.json`. Rotation policy keeps the last 10 snapshots.
+
+### State introspection commands
+
+Agents need to understand current state before making decisions:
+
+- **`scribe status --json`** — Returns drift analysis: local vs. registry versions, broken symlinks, orphaned skills, pending updates
+- **`scribe doctor --json`** — Returns health check results: registry reachability, filesystem permissions, state consistency, tool directory validity
+- **`scribe log --json --since 1h`** — Returns recent operations for context reconstruction
+
+The `doctor` command follows `brew doctor`'s model: checks everything, returns structured results with severity levels and actionable remediation for each issue found.
+
+---
+
+## 7. Anti-patterns: what not to do when designing for agents
+
+**Never use a pager in non-TTY mode.** AWS CLI v2 changed its default pager to `less`, breaking thousands of CI jobs when the pager waited for keyboard input in headless environments. Always check TTY before enabling pagination. Scribe should never invoke a pager when stdout is piped.
+
+**Never mix data and decoration on stdout.** "Fetching skills... done ✓" followed by JSON on the same stream is unparseable. Progress messages go to stderr. Always. The stdout stream is sacred data territory.
+
+**Never return inconsistent types.** If `scribe list --json` returns `"version": "1.2.0"` (string) on one skill and `"version": 1.2` (number) on another, agents will crash. Define types once, enforce them everywhere.
+
+**Never change JSON field names without a version bump.** Renaming `skill_name` to `name` in a patch release silently breaks every agent workflow. Treat `--json` output as a versioned API contract with backward compatibility guarantees.
+
+**Never require interactive input in programmatic mode.** If a required flag is missing in non-TTY mode, fail immediately with a structured error listing exactly which flags are required. Never block waiting for stdin that will never arrive.
+
+**Never return exit code 0 on failure.** Some tools return 0 but include error information in stdout/stderr. Agents check exit codes first — a false 0 means the agent proceeds with corrupted state. If anything went wrong, the exit code must be non-zero.
+
+**Never embed state in environment that isn't documented.** If Scribe reads `SCRIBE_REGISTRY_URL`, `SCRIBE_SKILLS_DIR`, or `SCRIBE_AUTH_TOKEN`, these must be documented in `--help` output and `schema` output. Ambient state that agents can't discover causes mysterious failures.
+
+**Never use human-readable time formats in JSON.** "3 days ago" or "last Tuesday" require NLP to parse. Always use ISO 8601 (`2026-04-13T10:30:00Z`) or Unix timestamps.
+
+**Never silently resolve ambiguity.** If "code-review" exists in two registries and Scribe picks one without telling the agent, the wrong skill gets installed. Ambiguity must produce an error with explicit options.
+
+**Never design commands that only work in sequence without documenting the sequence.** If `scribe init` must precede `scribe install`, the error from running `install` before `init` must say "Run 'scribe init' first," not "Error: state file not found."
+
+---
+
+## 8. Implementation priorities: quick wins versus strategic investments
+
+### Week 1–2: Foundation (highest ROI, lowest effort)
+
+**Semantic exit codes.** Define the exit code taxonomy (0–10) and implement it consistently. This is a code-level change with no UX impact on humans but massive impact on agent reliability. Every `os.Exit(1)` becomes a specific code.
+
+**Structured error responses.** Wrap all error returns in a `StructuredError` struct with `code`, `message`, `retryable`, and `remediation` fields. When `--json` is active, errors serialize to JSON on stderr. Without `--json`, they render as human-readable messages. This is the single highest-leverage change.
+
+**`--json` flag on list and status commands.** Start with read-only commands: `scribe list --json`, `scribe search --json`, `scribe info --json`. These are the commands agents call most frequently. Define the output schema and commit to it.
+
+**TTY detection.** Use `isatty` to auto-detect pipe vs. terminal. In pipe mode: no colors, no prompts, no progress bars. If stdin is not a terminal and a required value is missing, fail with a clear error listing missing flags.
+
+### Week 3–4: Core agent experience
+
+**`--yes` and `--dry-run` flags.** Add to all mutating commands. `--yes` skips confirmation prompts. `--dry-run` shows what would change without acting. `--dry-run --json` is the agent's primary decision-making input.
+
+**Idempotent install.** `scribe install <skill>` with an already-installed skill should exit 0 with `{"status":"already_installed"}` instead of failing. Add `--if-not-exists` as a fallback for backward compatibility.
+
+**State file initialization.** Create `scribe.state.json` tracking installed skills, their versions, source registries, and installation timestamps. This becomes the foundation for `status`, `diff`, and `rollback`.
+
+**`CLAUDE.md` skill file.** Ship a markdown file documenting all commands, flags, exit codes, and examples. Claude Code reads this file to learn how to use Scribe. Include realistic examples — agents learn from examples faster than descriptions.
+
+### Month 2: Advanced patterns
+
+**Plan/apply workflow.** Implement `scribe plan <operation> --json` producing a structured change plan, and `scribe apply` executing the last plan. This is the terraform pattern.
+
+**`scribe doctor` command.** Check registry reachability, symlink validity, state consistency, tool directory existence. Output structured results with severity and remediation. Agents call this after failures to diagnose issues.
+
+**`scribe schema <command>` introspection.** Return JSON Schema for every command's input (flags/args) and output format. This enables dynamic tool discovery by agents without reading documentation.
+
+**Structured operation log.** Write JSON Lines to `~/.scribe/operations.log` recording every mutation: timestamp, command, skill, status, duration, actor (cli/mcp/ci). Support `scribe log --json --since 24h`.
+
+### Month 3+: Strategic capabilities
+
+**MCP server mode.** `scribe mcp serve` runs as a stdio-based MCP server using the official Go SDK. Same binary, dual surface. Expose all commands as MCP tools with proper annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`).
+
+**Lockfile management.** Implement `scribe.lock` with exact versions and integrity checksums. Add `scribe ci` for frozen-lockfile installs. Support `scribe why <skill>` for provenance tracking.
+
+**Rollback and snapshots.** State snapshots before mutations. `scribe rollback` to revert. Keep last 10 snapshots with rotation.
+
+**Session and rate limit management.** Include `_meta` in JSON responses with rate limit status. Implement `--max-retries` with exponential backoff for network operations.
+
+---
+
+## 9. Measurement plan: tracking whether agents succeed
+
+### Primary metrics
+
+**Agent task completion rate** — the percentage of agent-initiated Scribe operations that complete without human intervention. Measure by tracking invocations where `actor=agent` (detectable via non-TTY, `CI=true`, or `AGENT=true` environment variable) and correlating with error rates. Target: **>90%** of agent-initiated operations succeed on first attempt.
+
+**Human intervention rate** — how often a human must step in to fix a Scribe-related issue during agent workflows. Track by counting operations that exit with intervention-required codes (exit 5 for conflicts, errors requiring human judgment). Target: **<10%** of all operations. Measure weekly, trend over time.
+
+**Parse error rate** — how often agents fail to parse Scribe's output. This should be **0%** with proper `--json` implementation. Detect by monitoring agent retry patterns: if an agent calls `scribe list --json` then immediately calls it again with different flags, the first call likely produced unparseable output.
+
+**Retry rate per command** — the average number of retries before success. High retry rates indicate unclear errors or missing idempotency. Track retries by comparing sequential identical commands in the operation log. Target: **<1.2 average retries** per successful operation (meaning most succeed first try).
+
+### Implementation approach
+
+**Structured telemetry in the operation log.** Every invocation records:
+
+```json
+{
+  "timestamp": "2026-04-13T10:30:00Z",
+  "command": "install",
+  "args": ["code-review"],
+  "flags": {"json": true, "yes": true},
+  "exit_code": 0,
+  "duration_ms": 1250,
+  "actor": "agent",
+  "tty": false,
+  "output_bytes": 342,
+  "scribe_version": "0.12.0"
+}
+```
+
+**`scribe metrics` command** aggregates telemetry: success rate by command, error distribution by code, retry frequency, average duration. Output as JSON for dashboard ingestion.
+
+**Golden dataset for regression.** Maintain 20–50 scripted agent scenarios: install a skill, sync from manifest, handle a conflict, recover from network error. Run these as CI tests on every release. Any regression in success rate blocks the release.
+
+**Context window impact tracking.** Measure output token count per command. If `scribe list --json` returns 50KB for 10 skills, agents are paying unnecessarily. Track average output size and set budgets per command. The `--fields` flag enables agents to request only what they need.
+
+### Dogfooding signals
+
+Use Scribe from Claude Code daily. Track friction points: how often Claude Code misinterprets output, fails to parse errors, or retries unnecessarily. Each friction point is a bug. Maintain a friction log with severity ratings and resolution status. The team's own experience as Scribe-via-agent users is the most sensitive signal.
+
+---
+
+## 10. Resources: standards, articles, and implementations
+
+### Essential reading
+
+The three defining articles on agent-first CLI design emerged in early 2026. Justin Poehnelt's "You Need to Rewrite Your CLI for AI Agents" provides the comprehensive blueprint including schema introspection, context window discipline, and multi-surface architecture. Ugo Enyioha's "Writing CLI Tools That AI Agents Actually Want to Use" distills eight practical rules covering structured output, exit codes, idempotency, and composability. The InfoQ piece "Patterns for AI Agent Driven CLIs" (August 2025) provides the cautionary tales including the AWS pager incident.
+
+### Protocol specifications
+
+The **Model Context Protocol specification** (version 2025-11-25) at `modelcontextprotocol.io` defines tool schemas, transport mechanisms, error handling, and the new Tasks abstraction for async operations. The specification was donated to the Linux Foundation's Agentic AI Foundation in December 2025. Claude's tool-use documentation at `platform.claude.com` details the `tool_use`/`tool_result` lifecycle, `strict` mode for schema enforcement, and `input_examples` for improved accuracy. OpenAI's function calling guide covers the parallel Responses API approach.
+
+### Go implementations
+
+The official Go MCP SDK (`github.com/modelcontextprotocol/go-sdk`) — maintained in collaboration with Google — is the recommended implementation for adding MCP support to a Go CLI. The community `mcp-go` library (`github.com/mark3labs/mcp-go`) offers backward compatibility across all spec versions. Go's own `gopls` language server includes an experimental MCP server, demonstrating the dual-surface (LSP + MCP) pattern from a single binary.
+
+### Reference implementations
+
+Google's Workspace CLI (`gws`) implements the exact architecture recommended here: one binary serving CLI, MCP, and Gemini extension surfaces, with schema introspection via `gws schema <method>`. The `mcptools` CLI demonstrates MCP server interaction patterns (`mcp call`, `mcp list`, `mcp shell`). Homebrew's `brew bundle` shows declarative package management via manifest files. The `awesome-claude-code-toolkit` repository (`github.com/rohitg00/awesome-claude-code-toolkit`) collects agent, skill, plugin, and hook examples for Claude Code.
+
+### Emerging standards
+
+The `agents.md` specification (GitHub issue #136) proposes a standard environment variable for AI agent runtime detection, analogous to `CI=true`. The JSON Agents specification at `jsonagents.org/cli` defines a portable agent manifest format with CLI validation tools. Google's Agent2Agent (A2A) protocol uses AgentCard (JSON) for cross-agent discovery. OpenTelemetry's GenAI semantic conventions provide standardized attributes for agent operation telemetry.
+
+---
+
+## Conclusion: the agent-first inversion
+
+The shift from human-first to agent-first isn't adding `--json` flags — it's inverting the design hierarchy. In human-first design, the pretty output is the primary path and JSON is an afterthought. In agent-first design, **structured JSON is the primary output** and human formatting is a rendering layer on top. Exit codes aren't status indicators — they're control flow primitives. Error messages aren't explanations — they're data structures carrying codes, affected resources, and executable remediation steps.
+
+Scribe's strongest advantage is timing. The agentic CLI design patterns crystallized in 2025–2026 with MCP, tool-use protocols, and reference implementations like `gws`. Building on these patterns rather than inventing from scratch means Scribe can implement proven designs. The three-phase plan — foundation work on exit codes and structured errors (weeks 1–2), core agent experience with dry-run and idempotency (weeks 3–4), then strategic capabilities like MCP and lockfiles (months 2–3) — delivers compounding value at each stage. Every week of the foundation work immediately reduces agent failure rates.
+
+The measurement discipline — tracking completion rates, retry rates, and parse errors from day one — creates a feedback loop that makes every subsequent decision data-driven rather than intuition-driven. The target is clear: **>90% of agent-initiated operations succeed on first attempt, <10% require human intervention.** These numbers are achievable with the patterns described here, because the failure modes are well-understood and the solutions are proven across `gh`, `kubectl`, `terraform`, and the package manager ecosystem.


### PR DESCRIPTION
## Summary
- **Spec** (`2026-04-13-agent-first-cli-design.md`): rationale and concrete patterns for making AI agents Scribe's primary audience — structured output, error contracts, idempotency, MCP-ready vocabulary. References gh/kubectl/terraform precedents.
- **Plan** (`2026-04-14-nono-inspired-patterns.md`): checkbox plan for adopting three nono-cli patterns — Claude Code hook integration, embedded registry catalog, three-state config layering.

Docs only, no code changes.

## Test plan
- [x] Files render correctly on GitHub