### PR TITLE
fix: allow typing 'q' in list search without quitting

### DIFF
--- a/cmd/list_tui_keys.go
+++ b/cmd/list_tui_keys.go
@@ -122,8 +122,19 @@ func (m listModel) updateList(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	text := typedText(msg)
 	switch msg.String() {
-	case "ctrl+c", "q":
+	case "ctrl+c":
 		if m.searchMode || m.search != "" {
+			m = m.resetSearch()
+			return m, nil
+		}
+		m.quitting = true
+		return m, tea.Quit
+	case "q":
+		if m.searchMode {
+			m = m.appendSearch("q")
+			return m, nil
+		}
+		if m.search != "" {
 			m = m.resetSearch()
 			return m, nil
 		}
@@ -194,7 +205,16 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
 	switch key {
-	case "ctrl+c", "q":
+	case "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "q":
+		if m.searchMode {
+			if m.focus == focusList {
+				m = m.appendSearch("q")
+			}
+			return m, nil
+		}
 		m.quitting = true
 		return m, tea.Quit
 	case "esc", "escape":


### PR DESCRIPTION
## Summary

- Pressing `q` while the search box is active in `scribe list` now inserts the character instead of resetting the search or quitting
- Applies to both the list view (`updateList`) and detail view (`updateDetail`)
- `ctrl+c` retains the original quit/reset behaviour unchanged

## Root cause

`"ctrl+c"` and `"q"` were grouped in the same `switch` case. When `searchMode` was active, `q` was caught there first — either resetting the search or quitting — before it could reach the `default` branch that appends typed characters.

## Fix

Separated `"q"` into its own case with a `searchMode` guard:
- `searchMode` active → append `"q"` to search buffer
- search has text but mode is off → clear search (previous behaviour)
- no search → quit (previous behaviour)

## Test plan

- [ ] `scribe list`, type `/` to enter search, type `query` — all characters including `q` appear in the filter
- [ ] `q` outside search still quits
- [ ] `ctrl+c` still quits / clears search as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)