### PR TITLE
add scribe doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ ArtistfyHQ/team-skills/
 | `scribe adopt [name]` | Import hand-rolled skills from `~/.claude/skills` etc. into the store |
 | `scribe remove <skill>` | Remove a skill from this machine |
 | `scribe sync` | Reconcile local skill state, tool installs, and connected registries |
+| `scribe doctor` | Inspect managed skills and projections for repairable issues |
+| `scribe doctor --fix` | Normalize canonical skill metadata and repair affected projections |
+| `scribe doctor --skill recap --fix` | Repair a single managed skill and its projections |
 | `scribe skill repair <skill> --tool <tool>` | Resolve preserved managed drift when a tool-local copy differs from the canonical store |
 | `scribe status` | Show connected registries, installed count, and last sync |
 | `scribe tools` | List detected AI tools, enable/disable |
@@ -218,6 +221,20 @@ If sync finds divergent content in a managed tool path, it preserves that conten
 conflict: recap in codex differs from managed copy
 run `scribe skill repair recap --tool codex` to resolve
 ```
+
+### `scribe doctor` v1 scope
+
+```bash
+scribe doctor
+scribe doctor --fix
+scribe doctor --skill recap --fix
+```
+
+`scribe doctor` audits managed skills for canonical `SKILL.md` metadata issues and projection drift.
+`scribe doctor --fix` applies safe metadata normalization and then repairs affected tool projections.
+
+`scribe doctor` v1 does not attempt to rewrite mixed package layouts for Codex.
+It focuses on canonical metadata health plus projection repair.
 
 ## Adoption — claim skills you already have
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -95,6 +95,8 @@ Use it for installs, updates, removal, adoption of unmanaged local skills, and s
 | actually adopt them | `scribe adopt --yes --json` |
 | explain what X does | `scribe explain X --json` |
 | show scribe status | `scribe status --json` |
+| audit managed skill health | `scribe doctor --json` |
+| repair managed skill metadata/projections | `scribe doctor --skill <name> --fix` |
 | connect a registry | `scribe registry add owner/repo` |
 
 ## Non-negotiable rules
@@ -171,6 +173,12 @@ This command only works for installed skills on disk.
 Top level: object with `version`, `registries`, and `installed_count`.
 Optional field: `last_sync`.
 
+### `scribe doctor --json`
+
+Top level: object with `issues`.
+Optional fields: `skill` and `fix`.
+Each issue may include `skill`, `tool`, `kind`, `status`, and `message`.
+
 ## Recommended flows
 
 Install a known skill:
@@ -198,6 +206,18 @@ Reconcile connected registries:
 ```bash
 scribe sync --json
 ```
+
+Audit and repair managed skill health:
+
+```bash
+scribe doctor --json
+scribe doctor --fix
+scribe doctor --skill recap --fix
+```
+
+`scribe doctor` audits managed skills and projection health.
+`scribe doctor --fix` applies safe metadata normalization and then repairs affected tool projections.
+`scribe doctor` v1 does not attempt to rewrite mixed package layouts for Codex; it focuses on canonical metadata health plus projection repair.
 
 Adopt unmanaged local skills:
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,13 +1,23 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/doctor"
+	"github.com/Naoray/scribe/internal/skillmd"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/sync"
+	"github.com/Naoray/scribe/internal/tools"
 )
 
 func newDoctorCommand() *cobra.Command {
@@ -21,11 +31,12 @@ Use --json for machine-readable output.
 Examples:
   scribe doctor
   scribe doctor --skill recap
+  scribe doctor --fix
   scribe doctor --json`,
 		Args: cobra.NoArgs,
 		RunE: runDoctor,
 	}
-	cmd.Flags().Bool("fix", false, "Reserved for repair mode (Task 4)")
+	cmd.Flags().Bool("fix", false, "Normalize canonical skill metadata and repair affected projections")
 	cmd.Flags().String("skill", "", "Inspect a single managed skill")
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	return cmd
@@ -45,6 +56,29 @@ type doctorReportJSON struct {
 	Issues []doctorIssueJSON `json:"issues"`
 }
 
+type doctorFixResult struct {
+	Name             string   `json:"name"`
+	UpdatedCanonical bool     `json:"updated_canonical"`
+	RepairedTools    []string `json:"repaired_tools,omitempty"`
+}
+
+type doctorSkillSnapshot struct {
+	Name        string
+	Installed    state.InstalledSkill
+	SkillContent []byte
+	BaseContent  []byte
+	Paths        []pathSnapshot
+}
+
+type pathSnapshot struct {
+	Path       string
+	Kind       string
+	Mode       os.FileMode
+	Data       []byte
+	LinkTarget string
+	BackupDir  string
+}
+
 func runDoctor(cmd *cobra.Command, _ []string) error {
 	fixFlag, _ := cmd.Flags().GetBool("fix")
 	skillFlag, _ := cmd.Flags().GetString("skill")
@@ -52,9 +86,6 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 
 	if fixFlag && jsonFlag {
 		return fmt.Errorf("doctor: --fix cannot be combined with --json")
-	}
-	if fixFlag {
-		return fmt.Errorf("doctor: --fix not implemented yet")
 	}
 
 	factory := newCommandFactory()
@@ -80,10 +111,432 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("inspect managed skills: %w", err)
 	}
 
+	if fixFlag {
+		results, err := applyDoctorFixes(cfg, st, skillFlag, report)
+		if err != nil {
+			return err
+		}
+		return writeDoctorFixText(cmd.OutOrStdout(), skillFlag, results)
+	}
+
 	if jsonFlag {
 		return writeDoctorJSON(cmd.OutOrStdout(), skillFlag, report)
 	}
 	return writeDoctorText(cmd.OutOrStdout(), skillFlag, report)
