### PR TITLE
feat: add scribe install command

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/workflow"
+)
+
+func newInstallCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install [skill...]",
+		Short: "Install skills from connected registries",
+		Long: `Install one or more skills from your connected registries.
+
+Without arguments, shows an interactive picker of all available skills.
+Pass skill names to install specific skills, or use --all to install everything.`,
+		Example: `  scribe install              # interactive picker
+  scribe install tdd commit   # install specific skills
+  scribe install --all        # install everything available`,
+		RunE: runInstall,
+	}
+	cmd.Flags().Bool("all", false, "Install all available skills without prompting")
+	cmd.Flags().String("registry", "", "Limit to a specific registry (owner/repo)")
+	return cmd
+}
+
+func runInstall(cmd *cobra.Command, args []string) error {
+	allFlag, _ := cmd.Flags().GetBool("all")
+	repoFlag, _ := cmd.Flags().GetString("registry")
+
+	bag := &workflow.Bag{
+		Args:           args,
+		InstallAllFlag: allFlag,
+		RepoFlag:       repoFlag,
+		Factory:        newCommandFactory(),
+		FilterRegistries: filterRegistries,
+	}
+	if err := workflow.Run(cmd.Context(), workflow.InstallSteps(), bag); err != nil {
+		return err
+	}
+	return saveWorkflowState(bag)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,6 +124,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		newListCommand(),
 		newBrowseCommand(),
+		newInstallCommand(),
 		newAddCommand(),
 		newRemoveCommand(),
 		newSyncCommand(),

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -41,6 +41,11 @@ type Syncer struct {
 	// unsynced local edits on disk.
 	ModifiedStrategy ModifiedStrategy
 
+	// SkillFilter, if non-nil, restricts the sync to only the named skills.
+	// Skills not in the list are skipped entirely (not even resolved/emitted).
+	// Used by `scribe install` to install specific skills.
+	SkillFilter []string
+
 	// TrustAll skips approval prompts for packages (--trust-all flag).
 	TrustAll bool
 
@@ -217,6 +222,19 @@ func (s *Syncer) Run(ctx context.Context, teamRepo string, st *state.State) erro
 	statuses, _, err := s.Diff(ctx, teamRepo, st)
 	if err != nil {
 		return fmt.Errorf("sync %s: %w", teamRepo, err)
+	}
+	if len(s.SkillFilter) > 0 {
+		allowed := make(map[string]bool, len(s.SkillFilter))
+		for _, n := range s.SkillFilter {
+			allowed[n] = true
+		}
+		filtered := statuses[:0]
+		for _, sk := range statuses {
+			if allowed[sk.Name] {
+				filtered = append(filtered, sk)
+			}
+		}
+		statuses = filtered
 	}
 	return s.apply(ctx, teamRepo, statuses, st)
 }

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -16,15 +16,21 @@ import (
 // Each step reads/writes only its relevant fields.
 type Bag struct {
 	// Inputs (set by cmd/ before Run)
-	Args         []string
-	JSONFlag     bool
-	RepoFlag     string // --registry filter
-	RemoteFlag   bool   // --remote: show available skills from registries
-	BrowseFlag   bool   // browse mode: remote catalog UI with install-first actions
-	InitialQuery string // initial search/filter text for TUI surfaces
-	TrustAllFlag bool   // --trust-all: approve all package commands without prompting
-	LazyGitHub   bool   // skip eager GitHub client/provider setup for local-only flows
-	Factory      *app.Factory
+	Args           []string
+	JSONFlag       bool
+	RepoFlag       string // --registry filter
+	RemoteFlag     bool   // --remote: show available skills from registries
+	BrowseFlag     bool   // browse mode: remote catalog UI with install-first actions
+	InitialQuery   string // initial search/filter text for TUI surfaces
+	TrustAllFlag   bool   // --trust-all: approve all package commands without prompting
+	InstallAllFlag bool   // --all: install all available skills without prompting
+	LazyGitHub     bool   // skip eager GitHub client/provider setup for local-only flows
+	Factory        *app.Factory
+
+	// SkillFilter is populated by StepSelectSkills with the names the user chose.
+	// If non-empty, StepSyncSkills passes it to the Syncer so only those skills
+	// are installed. Nil means no filter (all eligible skills processed).
+	SkillFilter []string
 
 	// Populated by steps
 	Config     *config.Config

--- a/internal/workflow/install.go
+++ b/internal/workflow/install.go
@@ -1,0 +1,112 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+
+	"charm.land/huh/v2"
+	"github.com/mattn/go-isatty"
+
+	"github.com/Naoray/scribe/internal/sync"
+)
+
+// InstallSteps returns the step list for the install command.
+func InstallSteps() []Step {
+	return []Step{
+		{"LoadConfig", StepLoadConfig},
+		{"LoadState", StepLoadState},
+		{"CheckConnected", StepCheckConnected},
+		{"FilterRegistries", StepFilterRegistries},
+		{"ResolveFormatter", StepResolveFormatter},
+		{"ResolveTools", StepResolveTools},
+		{"SelectSkills", StepSelectSkills},
+		{"SyncSkills", StepSyncSkills},
+	}
+}
+
+// StepSelectSkills resolves which skills to install and sets b.SkillFilter.
+//
+//   - Skill names in b.Args: install exactly those skills.
+//   - b.InstallAllFlag: install everything available (no filter).
+//   - Interactive TTY: show a multi-select picker of available skills.
+//   - Non-TTY, no args, no --all: error with a hint.
+func StepSelectSkills(ctx context.Context, b *Bag) error {
+	// Explicit names — use them directly without fetching the full catalog.
+	if len(b.Args) > 0 {
+		b.SkillFilter = b.Args
+		return nil
+	}
+
+	// --all: no filter; syncer installs every StatusMissing skill.
+	if b.InstallAllFlag {
+		return nil
+	}
+
+	// No args — need to fetch what's available.
+	isTTY := isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
+	if !isTTY {
+		return fmt.Errorf("no skill names given — pass skill names, --all, or run in a terminal for interactive selection")
+	}
+
+	// Collect StatusMissing skills across all connected registries.
+	type option struct {
+		name     string
+		registry string
+	}
+	seen := map[string]bool{}
+	var available []option
+
+	syncer := &sync.Syncer{
+		Client:   sync.WrapGitHubClient(b.Client),
+		Provider: b.Provider,
+	}
+
+	for _, repo := range b.Repos {
+		statuses, _, err := syncer.Diff(ctx, repo, b.State)
+		if err != nil {
+			// Non-fatal: skip unreachable registries, user can fix and re-run.
+			fmt.Fprintf(os.Stderr, "warning: could not reach %s: %v\n", repo, err)
+			continue
+		}
+		for _, sk := range statuses {
+			if sk.Status == sync.StatusMissing && !seen[sk.Name] {
+				seen[sk.Name] = true
+				available = append(available, option{name: sk.Name, registry: repo})
+			}
+		}
+	}
+
+	if len(available) == 0 {
+		fmt.Fprintln(os.Stdout, "All available skills are already installed.")
+		return errSkip
+	}
+
+	// Sort alphabetically for a stable picker list.
+	sort.Slice(available, func(i, j int) bool {
+		return available[i].name < available[j].name
+	})
+
+	opts := make([]huh.Option[string], len(available))
+	for i, o := range available {
+		opts[i] = huh.NewOption(o.name, o.name)
+	}
+
+	var selected []string
+	err := huh.NewMultiSelect[string]().
+		Title(fmt.Sprintf("Select skills to install (%d available)", len(available))).
+		Options(opts...).
+		Value(&selected).
+		Run()
+	if err != nil {
+		return err
+	}
+
+	if len(selected) == 0 {
+		return errSkip
+	}
+
+	b.SkillFilter = selected
+	return nil
+}

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -262,11 +262,12 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 	resolved := map[string]sync.SkillStatus{}
 
 	syncer := &sync.Syncer{
-		Client:   sync.WrapGitHubClient(b.Client),
-		Provider: b.Provider,
-		Tools:    b.Tools,
-		Executor: &sync.ShellExecutor{},
-		TrustAll: b.TrustAllFlag,
+		Client:      sync.WrapGitHubClient(b.Client),
+		Provider:    b.Provider,
+		Tools:       b.Tools,
+		Executor:    &sync.ShellExecutor{},
+		TrustAll:    b.TrustAllFlag,
+		SkillFilter: b.SkillFilter,
 		Emit: func(msg any) {
 			switch m := msg.(type) {
 			case sync.SkillResolvedMsg:


### PR DESCRIPTION
## Summary

- Migration path for users upgrading from the auto-install model (PR #94 removes auto-install from sync/connect)
- Explicit opt-in install from connected registries

## Usage

```
scribe install              # interactive multi-select picker of available skills
scribe install tdd commit   # install specific skills by name
scribe install --all        # install all available skills
scribe install --registry mattpocock/skills  # limit to one registry
```

## How it works

- `StepSelectSkills` runs before `StepSyncSkills` to populate `b.SkillFilter`
- Named args → filter directly (no API call needed)
- `--all` → nil filter, syncer installs everything StatusMissing
- Interactive TTY → calls `Syncer.Diff()` across all registries to find StatusMissing skills, shows `huh.MultiSelect` picker
- Non-TTY + no args → actionable error message
- `Syncer.SkillFilter []string` — when set, `Run()` filters diff results before `apply()`

## Test plan

- [ ] `go test ./...` green
- [ ] `scribe install` in TTY shows picker of uninstalled skills
- [ ] `scribe install tdd` installs tdd directly
- [ ] `scribe install --all` installs everything available
- [ ] Non-TTY: `echo | scribe install` gives helpful error
- [ ] Already-installed skills don't appear in picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)