### PR TITLE
feat: add mattpocock/skills as default built-in registry

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -15,13 +15,15 @@ import (
 func newConnectCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "connect [owner/repo]",
-		Short: "Connect to a team skills repo",
-		Long: `Connect to a team skills repo so Scribe can sync your local skills.
+		Short: "Connect to a skill registry",
+		Long: `Connect to a skill registry so Scribe can sync skills from it.
 
-The repo must contain a scribe.toml with a [team] section.
+Works with any GitHub repo containing skills — team registries (scribe.yaml)
+and community registries (bare skill files) are both supported.
 
 Examples:
   scribe connect ArtistfyHQ/team-skills
+  scribe connect mattpocock/skills
   scribe connect                          # interactive prompt`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runConnect,
@@ -56,7 +58,7 @@ func resolveRepo(args []string) (string, error) {
 
 	var repo string
 	err := huh.NewInput().
-		Title("Team skills repo").
+		Title("Skill registry repo").
 		Placeholder("owner/repo").
 		Validate(func(s string) error {
 			_, _, err := manifest.ParseOwnerRepo(s)

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/doctor"
+)
+
+func newDoctorCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Inspect managed skill health",
+		Long: `Inspect managed skill health and report canonical metadata or projection drift.
+
+Use --json for machine-readable output.
+
+Examples:
+  scribe doctor
+  scribe doctor --skill recap
+  scribe doctor --json`,
+		Args: cobra.NoArgs,
+		RunE: runDoctor,
+	}
+	cmd.Flags().Bool("fix", false, "Reserved for repair mode (Task 4)")
+	cmd.Flags().String("skill", "", "Inspect a single managed skill")
+	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	return cmd
+}
+
+type doctorIssueJSON struct {
+	Skill   string `json:"skill"`
+	Tool    string `json:"tool,omitempty"`
+	Kind    string `json:"kind"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+type doctorReportJSON struct {
+	Skill  string            `json:"skill,omitempty"`
+	Fix    bool              `json:"fix"`
+	Issues []doctorIssueJSON `json:"issues"`
+}
+
+func runDoctor(cmd *cobra.Command, _ []string) error {
+	fixFlag, _ := cmd.Flags().GetBool("fix")
+	skillFlag, _ := cmd.Flags().GetString("skill")
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+
+	if fixFlag && jsonFlag {
+		return fmt.Errorf("doctor: --fix cannot be combined with --json")
+	}
+	if fixFlag {
+		return fmt.Errorf("doctor: --fix not implemented yet")
+	}
+
+	factory := newCommandFactory()
+
+	cfg, err := factory.Config()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	st, err := factory.State()
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
+
+	if skillFlag != "" {
+		if _, ok := st.Installed[skillFlag]; !ok {
+			return fmt.Errorf("doctor: skill %q is not installed", skillFlag)
+		}
+	}
+
+	report, err := doctor.InspectManagedSkills(cfg, st, skillFlag)
+	if err != nil {
+		return fmt.Errorf("inspect managed skills: %w", err)
+	}
+
+	if jsonFlag {
+		return writeDoctorJSON(cmd.OutOrStdout(), skillFlag, report)
+	}
+	return writeDoctorText(cmd.OutOrStdout(), skillFlag, report)
+}
+
+func writeDoctorJSON(w io.Writer, skill string, report doctor.Report) error {
+	out := doctorReportJSON{
+		Skill:  skill,
+		Fix:    false,
+		Issues: make([]doctorIssueJSON, 0, len(report.Issues)),
+	}
+	for _, issue := range report.Issues {
+		out.Issues = append(out.Issues, doctorIssueJSON{
+			Skill:   issue.Skill,
+			Tool:    issue.Tool,
+			Kind:    string(issue.Kind),
+			Status:  issue.Status,
+			Message: issue.Message,
+		})
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+func writeDoctorText(w io.Writer, skill string, report doctor.Report) error {
+	if len(report.Issues) == 0 {
+		if skill != "" {
+			_, err := fmt.Fprintf(w, "No managed skill issues found for %s.\n", skill)
+			return err
+		}
+		_, err := fmt.Fprintln(w, "No managed skill issues found.")
+		return err
+	}
+
+	if skill != "" {
+		if _, err := fmt.Fprintf(w, "Managed skill issues for %s:\n", skill); err != nil {
+			return err
+		}
+	} else {
+		if _, err := fmt.Fprintln(w, "Managed skill issues:"); err != nil {
+			return err
+		}
+	}
+
+	for _, issue := range report.Issues {
+		if issue.Tool != "" {
+			if _, err := fmt.Fprintf(w, "- %s [%s] %s tool=%s: %s\n", issue.Skill, issue.Status, issue.Kind, issue.Tool, issue.Message); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := fmt.Fprintf(w, "- %s [%s] %s: %s\n", issue.Skill, issue.Status, issue.Kind, issue.Message); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/doctor"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+func TestDoctorCommandReportsIssues(t *testing.T) {
+	setupDoctorIssueFixture(t)
+
+	root := newRootCmd()
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"doctor"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v (stderr=%s)", err, errBuf.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "recap") {
+		t.Fatalf("expected recap in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "missing a description") {
+		t.Fatalf("expected canonical metadata message in output, got:\n%s", got)
+	}
+}
+
+func TestDoctorRejectsUnknownSkill(t *testing.T) {
+	setupDoctorCleanFixture(t)
+
+	root := newRootCmd()
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"doctor", "--skill", "missing"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown skill")
+	}
+	if !strings.Contains(err.Error(), "not installed") {
+		t.Fatalf("expected not-installed error, got %q", err.Error())
+	}
+}
+
+func TestDoctorRejectsBareFix(t *testing.T) {
+	setupDoctorCleanFixture(t)
+
+	root := newRootCmd()
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"doctor", "--fix"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for bare --fix")
+	}
+	if !strings.Contains(err.Error(), "--fix not implemented yet") {
+		t.Fatalf("expected not-implemented error, got %q", err.Error())
+	}
+}
+
+func TestDoctorNoIssueOutput(t *testing.T) {
+	setupDoctorCleanFixture(t)
+
+	root := newRootCmd()
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"doctor"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v (stderr=%s)", err, errBuf.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "No managed skill issues found.") {
+		t.Fatalf("expected no-issue output, got:\n%s", got)
+	}
+}
+
+func TestDoctorJSONOutput(t *testing.T) {
+	setupDoctorIssueFixture(t)
+
+	root := newRootCmd()
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"doctor", "--json"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v (stderr=%s)", err, errBuf.String())
+	}
+
+	var report struct {
+		Issues []struct {
+			Skill   string `json:"skill"`
+			Tool    string `json:"tool"`
+			Kind    string `json:"kind"`
+			Status  string `json:"status"`
+			Message string `json:"message"`
+		} `json:"issues"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, out.String())
+	}
+	if len(report.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d: %+v", len(report.Issues), report.Issues)
+	}
+}
+
+func TestDoctorTextIncludesTool(t *testing.T) {
+	var buf bytes.Buffer
+	err := writeDoctorText(&buf, "", doctor.Report{
+		Issues: []doctor.Issue{{
+			Skill:   "recap",
+			Tool:    "codex",
+			Kind:    doctor.IssueProjectionDrift,
+			Status:  "warn",
+			Message: "missing managed projection",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("writeDoctorText: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "tool=codex") {
+		t.Fatalf("expected tool in text output, got:\n%s", got)
+	}
+}
+
+func setupDoctorCleanFixture(t *testing.T) {
+	t.Helper()
+	setupDoctorFixture(t, false)
+}
+
+func setupDoctorIssueFixture(t *testing.T) {
+	t.Helper()
+	setupDoctorFixture(t, true)
+}
+
+func setupDoctorFixture(t *testing.T, withIssue bool) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	cfg := &config.Config{BuiltinsVersion: 3}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	if _, err := tools.WriteToStore("recap", []tools.SkillFile{{
+		Path: "SKILL.md",
+		Content: []byte(`---
+name: recap
+description: Keep daily notes and summaries.
+---
+
+# Recap
+`),
+	}}); err != nil {
+		t.Fatalf("write recap store: %v", err)
+	}
+
+	if _, err := tools.WriteToStore("notes", []tools.SkillFile{{
+		Path: "SKILL.md",
+		Content: []byte(`---
+name: notes
+description: Capture anything useful.
+---
+
+# Notes
+`),
+	}}); err != nil {
+		t.Fatalf("write notes store: %v", err)
+	}
+
+	if withIssue {
+		recapDir := filepath.Join(home, ".scribe", "skills", "recap")
+		if err := os.WriteFile(filepath.Join(recapDir, "SKILL.md"), []byte(`---
+name: recap
+---
+
+# Recap
+`), 0o644); err != nil {
+			t.Fatalf("overwrite recap store: %v", err)
+		}
+	}
+
+	st := &state.State{
+		SchemaVersion: 4,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Revision:      1,
+				InstalledHash: "hash-recap",
+				ToolsMode:     state.ToolsModePinned,
+			},
+			"notes": {
+				Revision:      1,
+				InstalledHash: "hash-notes",
+				ToolsMode:     state.ToolsModePinned,
+			},
+		},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -142,6 +142,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		newCreateCommand(),
 		newExplainCommand(),
+		newDoctorCommand(),
 		newUpgradeCommand(),
 		newUpgradeAgentCommand(),
 	)

--- a/internal/add/add.go
+++ b/internal/add/add.go
@@ -58,16 +58,36 @@ func (a *Adder) DiscoverLocal(st *state.State) ([]Candidate, error) {
 
 	candidates := make([]Candidate, 0, len(skills))
 	for _, sk := range skills {
+		source := sourceFromState(st, sk.Name)
 		candidates = append(candidates, Candidate{
 			Name:        sk.Name,
 			Description: sk.Description,
 			Origin:      "local",
 			Package:     sk.Package,
 			LocalPath:   sk.LocalPath,
+			Source:      source,
 		})
 	}
 
 	return candidates, nil
+}
+
+// sourceFromState returns the "github:owner/repo@ref" string for a skill if
+// state records a registry origin for it. Empty string means local-only.
+func sourceFromState(st *state.State, name string) string {
+	if st == nil {
+		return ""
+	}
+	installed, ok := st.Installed[name]
+	if !ok || len(installed.Sources) == 0 {
+		return ""
+	}
+	src := installed.Sources[0]
+	ref := src.Ref
+	if ref == "" {
+		ref = "main"
+	}
+	return fmt.Sprintf("github:%s@%s", src.Registry, ref)
 }
 
 // DiscoverRemote finds skills in other registries that are not in the target registry.

--- a/internal/add/add_test.go
+++ b/internal/add/add_test.go
@@ -116,12 +116,68 @@ func TestDiscoverLocalSkills(t *testing.T) {
 	if !ok {
 		t.Fatal("missing candidate: deploy")
 	}
-	// Local discovery no longer populates Source — local candidates always need upload.
-	if deploy.Source != "" {
-		t.Errorf("deploy source: got %q, want empty", deploy.Source)
+	// State records registry origin — source should be populated so no upload is needed.
+	if deploy.Source != "github:owner/repo@v1.0.0" {
+		t.Errorf("deploy source: got %q, want github:owner/repo@v1.0.0", deploy.Source)
 	}
-	if !deploy.NeedsUpload() {
-		t.Error("deploy should need upload (local candidate)")
+	if deploy.NeedsUpload() {
+		t.Error("deploy should not need upload — has registry source from state")
+	}
+}
+
+func TestDiscoverLocal_SourceFromState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// grill-me: synced from mattpocock/skills — should get source, no upload.
+	grillDir := filepath.Join(home, ".scribe", "skills", "grill-me")
+	if err := os.MkdirAll(grillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(grillDir, "SKILL.md"), []byte("# Grill Me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// local-only: no state entry — should need upload.
+	localDir := filepath.Join(home, ".scribe", "skills", "my-tool")
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "SKILL.md"), []byte("# My Tool"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	st := &state.State{
+		Installed: map[string]state.InstalledSkill{
+			"grill-me": {Sources: []state.SkillSource{{Registry: "mattpocock/skills", Ref: "main"}}},
+		},
+	}
+
+	adder := &add.Adder{}
+	candidates, err := adder.DiscoverLocal(st)
+	if err != nil {
+		t.Fatalf("DiscoverLocal: %v", err)
+	}
+
+	byName := map[string]add.Candidate{}
+	for _, c := range candidates {
+		byName[c.Name] = c
+	}
+
+	grill := byName["grill-me"]
+	if grill.Source != "github:mattpocock/skills@main" {
+		t.Errorf("grill-me source: got %q, want github:mattpocock/skills@main", grill.Source)
+	}
+	if grill.NeedsUpload() {
+		t.Error("grill-me should not need upload — source known from state")
+	}
+
+	myTool := byName["my-tool"]
+	if myTool.Source != "" {
+		t.Errorf("my-tool source: got %q, want empty (no state entry)", myTool.Source)
+	}
+	if !myTool.NeedsUpload() {
+		t.Error("my-tool should need upload — no registry origin")
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,392 @@
+package doctor
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/skillmd"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+	"gopkg.in/yaml.v3"
+)
+
+type IssueKind string
+
+const (
+	IssueCanonicalMetadata IssueKind = "canonical_metadata"
+	IssueProjectionDrift   IssueKind = "projection_drift"
+)
+
+type Issue struct {
+	Skill   string
+	Tool    string
+	Kind    IssueKind
+	Status  string
+	Message string
+}
+
+type Report struct {
+	Issues []Issue
+}
+
+func InspectManagedSkills(cfg *config.Config, st *state.State, name string) (Report, error) {
+	if st == nil {
+		return Report{}, fmt.Errorf("load state: missing")
+	}
+
+	names := managedSkillNames(st, name)
+	if len(names) == 0 {
+		return Report{}, nil
+	}
+
+	availableTools := availableToolNames(cfg)
+
+	var issues []Issue
+	for _, skillName := range names {
+		skill := st.Installed[skillName]
+
+		if skill.Type == "package" {
+			continue
+		}
+
+		if canonicalIssues, err := inspectCanonicalMetadata(skillName); err != nil {
+			return Report{}, err
+		} else {
+			issues = append(issues, canonicalIssues...)
+		}
+
+		if projectionIssue, ok := inspectProjectionDrift(cfg, skillName, skill, availableTools); ok {
+			issues = append(issues, projectionIssue)
+		}
+	}
+
+	sort.SliceStable(issues, func(i, j int) bool {
+		if issues[i].Skill != issues[j].Skill {
+			return issues[i].Skill < issues[j].Skill
+		}
+		if issues[i].Kind != issues[j].Kind {
+			return issues[i].Kind < issues[j].Kind
+		}
+		if issues[i].Tool != issues[j].Tool {
+			return issues[i].Tool < issues[j].Tool
+		}
+		return issues[i].Message < issues[j].Message
+	})
+
+	return Report{Issues: issues}, nil
+}
+
+func managedSkillNames(st *state.State, name string) []string {
+	if name != "" {
+		if _, ok := st.Installed[name]; !ok {
+			return nil
+		}
+		return []string{name}
+	}
+
+	names := make([]string, 0, len(st.Installed))
+	for skillName := range st.Installed {
+		names = append(names, skillName)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func availableToolNames(cfg *config.Config) []string {
+	seen := map[string]bool{}
+	disabled := map[string]bool{}
+	names := make([]string, 0)
+
+	if cfg != nil {
+		for _, tc := range cfg.Tools {
+			if strings.TrimSpace(tc.Name) == "" {
+				continue
+			}
+			if !tc.Enabled {
+				disabled[strings.ToLower(tc.Name)] = true
+			}
+		}
+	}
+
+	for _, tool := range tools.DetectTools() {
+		name := tool.Name()
+		key := strings.ToLower(name)
+		if seen[key] || disabled[key] {
+			continue
+		}
+		seen[key] = true
+		names = append(names, name)
+	}
+	if cfg == nil {
+		return names
+	}
+	for _, tc := range cfg.Tools {
+		if !tc.Enabled || strings.TrimSpace(tc.Name) == "" {
+			continue
+		}
+		key := strings.ToLower(tc.Name)
+		if seen[key] || disabled[key] {
+			continue
+		}
+		seen[key] = true
+		names = append(names, tc.Name)
+	}
+	return names
+}
+
+func inspectCanonicalMetadata(skillName string) ([]Issue, error) {
+	canonicalDir, err := storeSkillDir(skillName)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := os.ReadFile(filepath.Join(canonicalDir, "SKILL.md"))
+	if err != nil {
+		return []Issue{{
+			Skill:   skillName,
+			Kind:    IssueCanonicalMetadata,
+			Status:  "error",
+			Message: fmt.Sprintf("read canonical SKILL.md: %v", err),
+		}}, nil
+	}
+
+	_, normalized, err := skillmd.Normalize(skillName, content)
+	if err != nil {
+		return []Issue{{
+			Skill:   skillName,
+			Kind:    IssueCanonicalMetadata,
+			Status:  "error",
+			Message: err.Error(),
+		}}, nil
+	}
+
+	if bytes.Equal(content, normalized) {
+		return nil, nil
+	}
+
+	message := "SKILL.md needs canonical normalization"
+	hasDescription, descErr := canonicalFrontmatterHasDescription(content)
+	if descErr != nil {
+		return []Issue{{
+			Skill:   skillName,
+			Kind:    IssueCanonicalMetadata,
+			Status:  "error",
+			Message: descErr.Error(),
+		}}, nil
+	}
+	if !hasDescription {
+		message = "SKILL.md is missing a description"
+	}
+
+	return []Issue{{
+		Skill:   skillName,
+		Kind:    IssueCanonicalMetadata,
+		Status:  "warn",
+		Message: message,
+	}}, nil
+}
+
+func inspectProjectionDrift(cfg *config.Config, skillName string, skill state.InstalledSkill, availableTools []string) (Issue, bool) {
+	expectedTools := skill.EffectiveTools(availableTools)
+	if skill.Type == "package" {
+		return Issue{}, false
+	}
+
+	type expectedProjection struct {
+		Tool   string
+		Target string
+	}
+
+	expectedPaths := make(map[string]expectedProjection, len(expectedTools))
+	opaquePaths := make(map[string]bool, len(expectedTools))
+	canonicalDir, err := storeSkillDir(skillName)
+	if err != nil {
+		return Issue{
+			Skill:   skillName,
+			Kind:    IssueProjectionDrift,
+			Status:  "error",
+			Message: fmt.Sprintf("resolve canonical dir: %v", err),
+		}, true
+	}
+
+	for _, toolName := range expectedTools {
+		tool, err := tools.ResolveByName(cfg, toolName)
+		if err != nil {
+			return Issue{
+				Skill:   skillName,
+				Tool:    toolName,
+				Kind:    IssueProjectionDrift,
+				Status:  "error",
+				Message: fmt.Sprintf("resolve tool %q: %v", toolName, err),
+			}, true
+		}
+		path, err := tool.SkillPath(skillName)
+		if err != nil {
+			return Issue{
+				Skill:   skillName,
+				Tool:    toolName,
+				Kind:    IssueProjectionDrift,
+				Status:  "error",
+				Message: fmt.Sprintf("resolve projection path for %q: %v", toolName, err),
+			}, true
+		}
+		target, inspectable := tool.CanonicalTarget(canonicalDir)
+		if !inspectable {
+			opaquePaths[path] = true
+			continue
+		}
+		expectedPaths[path] = expectedProjection{Tool: toolName, Target: target}
+	}
+
+	actualPaths := projectionPaths(skill)
+	actualSet := make(map[string]bool, len(actualPaths))
+	for _, path := range actualPaths {
+		if path == "" {
+			continue
+		}
+		actualSet[path] = true
+	}
+
+	var details []string
+	primaryTool := ""
+
+	for _, conflict := range skill.Conflicts {
+		if opaquePaths[conflict.Path] {
+			continue
+		}
+		details = append(details, fmt.Sprintf("%s projection at %s is conflicted", conflict.Tool, conflict.Path))
+		if primaryTool == "" && conflict.Tool != "" {
+			primaryTool = conflict.Tool
+		}
+	}
+
+	for _, path := range actualPaths {
+		if path == "" {
+			continue
+		}
+		if _, ok := expectedPaths[path]; ok {
+			continue
+		}
+		if opaquePaths[path] {
+			continue
+		}
+		toolName := inferToolName(path, cfg, skillName)
+		details = append(details, fmt.Sprintf("unexpected managed projection %s at %s", toolName, path))
+		if primaryTool == "" {
+			primaryTool = toolName
+		}
+	}
+
+	for path, expected := range expectedPaths {
+		if !actualSet[path] {
+			details = append(details, fmt.Sprintf("missing managed projection for %s at %s", expected.Tool, path))
+			if primaryTool == "" {
+				primaryTool = expected.Tool
+			}
+			continue
+		}
+		if !pathPointsToCanonical(path, expected.Target) {
+			details = append(details, fmt.Sprintf("%s projection at %s does not point to the canonical target", expected.Tool, path))
+			if primaryTool == "" {
+				primaryTool = expected.Tool
+			}
+		}
+	}
+
+	if len(details) == 0 {
+		return Issue{}, false
+	}
+
+	return Issue{
+		Skill:   skillName,
+		Tool:    primaryTool,
+		Kind:    IssueProjectionDrift,
+		Status:  "warn",
+		Message: strings.Join(details, "; "),
+	}, true
+}
+
+func projectionPaths(skill state.InstalledSkill) []string {
+	if len(skill.ManagedPaths) > 0 {
+		return append([]string(nil), skill.ManagedPaths...)
+	}
+	return append([]string(nil), skill.Paths...)
+}
+
+func inferToolName(path string, cfg *config.Config, skillName string) string {
+	for _, toolName := range availableToolNames(cfg) {
+		tool, err := tools.ResolveByName(cfg, toolName)
+		if err != nil {
+			continue
+		}
+		toolPath, err := tool.SkillPath(skillName)
+		if err == nil && toolPath == path {
+			return tool.Name()
+		}
+	}
+	return ""
+}
+
+func pathPointsToCanonical(path, canonicalDir string) bool {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	canonicalResolved, err := filepath.EvalSymlinks(canonicalDir)
+	if err != nil {
+		canonicalResolved = canonicalDir
+	}
+	return resolved == canonicalResolved
+}
+
+func storeSkillDir(skillName string) (string, error) {
+	base, err := tools.StoreDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve store dir: %w", err)
+	}
+	return filepath.Join(base, skillName), nil
+}
+
+func canonicalFrontmatterHasDescription(content []byte) (bool, error) {
+	type frontmatter struct {
+		Description string `yaml:"description"`
+	}
+
+	normalized := normalizeLineEndings(content)
+	if !bytes.HasPrefix(normalized, []byte("---\n")) {
+		return false, nil
+	}
+
+	lines := bytes.Split(normalized, []byte("\n"))
+	if len(lines) < 2 {
+		return false, fmt.Errorf("parse frontmatter: unterminated frontmatter")
+	}
+
+	var fmLines [][]byte
+	end := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(string(lines[i])) == "---" {
+			end = i
+			break
+		}
+		fmLines = append(fmLines, lines[i])
+	}
+	if end < 0 {
+		return false, fmt.Errorf("parse frontmatter: unterminated frontmatter")
+	}
+
+	var fm frontmatter
+	if err := yaml.Unmarshal(bytes.Join(fmLines, []byte("\n")), &fm); err != nil {
+		return false, fmt.Errorf("parse frontmatter: %w", err)
+	}
+	return strings.TrimSpace(fm.Description) != "", nil
+}
+
+func normalizeLineEndings(content []byte) []byte {
+	return bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,377 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+func TestInspectSkillReportsMissingDescription(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	writeSkill(t, "recap", []byte(`---
+name: recap
+---
+
+# Recap
+
+Keep daily notes and summaries.
+`))
+
+	st := managedState("recap", []string{"claude"}, nil)
+
+	report, err := InspectManagedSkills(nil, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+
+	if len(report.Issues) != 1 {
+		t.Fatalf("Issues = %d, want 1: %+v", len(report.Issues), report.Issues)
+	}
+	issue := report.Issues[0]
+	if issue.Skill != "recap" {
+		t.Fatalf("Skill = %q, want recap", issue.Skill)
+	}
+	if issue.Kind != IssueCanonicalMetadata {
+		t.Fatalf("Kind = %q, want %q", issue.Kind, IssueCanonicalMetadata)
+	}
+	if issue.Status != "warn" {
+		t.Fatalf("Status = %q, want warn", issue.Status)
+	}
+	if !strings.Contains(issue.Message, "description") {
+		t.Fatalf("Message = %q, want description-related issue", issue.Message)
+	}
+}
+
+func TestInspectSkillReportsInvalidFrontmatter(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	writeSkill(t, "recap", []byte(`---
+name: recap
+
+# missing closing delimiter
+`))
+
+	st := managedState("recap", []string{"claude"}, nil)
+
+	report, err := InspectManagedSkills(nil, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+
+	if len(report.Issues) != 1 {
+		t.Fatalf("Issues = %d, want 1: %+v", len(report.Issues), report.Issues)
+	}
+	issue := report.Issues[0]
+	if issue.Skill != "recap" {
+		t.Fatalf("Skill = %q, want recap", issue.Skill)
+	}
+	if issue.Kind != IssueCanonicalMetadata {
+		t.Fatalf("Kind = %q, want %q", issue.Kind, IssueCanonicalMetadata)
+	}
+	if issue.Status != "error" {
+		t.Fatalf("Status = %q, want error", issue.Status)
+	}
+	if !strings.Contains(issue.Message, "frontmatter") {
+		t.Fatalf("Message = %q, want frontmatter-related issue", issue.Message)
+	}
+}
+
+func TestInspectSkillReportsBrokenProjectionState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	canonical := writeSkill(t, "recap", []byte(`---
+name: recap
+description: Keep daily notes and summaries.
+---
+
+# Recap
+`))
+
+	codexPath := filepath.Join(home, ".codex", "skills", "recap")
+	if err := os.MkdirAll(filepath.Dir(codexPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(canonical, codexPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	cfg := &config.Config{
+		Tools: []config.ToolConfig{
+			{Name: "claude", Enabled: true},
+			{Name: "codex", Enabled: true},
+		},
+	}
+	st := managedState("recap", []string{"claude"}, []string{codexPath})
+
+	report, err := InspectManagedSkills(cfg, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+
+	if len(report.Issues) != 1 {
+		t.Fatalf("Issues = %d, want 1: %+v", len(report.Issues), report.Issues)
+	}
+	issue := report.Issues[0]
+	if issue.Skill != "recap" {
+		t.Fatalf("Skill = %q, want recap", issue.Skill)
+	}
+	if issue.Kind != IssueProjectionDrift {
+		t.Fatalf("Kind = %q, want %q", issue.Kind, IssueProjectionDrift)
+	}
+	if issue.Tool != "codex" {
+		t.Fatalf("Tool = %q, want codex", issue.Tool)
+	}
+	if issue.Status != "warn" {
+		t.Fatalf("Status = %q, want warn", issue.Status)
+	}
+}
+
+func TestInspectCanLimitToOneSkill(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	writeSkill(t, "recap", []byte(`---
+name: recap
+---
+
+Keep daily notes and summaries.
+`))
+	writeSkill(t, "notes", []byte(`---
+name: notes
+---
+
+Capture anything useful.
+`))
+
+	st := &state.State{
+		SchemaVersion: 4,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Revision:      1,
+				InstalledHash: "a",
+				Tools:         []string{"claude"},
+				ToolsMode:     state.ToolsModePinned,
+			},
+			"notes": {
+				Revision:      1,
+				InstalledHash: "b",
+				Tools:         []string{"claude"},
+				ToolsMode:     state.ToolsModePinned,
+			},
+		},
+	}
+
+	report, err := InspectManagedSkills(nil, st, "recap")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+
+	if len(report.Issues) != 1 {
+		t.Fatalf("Issues = %d, want 1: %+v", len(report.Issues), report.Issues)
+	}
+	if report.Issues[0].Skill != "recap" {
+		t.Fatalf("Skill = %q, want recap", report.Issues[0].Skill)
+	}
+}
+
+func TestInspectSkipsPackageSkills(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	writeSkill(t, "bundle", []byte(`---
+name: bundle
+
+# broken package metadata that should be ignored
+`))
+
+	st := &state.State{
+		SchemaVersion: 4,
+		Installed: map[string]state.InstalledSkill{
+			"bundle": {
+				Revision:      1,
+				InstalledHash: "pkg",
+				Tools:         []string{"claude"},
+				ToolsMode:     state.ToolsModePinned,
+				Type:          "package",
+			},
+		},
+	}
+
+	report, err := InspectManagedSkills(nil, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+	if len(report.Issues) != 0 {
+		t.Fatalf("Issues = %d, want 0: %+v", len(report.Issues), report.Issues)
+	}
+}
+
+func TestInspectSkipsOpaqueToolProjections(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	writeSkill(t, "recap", []byte(`---
+name: recap
+description: Keep daily notes and summaries.
+---
+
+# Recap
+`))
+
+	ghostPath := filepath.Join(home, ".ghost", "skills", "recap")
+	st := &state.State{
+		SchemaVersion: 4,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Revision:      1,
+				InstalledHash: "hash",
+				Tools:         []string{"ghost"},
+				ToolsMode:     state.ToolsModePinned,
+				ManagedPaths:  []string{ghostPath},
+				Paths:         []string{ghostPath},
+			},
+		},
+	}
+	cfg := &config.Config{
+		Tools: []config.ToolConfig{
+			{
+				Name:      "ghost",
+				Enabled:   true,
+				Install:   "echo install",
+				Uninstall: "echo uninstall",
+				Path:      ghostPath,
+			},
+		},
+	}
+
+	report, err := InspectManagedSkills(cfg, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+	if len(report.Issues) != 0 {
+		t.Fatalf("Issues = %d, want 0: %+v", len(report.Issues), report.Issues)
+	}
+}
+
+func TestInspectContinuesWithInvalidUnrelatedToolConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	canonical := writeSkill(t, "recap", []byte(`---
+name: recap
+---
+
+# Recap
+
+Keep daily notes and summaries.
+`))
+
+	claudePath := filepath.Join(home, ".claude", "skills", "recap")
+	if err := os.MkdirAll(filepath.Dir(claudePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(canonical, claudePath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	st := managedState("recap", []string{"claude"}, []string{claudePath})
+	cfg := &config.Config{
+		Tools: []config.ToolConfig{
+			{Name: "claude", Enabled: true},
+			{Name: "broken", Enabled: true, Install: "echo install"},
+		},
+	}
+
+	report, err := InspectManagedSkills(cfg, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+	if len(report.Issues) != 1 {
+		t.Fatalf("Issues = %d, want 1: %+v", len(report.Issues), report.Issues)
+	}
+	if report.Issues[0].Kind != IssueCanonicalMetadata {
+		t.Fatalf("Kind = %q, want %q", report.Issues[0].Kind, IssueCanonicalMetadata)
+	}
+}
+
+func TestInspectIgnoresExplicitlyDisabledBuiltinTools(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	writeSkill(t, "recap", []byte(`---
+name: recap
+description: Keep daily notes and summaries.
+---
+
+# Recap
+`))
+
+	st := &state.State{
+		SchemaVersion: 4,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Revision:      1,
+				InstalledHash: "hash",
+				ToolsMode:     state.ToolsModeInherit,
+			},
+		},
+	}
+	cfg := &config.Config{
+		Tools: []config.ToolConfig{
+			{Name: "claude", Enabled: false},
+		},
+	}
+
+	report, err := InspectManagedSkills(cfg, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+	if len(report.Issues) != 0 {
+		t.Fatalf("Issues = %d, want 0: %+v", len(report.Issues), report.Issues)
+	}
+}
+
+func writeSkill(t *testing.T, name string, content []byte) string {
+	t.Helper()
+
+	dir, err := tools.WriteToStore(name, []tools.SkillFile{{Path: "SKILL.md", Content: content}})
+	if err != nil {
+		t.Fatalf("WriteToStore(%s): %v", name, err)
+	}
+	return dir
+}
+
+func managedState(name string, toolsList []string, managedPaths []string) *state.State {
+	return &state.State{
+		SchemaVersion: 4,
+		Installed: map[string]state.InstalledSkill{
+			name: {
+				Revision:      1,
+				InstalledHash: "hash",
+				Tools:         append([]string(nil), toolsList...),
+				ToolsMode:     state.ToolsModePinned,
+				ManagedPaths:  append([]string(nil), managedPaths...),
+				Paths:         append([]string(nil), managedPaths...),
+			},
+		},
+	}
+}

--- a/internal/firstrun/default_registries.yaml
+++ b/internal/firstrun/default_registries.yaml
@@ -1,0 +1,13 @@
+# Default registries bundled with scribe.
+# Bump version whenever the list changes — ApplyBuiltins uses this to backfill
+# existing users who were on an older version.
+version: 4
+registries:
+  - repo: Naoray/scribe
+    type: community
+  - repo: anthropics/skills
+    type: community
+  - repo: expo/skills
+    type: community
+  - repo: mattpocock/skills
+    type: community

--- a/internal/firstrun/firstrun.go
+++ b/internal/firstrun/firstrun.go
@@ -24,10 +24,11 @@ var builtinRepos = []string{
 	"Naoray/scribe",
 	"anthropics/skills",
 	"expo/skills",
+	"mattpocock/skills",
 }
 
 // currentBuiltinsVersion bumps whenever builtinRepos changes.
-const currentBuiltinsVersion = 3
+const currentBuiltinsVersion = 4
 
 // BuiltinRegistries returns RegistryConfig entries for built-in registries.
 func BuiltinRegistries() []config.RegistryConfig {

--- a/internal/firstrun/firstrun.go
+++ b/internal/firstrun/firstrun.go
@@ -2,12 +2,15 @@ package firstrun
 
 import (
 	"bufio"
+	_ "embed"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/Naoray/scribe/internal/adopt"
 	"github.com/Naoray/scribe/internal/config"
@@ -19,25 +22,36 @@ import (
 const removeOpenAICodexMigration = "remove_openai_codex_v1"
 const renameBuiltinReposMigration = "rename_builtin_repos_v1"
 
-// builtinRepos are well-known public registries auto-added during first run.
-var builtinRepos = []string{
-	"Naoray/scribe",
-	"anthropics/skills",
-	"expo/skills",
-	"mattpocock/skills",
+//go:embed default_registries.yaml
+var defaultRegistriesYAML []byte
+
+// defaultRegistriesConfig is the shape of default_registries.yaml.
+type defaultRegistriesConfig struct {
+	Version    int `yaml:"version"`
+	Registries []struct {
+		Repo string `yaml:"repo"`
+		Type string `yaml:"type"`
+	} `yaml:"registries"`
 }
 
-// currentBuiltinsVersion bumps whenever builtinRepos changes.
-const currentBuiltinsVersion = 4
+// parsedDefaults is populated once at init from the embedded YAML.
+var parsedDefaults = func() defaultRegistriesConfig {
+	var cfg defaultRegistriesConfig
+	if err := yaml.Unmarshal(defaultRegistriesYAML, &cfg); err != nil {
+		panic(fmt.Sprintf("firstrun: parse default_registries.yaml: %v", err))
+	}
+	return cfg
+}()
 
-// BuiltinRegistries returns RegistryConfig entries for built-in registries.
+// BuiltinRegistries returns RegistryConfig entries for built-in registries
+// as declared in default_registries.yaml.
 func BuiltinRegistries() []config.RegistryConfig {
-	registries := make([]config.RegistryConfig, len(builtinRepos))
-	for i, repo := range builtinRepos {
+	registries := make([]config.RegistryConfig, len(parsedDefaults.Registries))
+	for i, r := range parsedDefaults.Registries {
 		registries[i] = config.RegistryConfig{
-			Repo:    repo,
+			Repo:    r.Repo,
 			Enabled: true,
-			Type:    config.RegistryTypeCommunity,
+			Type:    r.Type,
 			Builtin: true,
 		}
 	}
@@ -133,7 +147,7 @@ func promptYN(in io.Reader, out io.Writer, question string, defaultYes bool) boo
 // firstRun is true only when the config had no prior builtins version.
 func ApplyBuiltins(cfg *config.Config) ([]string, bool) {
 	firstRun := cfg.BuiltinsVersion == 0
-	if cfg.BuiltinsVersion >= currentBuiltinsVersion {
+	if cfg.BuiltinsVersion >= parsedDefaults.Version {
 		return nil, false
 	}
 
@@ -144,7 +158,7 @@ func ApplyBuiltins(cfg *config.Config) ([]string, bool) {
 			added = append(added, builtin.Repo)
 		}
 	}
-	cfg.BuiltinsVersion = currentBuiltinsVersion
+	cfg.BuiltinsVersion = parsedDefaults.Version
 	return added, firstRun
 }
 

--- a/internal/firstrun/firstrun_internal_test.go
+++ b/internal/firstrun/firstrun_internal_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestApplyBuiltins_AlreadyCurrentIsNoop(t *testing.T) {
-	cfg := &config.Config{BuiltinsVersion: currentBuiltinsVersion}
+	cfg := &config.Config{BuiltinsVersion: parsedDefaults.Version}
 	added, firstRun := ApplyBuiltins(cfg)
 
 	if len(added) != 0 {

--- a/internal/firstrun/firstrun_test.go
+++ b/internal/firstrun/firstrun_test.go
@@ -1,6 +1,7 @@
 package firstrun_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Naoray/scribe/internal/config"
@@ -104,6 +105,34 @@ func TestApplyBuiltins_ExistingUserGetsNaorayScribeBackfilled(t *testing.T) {
 	}
 	if cfg.FindRegistry("mattpocock/skills") == nil {
 		t.Error("mattpocock/skills not in config after backfill")
+	}
+}
+
+func TestApplyBuiltins_ManuallyConnectedNotDuplicated(t *testing.T) {
+	// User already ran `scribe registry connect mattpocock/skills` before it became a builtin.
+	cfg := &config.Config{
+		BuiltinsVersion: 3, // pre-mattpocock version
+		Registries: []config.RegistryConfig{
+			{Repo: "Naoray/scribe", Enabled: true, Type: config.RegistryTypeCommunity, Builtin: true},
+			{Repo: "anthropics/skills", Enabled: true, Type: config.RegistryTypeCommunity, Builtin: true},
+			{Repo: "expo/skills", Enabled: true, Type: config.RegistryTypeCommunity, Builtin: true},
+			{Repo: "mattpocock/skills", Enabled: true, Type: config.RegistryTypeCommunity, Builtin: false},
+		},
+	}
+	added, _ := firstrun.ApplyBuiltins(cfg)
+
+	if len(added) != 0 {
+		t.Errorf("expected nothing added (already connected manually), got %v", added)
+	}
+
+	count := 0
+	for _, r := range cfg.Registries {
+		if strings.EqualFold(r.Repo, "mattpocock/skills") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("mattpocock/skills appears %d times in config, want exactly 1", count)
 	}
 }
 

--- a/internal/firstrun/firstrun_test.go
+++ b/internal/firstrun/firstrun_test.go
@@ -72,8 +72,8 @@ func TestApplyBuiltins_FirstRunAddsAllAndMarksVersion(t *testing.T) {
 	if !firstRun {
 		t.Error("first run should report firstRun=true")
 	}
-	if len(added) != 3 {
-		t.Errorf("first run should add 3 builtins, got %d: %v", len(added), added)
+	if len(added) != 4 {
+		t.Errorf("first run should add 4 builtins, got %d: %v", len(added), added)
 	}
 	if added[0] != "Naoray/scribe" {
 		t.Errorf("Naoray/scribe must be first in builtin order, got %q", added[0])
@@ -93,14 +93,17 @@ func TestApplyBuiltins_ExistingUserGetsNaorayScribeBackfilled(t *testing.T) {
 	}
 	added, firstRun := firstrun.ApplyBuiltins(cfg)
 
-	if len(added) != 1 || added[0] != "Naoray/scribe" {
-		t.Errorf("only Naoray/scribe should be backfilled, got %v", added)
+	if len(added) != 2 {
+		t.Errorf("Naoray/scribe and mattpocock/skills should be backfilled, got %v", added)
 	}
 	if firstRun {
 		t.Error("existing user should report firstRun=false")
 	}
 	if cfg.FindRegistry("Naoray/scribe") == nil {
 		t.Error("Naoray/scribe not in config after backfill")
+	}
+	if cfg.FindRegistry("mattpocock/skills") == nil {
+		t.Error("mattpocock/skills not in config after backfill")
 	}
 }
 

--- a/internal/skillmd/normalize.go
+++ b/internal/skillmd/normalize.go
@@ -1,0 +1,300 @@
+package skillmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Doc is the parsed and normalized view of a SKILL.md file.
+type Doc struct {
+	Name        string
+	Description string
+	Body        string
+	Changed     bool
+}
+
+type frontmatter struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+// Normalize parses SKILL.md content and returns a canonical representation.
+//
+// It rewrites frontmatter deterministically, preserving unrelated keys while
+// normalizing name and description. Missing name is filled from dirName and
+// missing description is filled from the first prose paragraph in the body.
+func Normalize(dirName string, content []byte) (Doc, []byte, error) {
+	body := normalizeLineEndings(content)
+	doc := Doc{Body: string(body)}
+
+	fm, body, hasFrontmatter, err := splitFrontmatter(body)
+	if err != nil {
+		return Doc{}, nil, err
+	}
+	doc.Body = string(body)
+
+	if hasFrontmatter {
+		parsed, err := parseFrontmatter(fm)
+		if err != nil {
+			return Doc{}, nil, err
+		}
+		doc.Name = strings.TrimSpace(parsed.Name)
+		doc.Description = strings.TrimSpace(parsed.Description)
+	}
+
+	if doc.Name == "" {
+		doc.Name = dirName
+	}
+	if doc.Description == "" {
+		doc.Description = ExtractFallbackDescription(doc.Body)
+	}
+
+	normalized, err := renderNormalized(doc.Name, doc.Description, doc.Body, hasFrontmatter, fm)
+	if err != nil {
+		return Doc{}, nil, err
+	}
+	doc.Changed = !bytes.Equal(content, normalized)
+	return doc, normalized, nil
+}
+
+// ExtractFallbackDescription returns the first prose paragraph in body.
+//
+// It skips headings, list items, blockquotes, tables, and fenced code blocks.
+// The returned paragraph has collapsed whitespace.
+func ExtractFallbackDescription(body string) string {
+	bodyBytes := normalizeLineEndings([]byte(body))
+	lines := strings.Split(string(bodyBytes), "\n")
+
+	inFence := false
+	var paragraph []string
+
+	flush := func() string {
+		if len(paragraph) == 0 {
+			return ""
+		}
+		text := strings.Join(paragraph, " ")
+		return strings.Join(strings.Fields(text), " ")
+	}
+
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if isFenceLine(line) {
+			inFence = !inFence
+			if len(paragraph) > 0 {
+				break
+			}
+			continue
+		}
+		if inFence {
+			continue
+		}
+		if line == "" {
+			if desc := flush(); desc != "" {
+				return desc
+			}
+			paragraph = nil
+			continue
+		}
+		if isIgnorableBlockLine(line) {
+			if len(paragraph) > 0 {
+				if desc := flush(); desc != "" {
+					return desc
+				}
+				paragraph = nil
+			}
+			continue
+		}
+		paragraph = append(paragraph, line)
+	}
+
+	return flush()
+}
+
+func normalizeLineEndings(content []byte) []byte {
+	return bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
+}
+
+type parsedFrontmatter struct {
+	Name        string
+	Description string
+	Extra       *yaml.Node
+}
+
+func parseFrontmatter(fm []byte) (parsedFrontmatter, error) {
+	var node yaml.Node
+	if err := yaml.Unmarshal(fm, &node); err != nil {
+		return parsedFrontmatter{}, fmt.Errorf("parse frontmatter: %w", err)
+	}
+	mapping, err := frontmatterMappingNode(&node)
+	if err != nil {
+		return parsedFrontmatter{}, err
+	}
+
+	parsed := parsedFrontmatter{Extra: mapping}
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		key := mapping.Content[i]
+		value := mapping.Content[i+1]
+		switch key.Value {
+		case "name":
+			parsed.Name = scalarString(value)
+		case "description":
+			parsed.Description = scalarString(value)
+		}
+	}
+	return parsed, nil
+}
+
+func frontmatterMappingNode(node *yaml.Node) (*yaml.Node, error) {
+	if node == nil {
+		return nil, fmt.Errorf("parse frontmatter: empty frontmatter")
+	}
+	switch node.Kind {
+	case yaml.DocumentNode:
+		if len(node.Content) != 1 {
+			return nil, fmt.Errorf("parse frontmatter: invalid document structure")
+		}
+		return frontmatterMappingNode(node.Content[0])
+	case yaml.MappingNode:
+		return node, nil
+	default:
+		return nil, fmt.Errorf("parse frontmatter: frontmatter must be a mapping")
+	}
+}
+
+func scalarString(node *yaml.Node) string {
+	if node == nil {
+		return ""
+	}
+	if node.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return node.Value
+}
+
+func splitFrontmatter(content []byte) ([]byte, []byte, bool, error) {
+	if !bytes.HasPrefix(content, []byte("---\n")) {
+		return nil, content, false, nil
+	}
+
+	lines := bytes.Split(content, []byte("\n"))
+	if len(lines) < 2 {
+		return nil, nil, false, fmt.Errorf("parse frontmatter: unterminated frontmatter")
+	}
+
+	var fmLines [][]byte
+	bodyStart := -1
+	for i := 1; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(string(line)) == "---" {
+			bodyStart = i + 1
+			break
+		}
+		fmLines = append(fmLines, line)
+	}
+	if bodyStart < 0 {
+		return nil, nil, false, fmt.Errorf("parse frontmatter: unterminated frontmatter")
+	}
+
+	body := bytes.Join(lines[bodyStart:], []byte("\n"))
+	body = bytes.TrimPrefix(body, []byte("\n"))
+
+	return bytes.Join(fmLines, []byte("\n")), body, true, nil
+}
+
+func renderNormalized(name, description, body string, hasFrontmatter bool, fm []byte) ([]byte, error) {
+	fmBytes, err := canonicalFrontmatter(name, description, hasFrontmatter, fm)
+	if err != nil {
+		return nil, err
+	}
+
+	var out bytes.Buffer
+	out.WriteString("---\n")
+	out.Write(fmBytes)
+	if !bytes.HasSuffix(fmBytes, []byte("\n")) {
+		out.WriteByte('\n')
+	}
+	out.WriteString("---\n")
+	if body != "" {
+		out.WriteByte('\n')
+		out.WriteString(strings.TrimLeft(body, "\n"))
+	}
+
+	return out.Bytes(), nil
+}
+
+func canonicalFrontmatter(name, description string, hasFrontmatter bool, fm []byte) ([]byte, error) {
+	if !hasFrontmatter {
+		return yaml.Marshal(frontmatter{Name: name, Description: description})
+	}
+
+	parsed, err := parseFrontmatter(fm)
+	if err != nil {
+		return nil, err
+	}
+
+	mapping := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	mapping.Content = append(mapping.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "name"},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: name},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "description"},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: description},
+	)
+
+	if parsed.Extra != nil {
+		for i := 0; i+1 < len(parsed.Extra.Content); i += 2 {
+			key := parsed.Extra.Content[i]
+			value := parsed.Extra.Content[i+1]
+			if key.Value == "name" || key.Value == "description" {
+				continue
+			}
+			mapping.Content = append(mapping.Content, key, value)
+		}
+	}
+
+	return yaml.Marshal(mapping)
+}
+
+func isFenceLine(line string) bool {
+	return strings.HasPrefix(line, "```") || strings.HasPrefix(line, "~~~")
+}
+
+func isIgnorableBlockLine(line string) bool {
+	if line == "" {
+		return false
+	}
+	switch {
+	case strings.HasPrefix(line, "#"):
+		return true
+	case strings.HasPrefix(line, ">"):
+		return true
+	case strings.HasPrefix(line, "|"):
+		return true
+	case strings.HasPrefix(line, "- "), strings.HasPrefix(line, "* "), strings.HasPrefix(line, "+ "):
+		return true
+	case isOrderedListItem(line):
+		return true
+	case line == "---", line == "***", line == "___":
+		return true
+	default:
+		return false
+	}
+}
+
+func isOrderedListItem(line string) bool {
+	i := 0
+	for i < len(line) && line[i] >= '0' && line[i] <= '9' {
+		i++
+	}
+	if i == 0 || i+1 >= len(line) {
+		return false
+	}
+	switch line[i] {
+	case '.', ')':
+		return line[i+1] == ' '
+	default:
+		return false
+	}
+}

--- a/internal/skillmd/normalize_test.go
+++ b/internal/skillmd/normalize_test.go
@@ -1,0 +1,159 @@
+package skillmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeAddsMissingFrontmatterFromDirectoryName(t *testing.T) {
+	doc, normalized, err := Normalize("ascii", []byte("# ASCII Diagram Generator\n\nCreate ASCII diagrams.\n"))
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+
+	if doc.Name != "ascii" {
+		t.Fatalf("Name = %q, want %q", doc.Name, "ascii")
+	}
+	if doc.Description != "Create ASCII diagrams." {
+		t.Fatalf("Description = %q, want %q", doc.Description, "Create ASCII diagrams.")
+	}
+	if !doc.Changed {
+		t.Fatal("Changed = false, want true")
+	}
+
+	content := string(normalized)
+	if !strings.HasPrefix(content, "---\n") {
+		t.Fatalf("normalized content missing frontmatter:\n%s", content)
+	}
+	if !strings.Contains(content, "name: ascii\n") {
+		t.Fatalf("normalized content missing name:\n%s", content)
+	}
+	if !strings.Contains(content, "description: Create ASCII diagrams.\n") {
+		t.Fatalf("normalized content missing description:\n%s", content)
+	}
+	if !strings.Contains(content, "# ASCII Diagram Generator\n") {
+		t.Fatalf("normalized content missing body:\n%s", content)
+	}
+}
+
+func TestNormalizeFillsMissingDescriptionFromFirstParagraph(t *testing.T) {
+	content := []byte(`---
+name: ascii
+---
+
+# ASCII Diagram Generator
+
+Create ASCII diagrams for flows,
+architectures, and processes.
+`)
+
+	doc, normalized, err := Normalize("ascii", content)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+
+	if doc.Name != "ascii" {
+		t.Fatalf("Name = %q, want %q", doc.Name, "ascii")
+	}
+	if doc.Description != "Create ASCII diagrams for flows, architectures, and processes." {
+		t.Fatalf("Description = %q", doc.Description)
+	}
+	if !doc.Changed {
+		t.Fatal("Changed = false, want true")
+	}
+	if !strings.Contains(string(normalized), "description: Create ASCII diagrams for flows, architectures, and processes.\n") {
+		t.Fatalf("normalized content missing extracted description:\n%s", normalized)
+	}
+}
+
+func TestNormalizeSkipsHeadingsListsAndCodeFences(t *testing.T) {
+	body := strings.Join([]string{
+		"# ASCII Diagram Generator",
+		"",
+		"- ignore this bullet",
+		"* ignore this bullet too",
+		"> ignore this quote",
+		"| ignore this table row |",
+		"```",
+		"still ignore this",
+		"```",
+		"",
+		"Create ASCII diagrams for flows, architectures, and processes.",
+	}, "\n")
+
+	if got := ExtractFallbackDescription(body); got != "Create ASCII diagrams for flows, architectures, and processes." {
+		t.Fatalf("ExtractFallbackDescription = %q", got)
+	}
+}
+
+func TestNormalizeRejectsUnrecoverableFrontmatter(t *testing.T) {
+	_, _, err := Normalize("ascii", []byte(`---
+name: ascii
+
+# missing closing delimiter
+`))
+	if err == nil {
+		t.Fatal("Normalize returned nil error for unrecoverable frontmatter")
+	}
+}
+
+func TestNormalizeCanonicalizesExistingFrontmatter(t *testing.T) {
+	input := []byte(`---
+description: Create ASCII diagrams.
+name: ascii
+---
+
+Body
+`)
+
+	_, normalized, err := Normalize("ascii", input)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+
+	if string(normalized) == string(input) {
+		t.Fatal("Normalize preserved non-canonical frontmatter; want deterministic rewrite")
+	}
+	if !strings.HasPrefix(string(normalized), "---\n") {
+		t.Fatalf("normalized content missing frontmatter:\n%s", normalized)
+	}
+	if !strings.Contains(string(normalized), "name: ascii\n") {
+		t.Fatalf("normalized content missing name:\n%s", normalized)
+	}
+	if !strings.Contains(string(normalized), "description: Create ASCII diagrams.\n") {
+		t.Fatalf("normalized content missing description:\n%s", normalized)
+	}
+}
+
+func TestNormalizePreservesExtraFrontmatterKeys(t *testing.T) {
+	input := []byte(`---
+license: MIT
+description: Create ASCII diagrams.
+name: ascii
+tags:
+  - diagrams
+  - ascii
+---
+
+Body
+`)
+
+	_, normalized, err := Normalize("ascii", input)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+
+	content := string(normalized)
+	if !strings.Contains(content, "name: ascii\n") {
+		t.Fatalf("normalized content missing name:\n%s", content)
+	}
+	if !strings.Contains(content, "description: Create ASCII diagrams.\n") {
+		t.Fatalf("normalized content missing description:\n%s", content)
+	}
+	if !strings.Contains(content, "license: MIT\n") {
+		t.Fatalf("normalized content dropped extra key:\n%s", content)
+	}
+	if !strings.Contains(content, "- diagrams\n") || !strings.Contains(content, "- ascii\n") {
+		t.Fatalf("normalized content dropped extra sequence:\n%s", content)
+	}
+}

--- a/internal/tools/codex.go
+++ b/internal/tools/codex.go
@@ -1,13 +1,15 @@
 package tools
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
+
+	"github.com/Naoray/scribe/internal/skillmd"
 )
 
 const toolCodex = "codex"
@@ -84,28 +86,12 @@ func ensureCodexCompatibleSkillMD(skillName, canonicalDir string) error {
 	if err != nil {
 		return fmt.Errorf("read codex skill %q: %w", skillName, err)
 	}
-	if strings.HasPrefix(string(content), "---\n") {
-		return nil
+	_, normalized, err := skillmd.Normalize(skillName, content)
+	if err != nil {
+		return err
 	}
-
-	description := firstBodyParagraph(content)
-	if description == "" {
-		description = skillName
-	}
-	normalized := []byte(fmt.Sprintf("---\nname: %s\ndescription: %s\n---\n\n%s", skillName, description, strings.TrimLeft(string(content), "\n")))
-	if err := WriteCanonicalSkill(canonicalDir, normalized); err != nil {
-		return fmt.Errorf("normalize codex skill %q: %w", skillName, err)
+	if !bytes.Equal(content, normalized) {
+		return WriteCanonicalSkill(canonicalDir, normalized)
 	}
 	return nil
-}
-
-func firstBodyParagraph(content []byte) string {
-	for _, line := range strings.Split(string(content), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
-			continue
-		}
-		return trimmed
-	}
-	return ""
 }

--- a/internal/workflow/registry_list.go
+++ b/internal/workflow/registry_list.go
@@ -5,12 +5,10 @@ import (
 	"encoding/json"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/mattn/go-isatty"
 
 	"github.com/Naoray/scribe/internal/state"
-	"github.com/Naoray/scribe/internal/tools"
 )
 
 // RegistryListSteps returns the step list for the registry list command.
@@ -22,16 +20,18 @@ func RegistryListSteps() []Step {
 	}
 }
 
-// CountSkillsPerRegistry counts installed skills per registry by matching
-// the slugified registry prefix in namespaced skill keys (e.g. "ArtistfyHQ-team-skills/deploy" matches "ArtistfyHQ/team-skills").
+// CountSkillsPerRegistry counts installed skills per registry by inspecting
+// the Sources field of each installed skill.
 func CountSkillsPerRegistry(repos []string, st *state.State) map[string]int {
 	counts := make(map[string]int, len(repos))
 	for _, repo := range repos {
 		counts[repo] = 0
-		slug := tools.SlugifyRegistry(repo)
-		for name := range st.Installed {
-			if strings.HasPrefix(name, slug+"/") {
-				counts[repo]++
+	}
+	for _, skill := range st.Installed {
+		for _, src := range skill.Sources {
+			if _, ok := counts[src.Registry]; ok {
+				counts[src.Registry]++
+				break
 			}
 		}
 	}

--- a/internal/workflow/registry_list_test.go
+++ b/internal/workflow/registry_list_test.go
@@ -11,14 +11,13 @@ import (
 )
 
 func TestCountSkillsPerRegistry(t *testing.T) {
-	// Keys are namespaced: slugified-registry/skill. CountSkillsPerRegistry matches
-	// the slugified registry prefix against each repo.
+	// Skills record their registry in Sources[].Registry.
 	st := &state.State{
 		Installed: map[string]state.InstalledSkill{
-			"ArtistfyHQ-skills/browse": {},
-			"ArtistfyHQ-skills/deploy": {},
-			"Naoray-my-skills/lint":    {},
-			"local/orphan":             {},
+			"browse": {Sources: []state.SkillSource{{Registry: "ArtistfyHQ/skills"}}},
+			"deploy": {Sources: []state.SkillSource{{Registry: "ArtistfyHQ/skills"}}},
+			"lint":   {Sources: []state.SkillSource{{Registry: "Naoray/my-skills"}}},
+			"orphan": {}, // no sources — not from any registry
 		},
 	}
 
@@ -62,8 +61,8 @@ func TestPrintRegistryJSON_Shape(t *testing.T) {
 	st := &state.State{
 		LastSync: syncTime,
 		Installed: map[string]state.InstalledSkill{
-			"Foo-bar/browse": {},
-			"Foo-bar/deploy": {},
+			"browse": {Sources: []state.SkillSource{{Registry: "Foo/bar"}}},
+			"deploy": {Sources: []state.SkillSource{{Registry: "Foo/bar"}}},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Adds `mattpocock/skills` to the `builtinRepos` list in `internal/firstrun`
- Bumps `currentBuiltinsVersion` from 3 → 4 so existing users receive the registry on next run via the backfill path
- Updates tests to expect 4 builtins and covers the backfill of `mattpocock/skills` for existing users

## Test Plan
- [ ] `go test ./internal/firstrun/...` passes
- [ ] `go test ./...` passes
- [ ] Fresh install: `scribe list --remote` shows `mattpocock/skills` as a connected registry
- [ ] Existing user: running any scribe command adds `mattpocock/skills` automatically