+}
+
+func applyDoctorFixes(cfg *config.Config, st *state.State, skillName string, report doctor.Report) ([]doctorFixResult, error) {
+	results := make([]doctorFixResult, 0)
+	applied := make([]doctorSkillSnapshot, 0)
+	for _, name := range doctorSkillNames(st, skillName) {
+		snapshot, err := snapshotDoctorSkill(cfg, st, name)
+		if err != nil {
+			if rollbackErr := rollbackDoctorSnapshots(st, applied); rollbackErr != nil {
+				return nil, fmt.Errorf("%w (rollback: %v)", err, rollbackErr)
+			}
+			return nil, err
+		}
+		result, changed, err := applyDoctorFix(cfg, st, name, report)
+		if err != nil {
+			if rollbackErr := rollbackDoctorSnapshots(st, append(applied, snapshot)); rollbackErr != nil {
+				return nil, fmt.Errorf("doctor: fix %s: %w (rollback: %v)", name, err, rollbackErr)
+			}
+			return nil, fmt.Errorf("doctor: fix %s: %w", name, err)
+		}
+		if changed {
+			applied = append(applied, snapshot)
+			results = append(results, result)
+		}
+	}
+	return results, nil
+}
+
+func applyDoctorFix(cfg *config.Config, st *state.State, name string, report doctor.Report) (doctorFixResult, bool, error) {
+	canonicalDir := filepath.Join(mustStoreDir(), name)
+	skillPath := filepath.Join(canonicalDir, "SKILL.md")
+
+	content, err := os.ReadFile(skillPath)
+	if err != nil {
+		return doctorFixResult{}, false, fmt.Errorf("read canonical SKILL.md: %w", err)
+	}
+
+	_, normalized, err := skillmd.Normalize(name, content)
+	if err != nil {
+		return doctorFixResult{}, false, err
+	}
+
+	needsProjectionRepair := doctorReportHasProjectionIssue(report, name)
+	updatedCanonical := !bytes.Equal(content, normalized)
+	if !updatedCanonical && !needsProjectionRepair {
+		return doctorFixResult{}, false, nil
+	}
+
+	workingState := cloneState(st)
+	result := doctorFixResult{Name: name}
+	if updatedCanonical {
+		if err := tools.WriteCanonicalSkill(canonicalDir, normalized); err != nil {
+			return doctorFixResult{}, false, err
+		}
+
+		installed := workingState.Installed[name]
+		installed.InstalledHash = sync.ComputeFileHash(normalized)
+		workingState.Installed[name] = installed
+		result.UpdatedCanonical = true
+		needsProjectionRepair = true
+	}
+
+	if needsProjectionRepair {
+		effectiveTools, err := doctorEffectiveTools(cfg, workingState.Installed[name])
+		if err != nil {
+			return doctorFixResult{}, false, err
+		}
+		if len(effectiveTools) > 0 {
+			repairResult, err := repairSkillProjections(cfg, workingState, name)
+			if err != nil {
+				return doctorFixResult{}, false, err
+			}
+			result.RepairedTools = append(result.RepairedTools, repairResult.Tools...)
+		} else {
+			if err := cleanupInactiveSkillProjections(workingState, name); err != nil {
+				return doctorFixResult{}, false, err
+			}
+			if err := workingState.Save(); err != nil {
+				return doctorFixResult{}, false, err
+			}
+			if !result.UpdatedCanonical {
+				result.RepairedTools = []string{"cleaned"}
+			}
+		}
+	} else if result.UpdatedCanonical {
+		if err := workingState.Save(); err != nil {
+			return doctorFixResult{}, false, err
+		}
+	}
+
+	*st = *workingState
+	return result, true, nil
+}
+
+func doctorSkillNames(st *state.State, skillName string) []string {
+	if skillName != "" {
+		return []string{skillName}
+	}
+
+	names := make([]string, 0, len(st.Installed))
+	for name, installed := range st.Installed {
+		if installed.Type == "package" {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func doctorReportHasProjectionIssue(report doctor.Report, name string) bool {
+	for _, issue := range report.Issues {
+		if issue.Skill == name && issue.Kind == doctor.IssueProjectionDrift {
+			return true
+		}
+	}
+	return false
+}
+
+func doctorEffectiveTools(cfg *config.Config, installed state.InstalledSkill) ([]string, error) {
+	statuses, err := tools.ResolveStatuses(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("resolve tools: %w", err)
+	}
+	return installed.EffectiveTools(availableToolNames(statuses)), nil
+}
+
+func cleanupInactiveSkillProjections(st *state.State, name string) error {
+	if st == nil {
+		return fmt.Errorf("load state: missing")
+	}
+
+	installed, ok := st.Installed[name]
+	if !ok {
+		return fmt.Errorf("skill %q is not installed", name)
+	}
+
+	pathSet := make(map[string]bool)
+	for _, path := range doctorProjectionPaths(installed) {
+		if strings.TrimSpace(path) != "" {
+			pathSet[path] = true
+		}
+	}
+	for _, conflict := range installed.Conflicts {
+		if strings.TrimSpace(conflict.Path) != "" {
+			pathSet[conflict.Path] = true
+		}
+	}
+
+	for path := range pathSet {
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("remove stale projection %s: %w", path, err)
+		}
+	}
+
+	installed.ManagedPaths = nil
+	installed.Paths = nil
+	installed.Conflicts = nil
+	st.Installed[name] = installed
+	return nil
+}
+
+func doctorProjectionPaths(installed state.InstalledSkill) []string {
+	if len(installed.ManagedPaths) > 0 {
+		return append([]string(nil), installed.ManagedPaths...)
+	}
+	return append([]string(nil), installed.Paths...)
+}
+
+func cloneState(src *state.State) *state.State {
+	if src == nil {
+		return nil
+	}
+
+	cloned := &state.State{
+		SchemaVersion:    src.SchemaVersion,
+		LastSync:         src.LastSync,
+		Installed:        make(map[string]state.InstalledSkill, len(src.Installed)),
+		Migrations:       make(map[string]bool, len(src.Migrations)),
+		RegistryFailures: make(map[string]state.RegistryFailure, len(src.RegistryFailures)),
+	}
+	for key, value := range src.Migrations {
+		cloned.Migrations[key] = value
+	}
+	for key, value := range src.RegistryFailures {
+		cloned.RegistryFailures[key] = value
+	}
+	for key, installed := range src.Installed {
+		cloned.Installed[key] = cloneInstalledSkill(installed)
+	}
+	return cloned
+}
+
+func cloneInstalledSkill(src state.InstalledSkill) state.InstalledSkill {
+	dst := src
+	dst.Sources = append([]state.SkillSource(nil), src.Sources...)
+	dst.Tools = append([]string(nil), src.Tools...)
+	dst.Paths = append([]string(nil), src.Paths...)
+	dst.ManagedPaths = append([]string(nil), src.ManagedPaths...)
+	dst.Conflicts = append([]state.ProjectionConflict(nil), src.Conflicts...)
+	return dst
+}
+
+func snapshotDoctorSkill(cfg *config.Config, st *state.State, name string) (doctorSkillSnapshot, error) {
+	installed, ok := st.Installed[name]
+	if !ok {
+		return doctorSkillSnapshot{}, fmt.Errorf("skill %q is not installed", name)
+	}
+
+	canonicalDir := filepath.Join(mustStoreDir(), name)
+	skillContent, err := os.ReadFile(filepath.Join(canonicalDir, "SKILL.md"))
+	if err != nil {
+		return doctorSkillSnapshot{}, fmt.Errorf("read canonical SKILL.md: %w", err)
+	}
+	baseContent, err := os.ReadFile(filepath.Join(canonicalDir, ".scribe-base.md"))
+	if err != nil {
+		return doctorSkillSnapshot{}, fmt.Errorf("read canonical .scribe-base.md: %w", err)
+	}
+
+	pathSet := make(map[string]bool)
+	for _, path := range doctorProjectionPaths(installed) {
+		if strings.TrimSpace(path) != "" {
+			pathSet[path] = true
+		}
+	}
+	for _, conflict := range installed.Conflicts {
+		if strings.TrimSpace(conflict.Path) != "" {
+			pathSet[conflict.Path] = true
+		}
+	}
+	if effectiveTools, err := doctorEffectiveTools(cfg, installed); err == nil {
+		for _, toolName := range effectiveTools {
+			tool, err := tools.ResolveByName(cfg, toolName)
+			if err != nil {
+				continue
+			}
+			path, err := tool.SkillPath(name)
+			if err != nil || strings.TrimSpace(path) == "" {
+				continue
+			}
+			pathSet[path] = true
+		}
+	}
+
+	paths := make([]string, 0, len(pathSet))
+	for path := range pathSet {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	snapshots := make([]pathSnapshot, 0, len(paths))
+	for _, path := range paths {
+		snapshot, err := snapshotPath(path)
+		if err != nil {
+			return doctorSkillSnapshot{}, err
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+
+	return doctorSkillSnapshot{
+		Name:         name,
+		Installed:    cloneInstalledSkill(installed),
+		SkillContent: skillContent,
+		BaseContent:  baseContent,
+		Paths:        snapshots,
+	}, nil
+}
+
+func rollbackDoctorSnapshots(st *state.State, snapshots []doctorSkillSnapshot) error {
+	if st == nil {
+		return fmt.Errorf("load state: missing")
+	}
+
+	var restoreErrs []string
+	for i := len(snapshots) - 1; i >= 0; i-- {
+		snapshot := snapshots[i]
+		canonicalDir := filepath.Join(mustStoreDir(), snapshot.Name)
+		if err := os.WriteFile(filepath.Join(canonicalDir, "SKILL.md"), snapshot.SkillContent, 0o644); err != nil {
+			restoreErrs = append(restoreErrs, fmt.Sprintf("%s canonical skill: %v", snapshot.Name, err))
+		}
+		if err := os.WriteFile(filepath.Join(canonicalDir, ".scribe-base.md"), snapshot.BaseContent, 0o644); err != nil {
+			restoreErrs = append(restoreErrs, fmt.Sprintf("%s canonical base: %v", snapshot.Name, err))
+		}
+		for _, path := range snapshot.Paths {
+			if err := restorePath(path); err != nil {
+				restoreErrs = append(restoreErrs, fmt.Sprintf("%s path %s: %v", snapshot.Name, path.Path, err))
+			}
+		}
+		st.Installed[snapshot.Name] = cloneInstalledSkill(snapshot.Installed)
+	}
+	if err := st.Save(); err != nil {
+		restoreErrs = append(restoreErrs, fmt.Sprintf("save state: %v", err))
+	}
+	for _, snapshot := range snapshots {
+		for _, path := range snapshot.Paths {
+			if path.BackupDir != "" {
+				_ = os.RemoveAll(path.BackupDir)
+			}
+		}
+	}
+	if len(restoreErrs) > 0 {
+		return fmt.Errorf("%s", strings.Join(restoreErrs, "; "))
+	}
+	return nil
+}
+
+func snapshotPath(path string) (pathSnapshot, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return pathSnapshot{Path: path, Kind: "absent"}, nil
+	}
+	if err != nil {
+		return pathSnapshot{}, fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	snapshot := pathSnapshot{Path: path, Mode: info.Mode()}
+	switch {
+	case info.Mode()&os.ModeSymlink != 0:
+		target, err := os.Readlink(path)
+		if err != nil {
+			return pathSnapshot{}, fmt.Errorf("readlink %s: %w", path, err)
+		}
+		snapshot.Kind = "symlink"
+		snapshot.LinkTarget = target
+	case info.IsDir():
+		backupDir, err := os.MkdirTemp("", "doctor-path-*")
+		if err != nil {
+			return pathSnapshot{}, fmt.Errorf("create path snapshot for %s: %w", path, err)
+		}
+		backupPath := filepath.Join(backupDir, "contents")
+		if err := copyPath(path, backupPath); err != nil {
+			_ = os.RemoveAll(backupDir)
+			return pathSnapshot{}, err
+		}
+		snapshot.Kind = "dir"
+		snapshot.BackupDir = backupPath
+	case info.Mode().IsRegular():
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return pathSnapshot{}, fmt.Errorf("read %s: %w", path, err)
+		}
+		snapshot.Kind = "file"
+		snapshot.Data = data
+	default:
+		return pathSnapshot{}, fmt.Errorf("unsupported projection type at %s", path)
+	}
+	return snapshot, nil
+}
+
+func restorePath(snapshot pathSnapshot) error {
+	if err := os.RemoveAll(snapshot.Path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	switch snapshot.Kind {
+	case "absent":
+		return nil
+	case "symlink":
+		if err := os.MkdirAll(filepath.Dir(snapshot.Path), 0o755); err != nil {
+			return err
+		}
+		return os.Symlink(snapshot.LinkTarget, snapshot.Path)
+	case "file":
+		if err := os.MkdirAll(filepath.Dir(snapshot.Path), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(snapshot.Path, snapshot.Data, snapshot.Mode.Perm())
+	case "dir":
+		return copyPath(snapshot.BackupDir, snapshot.Path)
+	default:
+		return fmt.Errorf("unknown path snapshot kind %q", snapshot.Kind)
+	}
+}
+
+func copyPath(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", src, err)
+	}
+	switch {
+	case info.Mode()&os.ModeSymlink != 0:
+		target, err := os.Readlink(src)
+		if err != nil {
+			return fmt.Errorf("readlink %s: %w", src, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		return os.Symlink(target, dst)
+	case info.IsDir():
+		if err := os.MkdirAll(dst, info.Mode().Perm()); err != nil {
+			return err
+		}
+		entries, err := os.ReadDir(src)
+		if err != nil {
+			return fmt.Errorf("read dir %s: %w", src, err)
+		}
+		for _, entry := range entries {
+			if err := copyPath(filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name())); err != nil {
+				return err
+			}
+		}
+		return nil
+	case info.Mode().IsRegular():
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", src, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(dst, data, info.Mode().Perm())
+	default:
+		return fmt.Errorf("unsupported path type at %s", src)
+	}
 }
 
 func writeDoctorJSON(w io.Writer, skill string, report doctor.Report) error {
@@ -135,6 +588,47 @@ func writeDoctorText(w io.Writer, skill string, report doctor.Report) error {
 			continue
 		}
 		if _, err := fmt.Fprintf(w, "- %s [%s] %s: %s\n", issue.Skill, issue.Status, issue.Kind, issue.Message); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeDoctorFixText(w io.Writer, skill string, results []doctorFixResult) error {
+	if len(results) == 0 {
+		if skill != "" {
+			_, err := fmt.Fprintf(w, "No managed skill issues found for %s.\n", skill)
+			return err
+		}
+		_, err := fmt.Fprintln(w, "No managed skill issues found.")
+		return err
+	}
+
+	if skill != "" {
+		if _, err := fmt.Fprintf(w, "Repaired managed skill %s:\n", skill); err != nil {
+			return err
+		}
+	} else {
+		if _, err := fmt.Fprintln(w, "Repaired managed skills:"); err != nil {
+			return err
+		}
+	}
+
+	for _, result := range results {
+		message := "repaired projections"
+		if result.UpdatedCanonical {
+			message = "normalized canonical SKILL.md"
+		}
+		if _, err := fmt.Fprintf(w, "- %s %s", result.Name, message); err != nil {
+			return err
+		}
+		if len(result.RepairedTools) > 0 {
+			if _, err := fmt.Fprintf(w, " and repaired tools: %s", strings.Join(result.RepairedTools, ", ")); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
 			return err
 		}
 	}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -7,10 +7,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/doctor"
 	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
 )
 
@@ -56,7 +58,7 @@ func TestDoctorRejectsUnknownSkill(t *testing.T) {
 	}
 }
 
-func TestDoctorRejectsBareFix(t *testing.T) {
+func TestDoctorFixNoopsWhenClean(t *testing.T) {
 	setupDoctorCleanFixture(t)
 
 	root := newRootCmd()
@@ -66,12 +68,254 @@ func TestDoctorRejectsBareFix(t *testing.T) {
 	root.SetErr(&errBuf)
 	root.SetArgs([]string{"doctor", "--fix"})
 
-	err := root.Execute()
-	if err == nil {
-		t.Fatal("expected error for bare --fix")
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v (stderr=%s)", err, errBuf.String())
 	}
-	if !strings.Contains(err.Error(), "--fix not implemented yet") {
-		t.Fatalf("expected not-implemented error, got %q", err.Error())
+	if !strings.Contains(out.String(), "No managed skill issues found.") {
+		t.Fatalf("expected no-op output, got:\n%s", out.String())
+	}
+}
+
+func TestDoctorFixRepairsAffectedProjections(t *testing.T) {
+	setupDoctorFixFixture(t)
+
+	root := newRootCmd()
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"doctor", "--fix", "--skill", "recap"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v (stderr=%s)", err, errBuf.String())
+	}
+
+	home := os.Getenv("HOME")
+	canonicalDir := filepath.Join(home, ".scribe", "skills", "recap")
+	canonicalResolved, err := filepath.EvalSymlinks(canonicalDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks canonical: %v", err)
+	}
+
+	codexPath := filepath.Join(home, ".codex", "skills", "recap")
+	resolved, err := filepath.EvalSymlinks(codexPath)
+	if err != nil {
+		t.Fatalf("EvalSymlinks codex: %v", err)
+	}
+	if resolved != canonicalResolved {
+		t.Fatalf("codex projection resolves to %q, want %q", resolved, canonicalResolved)
+	}
+}
+
+func TestDoctorFixUpdatesInstalledHash(t *testing.T) {
+	setupDoctorFixFixture(t)
+
+	root := newRootCmd()
+	root.SetArgs([]string{"doctor", "--fix", "--skill", "recap"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	home := os.Getenv("HOME")
+	content, err := os.ReadFile(filepath.Join(home, ".scribe", "skills", "recap", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read canonical SKILL.md: %v", err)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+
+	got := st.Installed["recap"].InstalledHash
+	want := sync.ComputeFileHash(content)
+	if got != want {
+		t.Fatalf("InstalledHash = %q, want %q", got, want)
+	}
+}
+
+func TestDoctorFixClearsProjectionConflicts(t *testing.T) {
+	setupDoctorFixFixture(t)
+
+	root := newRootCmd()
+	root.SetArgs([]string{"doctor", "--fix", "--skill", "recap"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if len(st.Installed["recap"].Conflicts) != 0 {
+		t.Fatalf("Conflicts = %v, want cleared", st.Installed["recap"].Conflicts)
+	}
+}
+
+func TestDoctorFixIsIdempotent(t *testing.T) {
+	setupDoctorFixFixture(t)
+
+	first := newRootCmd()
+	first.SetArgs([]string{"doctor", "--fix", "--skill", "recap"})
+	if err := first.Execute(); err != nil {
+		t.Fatalf("first execute: %v", err)
+	}
+
+	home := os.Getenv("HOME")
+	canonicalPath := filepath.Join(home, ".scribe", "skills", "recap", "SKILL.md")
+	contentBefore, err := os.ReadFile(canonicalPath)
+	if err != nil {
+		t.Fatalf("read canonical SKILL.md: %v", err)
+	}
+
+	stBefore, err := state.Load()
+	if err != nil {
+		t.Fatalf("load state before second run: %v", err)
+	}
+
+	second := newRootCmd()
+	second.SetArgs([]string{"doctor", "--fix", "--skill", "recap"})
+	if err := second.Execute(); err != nil {
+		t.Fatalf("second execute: %v", err)
+	}
+
+	contentAfter, err := os.ReadFile(canonicalPath)
+	if err != nil {
+		t.Fatalf("read canonical SKILL.md after second run: %v", err)
+	}
+	if !bytes.Equal(contentAfter, contentBefore) {
+		t.Fatalf("canonical SKILL.md changed on second run:\nbefore:\n%s\nafter:\n%s", contentBefore, contentAfter)
+	}
+
+	stAfter, err := state.Load()
+	if err != nil {
+		t.Fatalf("load state after second run: %v", err)
+	}
+
+	beforeSkill := stBefore.Installed["recap"]
+	afterSkill := stAfter.Installed["recap"]
+	if afterSkill.InstalledHash != beforeSkill.InstalledHash {
+		t.Fatalf("InstalledHash changed on second run: %q -> %q", beforeSkill.InstalledHash, afterSkill.InstalledHash)
+	}
+	if strings.Join(afterSkill.ManagedPaths, ",") != strings.Join(beforeSkill.ManagedPaths, ",") {
+		t.Fatalf("ManagedPaths changed on second run: %v -> %v", beforeSkill.ManagedPaths, afterSkill.ManagedPaths)
+	}
+	if len(afterSkill.Conflicts) != 0 {
+		t.Fatalf("Conflicts after second run = %v, want empty", afterSkill.Conflicts)
+	}
+}
+
+func TestDoctorFixCleansZeroEffectiveToolDrift(t *testing.T) {
+	setupDoctorZeroEffectiveToolsFixture(t)
+
+	root := newRootCmd()
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	root.SetArgs([]string{"doctor", "--fix", "--skill", "recap"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v (stderr=%s)", err, errBuf.String())
+	}
+
+	home := os.Getenv("HOME")
+	stalePath := filepath.Join(home, ".codex", "skills", "recap")
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale projection still exists at %s", stalePath)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	got := st.Installed["recap"]
+	if len(got.ManagedPaths) != 0 {
+		t.Fatalf("ManagedPaths = %v, want empty", got.ManagedPaths)
+	}
+	if len(got.Paths) != 0 {
+		t.Fatalf("Paths = %v, want empty", got.Paths)
+	}
+	if len(got.Conflicts) != 0 {
+		t.Fatalf("Conflicts = %v, want empty", got.Conflicts)
+	}
+	if !strings.Contains(out.String(), "repaired projections") {
+		t.Fatalf("expected repair output, got:\n%s", out.String())
+	}
+}
+
+func TestDoctorFixRollsBackEarlierSkillsWhenLaterSnapshotFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	cfg := &config.Config{BuiltinsVersion: 3}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	original := []byte(`---
+name: recap
+---
+
+# Recap
+
+Keep daily notes and summaries.
+`)
+	if _, err := tools.WriteToStore("recap", []tools.SkillFile{{Path: "SKILL.md", Content: original}}); err != nil {
+		t.Fatalf("write recap store: %v", err)
+	}
+
+	brokenDir, err := tools.WriteToStore("zzbroken", []tools.SkillFile{{Path: "SKILL.md", Content: []byte(`# Broken
+`)}})
+	if err != nil {
+		t.Fatalf("write broken store: %v", err)
+	}
+	if err := os.Remove(filepath.Join(brokenDir, "SKILL.md")); err != nil {
+		t.Fatalf("remove broken SKILL.md: %v", err)
+	}
+
+	st := &state.State{
+		SchemaVersion: 4,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Revision:      1,
+				InstalledHash: "oldhash",
+				ToolsMode:     state.ToolsModePinned,
+			},
+			"zzbroken": {
+				Revision:      1,
+				InstalledHash: "brokenhash",
+				ToolsMode:     state.ToolsModePinned,
+			},
+		},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	root := newRootCmd()
+	root.SetArgs([]string{"doctor", "--fix"})
+	err = root.Execute()
+	if err == nil {
+		t.Fatal("expected error when later skill snapshot fails")
+	}
+
+	recapPath := filepath.Join(home, ".scribe", "skills", "recap", "SKILL.md")
+	gotContent, err := os.ReadFile(recapPath)
+	if err != nil {
+		t.Fatalf("read recap SKILL.md: %v", err)
+	}
+	if !bytes.Equal(gotContent, original) {
+		t.Fatalf("recap SKILL.md was not rolled back:\nwant:\n%s\ngot:\n%s", original, gotContent)
+	}
+
+	st, err = state.Load()
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if got := st.Installed["recap"].InstalledHash; got != "oldhash" {
+		t.Fatalf("InstalledHash after rollback = %q, want oldhash", got)
 	}
 }
 
@@ -219,6 +463,148 @@ name: recap
 				Revision:      1,
 				InstalledHash: "hash-notes",
 				ToolsMode:     state.ToolsModePinned,
+			},
+		},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+}
+
+func setupDoctorFixFixture(t *testing.T) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	cfg := &config.Config{
+		BuiltinsVersion: 3,
+		Tools: []config.ToolConfig{
+			{Name: "codex", Type: tools.ToolTypeBuiltin, Enabled: true},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	canonicalDir, err := tools.WriteToStore("recap", []tools.SkillFile{{
+		Path: "SKILL.md",
+		Content: []byte(`---
+name: recap
+---
+
+# Recap
+
+Keep daily notes and summaries.
+`),
+	}})
+	if err != nil {
+		t.Fatalf("write recap store: %v", err)
+	}
+
+	codex := tools.CodexTool{}
+	codexPath, err := codex.SkillPath("recap")
+	if err != nil {
+		t.Fatalf("codex skill path: %v", err)
+	}
+	if err := os.MkdirAll(codexPath, 0o755); err != nil {
+		t.Fatalf("mkdir codex projection: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexPath, "SKILL.md"), []byte("# recap\nlocal drift\n"), 0o644); err != nil {
+		t.Fatalf("write conflicted projection: %v", err)
+	}
+
+	normalizedContent, err := os.ReadFile(filepath.Join(canonicalDir, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read canonical content: %v", err)
+	}
+
+	st := &state.State{
+		SchemaVersion: 4,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Revision:      1,
+				InstalledHash: "stalehash",
+				Tools:         []string{"codex"},
+				ToolsMode:     state.ToolsModePinned,
+				Paths:         []string{codexPath},
+				ManagedPaths:  []string{codexPath},
+				Conflicts: []state.ProjectionConflict{{
+					Tool:      "codex",
+					Path:      codexPath,
+					FoundHash: sync.ComputeFileHash([]byte("# recap\nlocal drift\n")),
+					SeenAt:    time.Now().UTC(),
+				}},
+			},
+		},
+	}
+	if st.Installed["recap"].InstalledHash == sync.ComputeFileHash(normalizedContent) {
+		t.Fatal("fixture installed hash unexpectedly matches normalized content")
+	}
+	if err := st.Save(); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+}
+
+func setupDoctorZeroEffectiveToolsFixture(t *testing.T) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	cfg := &config.Config{
+		BuiltinsVersion: 3,
+		Tools: []config.ToolConfig{
+			{Name: "codex", Type: tools.ToolTypeBuiltin, Enabled: false},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	if _, err := tools.WriteToStore("recap", []tools.SkillFile{{
+		Path: "SKILL.md",
+		Content: []byte(`---
+name: recap
+description: Keep daily notes and summaries.
+---
+
+# Recap
+`),
+	}}); err != nil {
+		t.Fatalf("write recap store: %v", err)
+	}
+
+	codex := tools.CodexTool{}
+	codexPath, err := codex.SkillPath("recap")
+	if err != nil {
+		t.Fatalf("codex skill path: %v", err)
+	}
+	if err := os.MkdirAll(codexPath, 0o755); err != nil {
+		t.Fatalf("mkdir stale codex projection: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexPath, "SKILL.md"), []byte("# recap\nstale drift\n"), 0o644); err != nil {
+		t.Fatalf("write stale codex projection: %v", err)
+	}
+
+	st := &state.State{
+		SchemaVersion: 4,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Revision:      1,
+				InstalledHash: "abc12345",
+				Tools:         []string{"codex"},
+				ToolsMode:     state.ToolsModePinned,
+				Paths:         []string{codexPath},
+				ManagedPaths:  []string{codexPath},
+				Conflicts: []state.ProjectionConflict{{
+					Tool:      "codex",
+					Path:      codexPath,
+					FoundHash: sync.ComputeFileHash([]byte("# recap\nstale drift\n")),
+					SeenAt:    time.Now().UTC(),
+				}},
 			},
 		},
 	}

--- a/cmd/skill_projection_repair.go
+++ b/cmd/skill_projection_repair.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 
@@ -45,6 +46,11 @@ func repairSkillProjections(cfg *config.Config, st *state.State, name string) (s
 			return skillProjectionRepairResult{}, err
 		}
 		_ = tool.Uninstall(name)
+		if path, err := tool.SkillPath(name); err == nil {
+			if err := os.RemoveAll(path); err != nil {
+				return skillProjectionRepairResult{}, fmt.Errorf("clear %s/%s: %w", toolName, name, err)
+			}
+		}
 		links, err := tool.Install(name, canonicalDir)
 		if err != nil {
 			return skillProjectionRepairResult{}, fmt.Errorf("repair %s/%s: %w", toolName, name, err)
@@ -60,8 +66,18 @@ func repairSkillProjections(cfg *config.Config, st *state.State, name string) (s
 	}
 	sort.Strings(managedPaths)
 
+	effectiveSet := setOf(effective)
+	filteredConflicts := make([]state.ProjectionConflict, 0, len(installed.Conflicts))
+	for _, conflict := range installed.Conflicts {
+		if effectiveSet[conflict.Tool] {
+			continue
+		}
+		filteredConflicts = append(filteredConflicts, conflict)
+	}
+
 	installed.ManagedPaths = managedPaths
 	installed.Paths = append([]string(nil), managedPaths...)
+	installed.Conflicts = filteredConflicts
 	st.Installed[name] = installed
 	if err := st.Save(); err != nil {
 		return skillProjectionRepairResult{}, err

--- a/docs/superpowers/plans/2026-04-16-scribe-doctor-command.md
+++ b/docs/superpowers/plans/2026-04-16-scribe-doctor-command.md
@@ -1,0 +1,344 @@
+# Scribe Doctor Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Add `scribe doctor` so Scribe can detect and safely fix canonical `SKILL.md` metadata issues, then repair affected tool projections without leaving state drift behind.
+
+**Architecture:** Split pure `SKILL.md` normalization into a leaf `internal/skillmd` package so both Codex install logic and doctor inspections can share it without import cycles. Keep `internal/doctor` focused on inspection/reporting only, and keep `--fix` orchestration in `cmd/doctor.go` so it can reuse existing command-level repair helpers, update `InstalledHash`, and clear projection conflicts after canonical rewrites.
+
+**Tech Stack:** Go, Cobra, existing `cmd`, `internal/state`, `internal/tools`, and a new `internal/skillmd` plus `internal/doctor` package
+
+---
+
+### Task 1: Add a leaf SKILL.md parser and deterministic normalizer
+
+**Files:**
+- Create: `internal/skillmd/normalize.go`
+- Create: `internal/skillmd/normalize_test.go`
+- Modify: `internal/tools/codex.go`
+
+- [x] **Step 1: Write the failing parser and normalization tests**
+
+```go
+func TestNormalizeAddsMissingFrontmatterFromDirectoryName(t *testing.T) {}
+func TestNormalizeFillsMissingDescriptionFromFirstParagraph(t *testing.T) {}
+func TestNormalizeSkipsHeadingsListsAndCodeFences(t *testing.T) {}
+func TestNormalizeRejectsUnrecoverableFrontmatter(t *testing.T) {}
+```
+
+- [x] **Step 2: Run the skillmd tests to verify they fail**
+
+Run: `go test ./internal/skillmd -run 'TestNormalize'`
+Expected: FAIL because the `internal/skillmd` package does not exist yet
+
+- [x] **Step 3: Implement the leaf parser and normalizer**
+
+```go
+type Doc struct {
+	Name        string
+	Description string
+	Body        string
+	Changed     bool
+}
+
+func Normalize(dirName string, content []byte) (Doc, []byte, error)
+func ExtractFallbackDescription(body string) string
+```
+
+```go
+func ExtractFallbackDescription(body string) string {
+	// Skip headings, list items, blockquotes, tables, fenced code blocks.
+	// Return the first non-empty prose paragraph with collapsed whitespace.
+}
+```
+
+- [x] **Step 4: Tighten Codex compatibility checks to use `internal/skillmd`**
+
+```go
+func ensureCodexCompatibleSkillMD(skillName, canonicalDir string) error {
+	content, err := os.ReadFile(filepath.Join(canonicalDir, "SKILL.md"))
+	if err != nil {
+		return fmt.Errorf("read codex skill %q: %w", skillName, err)
+	}
+	_, normalized, err := skillmd.Normalize(skillName, content)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(content, normalized) {
+		return WriteCanonicalSkill(canonicalDir, normalized)
+	}
+	return nil
+}
+```
+
+- [x] **Step 5: Run package tests**
+
+Run: `go test ./internal/skillmd ./internal/tools -run 'TestNormalize|TestCodex'`
+Expected: PASS
+
+- [x] **Step 6: Commit**
+
+```bash
+git add internal/skillmd/normalize.go internal/skillmd/normalize_test.go internal/tools/codex.go
+git commit -m "feat: normalize skill metadata in a shared package"
+```
+
+### Task 2: Add doctor inspection types for managed canonical skills
+
+**Files:**
+- Create: `internal/doctor/doctor.go`
+- Create: `internal/doctor/doctor_test.go`
+
+- [x] **Step 1: Write failing inspection tests for canonical metadata and projection drift**
+
+```go
+func TestInspectSkillReportsMissingDescription(t *testing.T) {}
+func TestInspectSkillReportsInvalidFrontmatter(t *testing.T) {}
+func TestInspectSkillReportsBrokenProjectionState(t *testing.T) {}
+func TestInspectCanLimitToOneSkill(t *testing.T) {}
+```
+
+- [x] **Step 2: Run the inspection tests to verify they fail**
+
+Run: `go test ./internal/doctor -run 'TestInspect'`
+Expected: FAIL because the inspection types do not exist yet
+
+- [x] **Step 3: Implement doctor inspection types and canonical health checks**
+
+```go
+type IssueKind string
+
+const (
+	IssueCanonicalMetadata IssueKind = "canonical_metadata"
+	IssueProjectionDrift   IssueKind = "projection_drift"
+)
+
+type Issue struct {
+	Skill   string
+	Tool    string
+	Kind    IssueKind
+	Status  string
+	Message string
+}
+
+type Report struct {
+	Issues []Issue
+}
+```
+
+```go
+func InspectManagedSkills(cfg *config.Config, st *state.State, name string) (Report, error)
+```
+
+- [x] **Step 4: Run the doctor package tests**
+
+Run: `go test ./internal/doctor`
+Expected: PASS
+
+- [x] **Step 5: Commit**
+
+```bash
+git add internal/doctor/doctor.go internal/doctor/doctor_test.go
+git commit -m "feat: inspect managed skill health"
+```
+
+### Task 3: Add `scribe doctor` command wiring with explicit flags
+
+**Files:**
+- Create: `cmd/doctor.go`
+- Create: `cmd/doctor_test.go`
+- Modify: `cmd/root.go`
+
+- [x] **Step 1: Write failing command tests for default, per-skill, and JSON output**
+
+```go
+func TestDoctorCommandReportsIssues(t *testing.T) {}
+func TestDoctorCommandLimitsToNamedSkill(t *testing.T) {}
+func TestDoctorJSONOutput(t *testing.T) {}
+func TestDoctorRejectsUnknownFlagsCombination(t *testing.T) {}
+```
+
+- [x] **Step 2: Run the command tests to verify they fail**
+
+Run: `go test ./cmd -run 'TestDoctor'`
+Expected: FAIL because the `doctor` command does not exist yet
+
+- [x] **Step 3: Implement the Cobra command and root registration**
+
+```go
+func newDoctorCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Inspect managed skill health",
+		Args:  cobra.NoArgs,
+		RunE:  runDoctor,
+	}
+	cmd.Flags().Bool("fix", false, "Normalize canonical skill metadata and repair affected projections")
+	cmd.Flags().String("skill", "", "Inspect a single managed skill")
+	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	return cmd
+}
+```
+
+```go
+cmd.AddCommand(newDoctorCommand())
+```
+
+- [x] **Step 4: Run the command package tests**
+
+Run: `go test ./cmd`
+Expected: PASS
+
+- [x] **Step 5: Commit**
+
+```bash
+git add cmd/doctor.go cmd/doctor_test.go cmd/root.go
+git commit -m "feat: add scribe doctor command"
+```
+
+### Task 4: Implement `doctor --fix` in `cmd` and repair state hygiene
+
+**Files:**
+- Modify: `cmd/doctor.go`
+- Modify: `cmd/doctor_test.go`
+- Modify: `cmd/skill_projection_repair.go`
+
+- [x] **Step 1: Write failing tests for canonical rewrite plus projection repair**
+
+```go
+func TestDoctorFixRepairsAffectedProjections(t *testing.T) {}
+func TestDoctorFixUpdatesInstalledHash(t *testing.T) {}
+func TestDoctorFixClearsProjectionConflicts(t *testing.T) {}
+func TestDoctorFixIsIdempotent(t *testing.T) {}
+```
+
+- [x] **Step 2: Run the command tests to verify they fail**
+
+Run: `go test ./cmd -run 'TestDoctorFix'`
+Expected: FAIL because `doctor --fix` does not rewrite canonical skills or update state yet
+
+- [x] **Step 3: Implement fix mode in `cmd/doctor.go`**
+
+```go
+type doctorFixResult struct {
+	Name             string   `json:"name"`
+	UpdatedCanonical bool     `json:"updated_canonical"`
+	RepairedTools    []string `json:"repaired_tools,omitempty"`
+}
+
+func runDoctor(cmd *cobra.Command, args []string) error {
+	// Inspect managed skills via internal/doctor.
+	// For --fix, normalize canonical SKILL.md using internal/skillmd.
+	// If canonical content changed:
+	//   1. WriteCanonicalSkill(...)
+	//   2. refresh InstalledHash
+	//   3. call repairSkillProjections(cfg, st, name)
+	//   4. clear related projection conflicts
+	//   5. save state
+}
+```
+
+- [x] **Step 4: Extend projection repair helpers only as needed for doctor orchestration**
+
+```go
+func repairSkillProjections(cfg *config.Config, st *state.State, name string) (skillProjectionRepairResult, error) {
+	// Preserve existing behavior, but make sure doctor can rely on the
+	// returned effective tool list and saved state after repair.
+}
+```
+
+- [x] **Step 5: Run the command test packages**
+
+Run: `go test ./cmd`
+Expected: PASS
+
+- [x] **Step 6: Commit**
+
+```bash
+git add cmd/doctor.go cmd/doctor_test.go cmd/skill_projection_repair.go
+git commit -m "feat: repair projections after doctor fixes"
+```
+
+### Task 5: Document the command and v1 scope
+
+**Files:**
+- Modify: `README.md`
+- Modify: `SKILL.md`
+
+- [x] **Step 1: Write a failing doc expectation check by locating the command list and examples to update**
+
+Run: `rg -n "skill repair|doctor|Commands|Daily Use" README.md SKILL.md`
+Expected: Output shows `doctor` is not documented yet
+
+- [x] **Step 2: Update README command tables and examples**
+
+```md
+| `scribe doctor` | Inspect managed skills and projections for repairable issues |
+| `scribe doctor --fix` | Normalize canonical skill metadata and repair affected projections |
+| `scribe doctor --skill recap --fix` | Repair a single managed skill and its projections |
+```
+
+- [x] **Step 3: Update the agent-facing SKILL.md so setup/help text includes `doctor`**
+
+```md
+- `scribe doctor` audits managed skills and projection health.
+- `scribe doctor --fix` applies safe metadata normalization and then repairs affected tool projections.
+```
+
+- [x] **Step 4: Call out the v1 scope explicitly**
+
+```md
+`scribe doctor` v1 does not attempt to rewrite mixed package layouts for Codex.
+It focuses on canonical metadata health plus projection repair.
+```
+
+- [x] **Step 5: Run targeted doc sanity checks**
+
+Run: `rg -n "scribe doctor" README.md SKILL.md`
+Expected: PASS with the new command documented in both files
+
+- [x] **Step 6: Commit**
+
+```bash
+git add README.md SKILL.md
+git commit -m "docs: add scribe doctor command guidance"
+```
+
+### Task 6: Run focused and full verification passes
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-04-16-scribe-doctor-command.md`
+
+- [x] **Step 1: Run the focused doctor-related test pass**
+
+Run: `go test ./internal/skillmd ./internal/doctor ./internal/tools ./cmd -run 'TestDoctor|TestNormalize|TestInspect'`
+Expected: PASS
+
+- [x] **Step 2: Run the full repository test suite**
+
+Run: `go test ./...`
+Expected: PASS
+
+- [x] **Step 3: Update this plan with any implementation reality changes discovered during execution**
+
+```md
+- Implementation ran in an isolated worktree on branch `feat/scribe-doctor-command-anvil` to avoid unrelated checkout noise.
+- Adjust file lists or commands only if the implementation uncovered a real naming/path difference.
+- Do not leave stale steps in the finished plan.
+```
+
+- [x] **Step 4: Commit the final verification sweep**
+
+```bash
+git add docs/superpowers/plans/2026-04-16-scribe-doctor-command.md
+git commit -m "test: verify scribe doctor implementation"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage: the plan now covers deterministic canonical normalization, `scribe doctor` command UX, `--fix` orchestration in `cmd`, `InstalledHash` refresh, projection conflict cleanup, docs, and verification.
+- Placeholder scan: no `TODO`/`TBD` placeholders remain; each task names concrete files and commands.
+- Type consistency: the plan uses `skillmd.Normalize`, `doctor.InspectManagedSkills`, and `repairSkillProjections` consistently without requiring `internal/*` packages to depend on `cmd/*`.
+- Scope check: Codex mixed-package exposure auditing is intentionally deferred from v1 because the plan does not yet define a safe remediation path.


### PR DESCRIPTION
Adds `scribe doctor` plus `doctor --fix` for managed-skill health.

What changed:
- added shared `internal/skillmd` normalization for canonical `SKILL.md`
- added `internal/doctor` inspections for canonical metadata drift and projection drift
- added `scribe doctor` with text/JSON output and `--skill`
- added `scribe doctor --fix` to normalize canonical metadata, refresh `InstalledHash`, repair projections, clear conflicts, and clean stale zero-effective-tool drift
- documented the command and its v1 scope in `README.md` and `SKILL.md`

A couple implementation details that mattered:
- `doctor --fix` now snapshots per-skill state/files and rolls back earlier repairs if a later skill fails
- zero-effective-tools drift is handled explicitly instead of reporting a fake success

Verification:
- `go test ./internal/skillmd ./internal/doctor ./internal/tools ./cmd -run 'TestDoctor|TestNormalize|TestInspect' -count=1`
- `go test ./cmd -run 'TestDoctorFix' -count=1`
- `go test ./cmd -count=1`
- `go test ./... -count=1`
