### PR TITLE
feat: add scribe skill tools subcommand

### DIFF
--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -19,7 +19,7 @@ func newSkillCommand() *cobra.Command {
 		Short: "Inspect or modify individual installed skills",
 		Long:  `Per-skill management for choosing tools and repairing managed drift.`,
 	}
-	cmd.AddCommand(newSkillEditCommand(), newSkillRepairCommand())
+	cmd.AddCommand(newSkillEditCommand(), newSkillToolsCommand(), newSkillRepairCommand())
 	return cmd
 }
 

--- a/cmd/skill_test.go
+++ b/cmd/skill_test.go
@@ -273,3 +273,136 @@ func TestSkillRepair_ToolWins(t *testing.T) {
 		t.Fatalf("canonical SKILL.md = %q, want generated codex frontmatter", content)
 	}
 }
+
+func TestSkillTools_ShowState(t *testing.T) {
+	seedSkillEnv(t)
+
+	cmd := newSkillToolsCommand()
+	cmd.SetArgs([]string{"commit"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+}
+
+func TestSkillTools_Enable(t *testing.T) {
+	seedSkillEnv(t)
+
+	// First pin to claude only.
+	pin := newSkillEditCommand()
+	pin.SetArgs([]string{"commit", "--tools", "claude", "--json"})
+	if err := pin.Execute(); err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+
+	// Now enable codex via skill tools.
+	cmd := newSkillToolsCommand()
+	cmd.SetArgs([]string{"commit", "--enable", "codex"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	st, _ := state.Load()
+	got := st.Installed["commit"]
+	if got.ToolsMode != state.ToolsModePinned {
+		t.Errorf("ToolsMode = %q, want pinned", got.ToolsMode)
+	}
+	for _, tool := range got.Tools {
+		if tool == "codex" {
+			return
+		}
+	}
+	t.Errorf("codex not in tools: %v", got.Tools)
+}
+
+func TestSkillTools_Disable(t *testing.T) {
+	seedSkillEnv(t)
+
+	cmd := newSkillToolsCommand()
+	cmd.SetArgs([]string{"commit", "--disable", "cursor"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	st, _ := state.Load()
+	got := st.Installed["commit"]
+	for _, tool := range got.Tools {
+		if tool == "cursor" {
+			t.Errorf("cursor still present after --disable: %v", got.Tools)
+		}
+	}
+}
+
+func TestSkillTools_DisableLastTool_ReturnsError(t *testing.T) {
+	seedSkillEnv(t)
+
+	// Pin to a single tool first.
+	pin := newSkillEditCommand()
+	pin.SetArgs([]string{"commit", "--tools", "claude", "--json"})
+	if err := pin.Execute(); err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+
+	cmd := newSkillToolsCommand()
+	cmd.SetArgs([]string{"commit", "--disable", "claude"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when disabling last tool")
+	}
+	if !strings.Contains(err.Error(), "--reset") {
+		t.Errorf("error should mention --reset, got: %v", err)
+	}
+}
+
+func TestSkillTools_Reset(t *testing.T) {
+	seedSkillEnv(t)
+
+	// Pin first.
+	pin := newSkillEditCommand()
+	pin.SetArgs([]string{"commit", "--tools", "claude", "--json"})
+	if err := pin.Execute(); err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+
+	cmd := newSkillToolsCommand()
+	cmd.SetArgs([]string{"commit", "--reset"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	st, _ := state.Load()
+	got := st.Installed["commit"]
+	if got.ToolsMode != state.ToolsModeInherit {
+		t.Errorf("ToolsMode = %q, want inherit after --reset", got.ToolsMode)
+	}
+}
+
+func TestSkillTools_RejectsPackage(t *testing.T) {
+	seedSkillEnv(t)
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	skill := st.Installed["commit"]
+	skill.Type = "package"
+	st.Installed["commit"] = skill
+	if err := st.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	cmd := newSkillToolsCommand()
+	cmd.SetArgs([]string{"commit", "--enable", "claude"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for package skill")
+	}
+}
+
+func TestSkillTools_JSONOutput(t *testing.T) {
+	seedSkillEnv(t)
+
+	cmd := newSkillToolsCommand()
+	cmd.SetArgs([]string{"commit", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+}

--- a/cmd/skill_tools_cmd.go
+++ b/cmd/skill_tools_cmd.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/state"
+)
+
+func newSkillToolsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tools <skill>",
+		Short: "Show or change which AI tools a skill is active in",
+		Long: `Show the current tool assignment for a skill, or modify it.
+
+Without flags, prints the skill's current tool mode and active tools.
+Use --enable / --disable to add or remove specific tools.
+Use --reset to return to inherit mode (tracks global tool settings).
+
+Examples:
+  scribe skill tools tdd                    # show current assignment
+  scribe skill tools tdd --enable cursor    # add cursor
+  scribe skill tools tdd --disable gemini   # remove gemini
+  scribe skill tools tdd --enable claude --disable codex
+  scribe skill tools tdd --reset            # revert to global defaults`,
+		Args: cobra.ExactArgs(1),
+		RunE: runSkillTools,
+	}
+	cmd.Flags().StringSlice("enable", nil, "Enable this skill for the given tool(s)")
+	cmd.Flags().StringSlice("disable", nil, "Disable this skill for the given tool(s)")
+	cmd.Flags().Bool("reset", false, "Revert to inherit mode (tracks globally-enabled tools)")
+	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	cmd.MarkFlagsMutuallyExclusive("enable", "reset")
+	cmd.MarkFlagsMutuallyExclusive("disable", "reset")
+	return cmd
+}
+
+func runSkillTools(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	enableFlag, _ := cmd.Flags().GetStringSlice("enable")
+	disableFlag, _ := cmd.Flags().GetStringSlice("disable")
+	resetFlag, _ := cmd.Flags().GetBool("reset")
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+	useJSON := jsonFlag || !isatty.IsTerminal(os.Stdout.Fd())
+
+	factory := newCommandFactory()
+	cfg, err := factory.Config()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	st, err := factory.State()
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
+
+	installed, ok := st.Installed[name]
+	if !ok {
+		return fmt.Errorf("skill %q is not installed — run `scribe list` to see managed skills", name)
+	}
+	if installed.Type == "package" {
+		return fmt.Errorf("skill %q is a package — per-skill tool assignment does not apply", name)
+	}
+
+	// No mutation flags → show current state.
+	if len(enableFlag) == 0 && len(disableFlag) == 0 && !resetFlag {
+		return renderSkillTools(name, installed, useJSON)
+	}
+
+	// Compute desired mode + tool list.
+	desiredMode := installed.ToolsMode
+	current := append([]string(nil), installed.Tools...)
+	var desired []string
+
+	switch {
+	case resetFlag:
+		desiredMode = state.ToolsModeInherit
+		desired = nil
+
+	default:
+		desiredMode = state.ToolsModePinned
+		desired = state.NormalizeToolSelection(current)
+
+		if len(enableFlag) > 0 {
+			desired = state.NormalizeToolSelection(append(desired, splitCSV(enableFlag)...))
+		}
+		if len(disableFlag) > 0 {
+			drop := setOf(splitCSV(disableFlag))
+			kept := desired[:0]
+			for _, t := range desired {
+				if !drop[t] {
+					kept = append(kept, t)
+				}
+			}
+			desired = kept
+		}
+
+		if len(desired) == 0 {
+			return fmt.Errorf("cannot disable all tools for %q — use --reset to revert to global defaults", name)
+		}
+	}
+
+	result, err := applySkillToolSelection(cfg, st, name, desiredMode, desired)
+	if err != nil {
+		return err
+	}
+
+	if useJSON {
+		out, _ := json.MarshalIndent(result, "", "  ")
+		fmt.Println(string(out))
+		return nil
+	}
+	renderSkillEditText(result)
+	return nil
+}
+
+func renderSkillTools(name string, skill state.InstalledSkill, useJSON bool) error {
+	mode := string(skill.ToolsMode)
+	if mode == "" {
+		mode = "inherit"
+	}
+	if useJSON {
+		out, _ := json.MarshalIndent(map[string]any{
+			"name":       name,
+			"tools_mode": mode,
+			"tools":      skill.Tools,
+		}, "", "  ")
+		fmt.Println(string(out))
+		return nil
+	}
+	fmt.Printf("%s\n", name)
+	fmt.Printf("  mode:  %s\n", mode)
+	if len(skill.Tools) > 0 {
+		fmt.Printf("  tools: %s\n", strings.Join(skill.Tools, ", "))
+	} else {
+		fmt.Printf("  tools: (none)\n")
+	}
+	return nil
+}

--- a/cmd/skill_tools_cmd.go
+++ b/cmd/skill_tools_cmd.go
@@ -136,6 +136,8 @@ func renderSkillTools(name string, skill state.InstalledSkill, useJSON bool) err
 	fmt.Printf("  mode:  %s\n", mode)
 	if len(skill.Tools) > 0 {
 		fmt.Printf("  tools: %s\n", strings.Join(skill.Tools, ", "))
+	} else if mode == "inherit" {
+		fmt.Printf("  tools: (inherits global settings)\n")
 	} else {
 		fmt.Printf("  tools: (none)\n")
 	}


### PR DESCRIPTION
## Summary

- `scribe skill tools <name>` — focused, agent-friendly interface for per-skill tool assignment
- Complements the existing `scribe skill edit` (which remains for power users)

## Usage

```
scribe skill tools tdd                    # show current mode + tools
scribe skill tools tdd --enable cursor    # add cursor
scribe skill tools tdd --disable gemini   # remove gemini
scribe skill tools tdd --enable claude --disable codex   # composable
scribe skill tools tdd --reset            # revert to inherit (global defaults)
scribe skill tools tdd --json             # machine output
```

## Design

- Thin wrapper over `applySkillToolSelection` (same logic as `skill edit`)
- `--enable`/`--disable` are more intuitive than `--add`/`--remove` for enable/disable semantics
- No-flag invocation shows state without mutating — safe to call from agents for inspection
- `--enable`/`--disable` are composable in a single call
- `--reset` and `--enable`/`--disable` are mutually exclusive

## Test plan

- [ ] `scribe skill tools tdd` shows mode + tools
- [ ] `scribe skill tools tdd --enable cursor` adds cursor to pinned set
- [ ] `scribe skill tools tdd --disable claude` removes claude
- [ ] `scribe skill tools tdd --reset` switches back to inherit
- [ ] `scribe skill tools tdd --disable claude --disable cursor` (last tool) → error
- [ ] `--json` flag outputs structured JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)