### PR TITLE
fix: registry skill counts always showing 0

### DIFF
--- a/internal/workflow/registry_list.go
+++ b/internal/workflow/registry_list.go
@@ -5,12 +5,9 @@ import (
 	"encoding/json"
 	"io"
 	"os"
-	"strings"
-
 	"github.com/mattn/go-isatty"
 
 	"github.com/Naoray/scribe/internal/state"
-	"github.com/Naoray/scribe/internal/tools"
 )
 
 // RegistryListSteps returns the step list for the registry list command.
@@ -22,16 +19,18 @@ func RegistryListSteps() []Step {
 	}
 }
 
-// CountSkillsPerRegistry counts installed skills per registry by matching
-// the slugified registry prefix in namespaced skill keys (e.g. "ArtistfyHQ-team-skills/deploy" matches "ArtistfyHQ/team-skills").
+// CountSkillsPerRegistry counts installed skills per registry by inspecting
+// the Sources field of each installed skill.
 func CountSkillsPerRegistry(repos []string, st *state.State) map[string]int {
 	counts := make(map[string]int, len(repos))
 	for _, repo := range repos {
 		counts[repo] = 0
-		slug := tools.SlugifyRegistry(repo)
-		for name := range st.Installed {
-			if strings.HasPrefix(name, slug+"/") {
-				counts[repo]++
+	}
+	for _, skill := range st.Installed {
+		for _, src := range skill.Sources {
+			if _, ok := counts[src.Registry]; ok {
+				counts[src.Registry]++
+				break
 			}
 		}
 	}

--- a/internal/workflow/registry_list_test.go
+++ b/internal/workflow/registry_list_test.go
@@ -11,14 +11,13 @@ import (
 )
 
 func TestCountSkillsPerRegistry(t *testing.T) {
-	// Keys are namespaced: slugified-registry/skill. CountSkillsPerRegistry matches
-	// the slugified registry prefix against each repo.
+	// Skills record their registry in Sources[].Registry.
 	st := &state.State{
 		Installed: map[string]state.InstalledSkill{
-			"ArtistfyHQ-skills/browse": {},
-			"ArtistfyHQ-skills/deploy": {},
-			"Naoray-my-skills/lint":    {},
-			"local/orphan":             {},
+			"browse": {Sources: []state.SkillSource{{Registry: "ArtistfyHQ/skills"}}},
+			"deploy": {Sources: []state.SkillSource{{Registry: "ArtistfyHQ/skills"}}},
+			"lint":   {Sources: []state.SkillSource{{Registry: "Naoray/my-skills"}}},
+			"orphan": {}, // no sources — not from any registry
 		},
 	}
 
@@ -62,8 +61,8 @@ func TestPrintRegistryJSON_Shape(t *testing.T) {
 	st := &state.State{
 		LastSync: syncTime,
 		Installed: map[string]state.InstalledSkill{
-			"Foo-bar/browse": {},
-			"Foo-bar/deploy": {},
+			"browse": {Sources: []state.SkillSource{{Registry: "Foo/bar"}}},
+			"deploy": {Sources: []state.SkillSource{{Registry: "Foo/bar"}}},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- `CountSkillsPerRegistry` was matching state map keys by slugified prefix (e.g. `anthropics-skills/foo`) but installed skills use flat keys (`foo`) with registry info stored in `Sources[].Registry`
- Switch to iterating `skill.Sources` and matching `src.Registry` against the repo list
- Update test fixtures to use `Sources` field instead of slug-prefixed keys

## Root cause

The state schema never used namespaced keys — that was a false assumption in the original implementation. Skills were always stored as `"skill-name"` with registry provenance in the `sources` array.

## Test plan

- [ ] `go test ./internal/workflow/...` passes
- [ ] `scribe registry` shows non-zero counts for connected registries

🤖 Generated with [Claude Code](https://claude.com/claude-code)