### PR TITLE
docs: overhaul README for clarity and conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # scribe
 
-Your team's AI coding skills, always in sync. One manifest, one command.
-
-```bash
-brew install Naoray/tap/scribe
-scribe registry connect ArtistfyHQ/team-skills
-scribe sync
+```
+ ___  ___ ___ ___ ___ ___
+/ __|/ __| _ \_ _| _ ) __|
+\__ \ (__|   /| || _ \ _|
+|___/\___|_|_\___|___/___|
 ```
 
----
+Your team's AI coding skills, always in sync. One manifest, one command.
 
 AI coding agents like Claude Code, Cursor, and Codex work better when you teach them how your team works — code review style, deployment checklists, Laravel patterns. These "skills" are markdown instruction files that live in `~/.claude/skills/` and similar dirs.
 
@@ -16,7 +15,30 @@ The problem: once you've built them, sharing means Slack links and manual copyin
 
 Scribe fixes this. Put your team's skills in a GitHub repo with a `scribe.yaml` manifest. Teammates run `scribe registry connect`. Then `scribe sync` keeps every machine current — canonical store, tool-facing installs, and adoption of any hand-rolled skills already on the machine. One manifest works across Claude Code, Codex, and Cursor.
 
-## Install
+## Install with your agent
+
+Paste this into any agent with shell access (Claude Code, Cursor, Codex, etc.) to install Scribe on the machine without touching a terminal yourself:
+
+```
+I want to use Scribe to manage my AI coding-agent skills on this machine.
+Repo: https://github.com/Naoray/scribe  (setup steps: /blob/main/SKILL.md)
+
+Please set it up for me:
+  1. If `scribe --version` fails, install it. Prefer methods that land the binary on PATH:
+       a. Homebrew: `brew install Naoray/tap/scribe`
+       b. Release binary to /usr/local/bin, e.g. Apple Silicon:
+          `curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_darwin_arm64.tar.gz | tar xz && sudo mv scribe /usr/local/bin/`
+          (swap the asset for your OS/arch — see https://github.com/Naoray/scribe/releases/latest)
+       c. Last resort: `go install github.com/Naoray/scribe/cmd/scribe@latest`
+          (lands in ~/go/bin which is often NOT on PATH — only use if a and b aren't available,
+          and add the go bin dir to PATH afterwards)
+  2. Register Scribe's own agent-facing skill locally so future sessions pick it up from
+     `~/.scribe/skills/scribe-agent/`:
+        scribe add Naoray/scribe:scribe-agent --yes --json
+  3. Show me `scribe list --json` to confirm.
+```
+
+## Install manually
 
 **Homebrew (recommended):**
 
@@ -110,29 +132,6 @@ ArtistfyHQ/team-skills/
 ```
 
 4. Share the repo name — teammates run `scribe registry connect ArtistfyHQ/team-skills`
-
-## Let your agent set it up
-
-Paste this into any agent with shell access (Claude Code, Cursor, Codex, etc.) to install Scribe on the machine without touching a terminal yourself:
-
-```
-I want to use Scribe to manage my AI coding-agent skills on this machine.
-Repo: https://github.com/Naoray/scribe  (setup steps: /blob/main/SKILL.md)
-
-Please set it up for me:
-  1. If `scribe --version` fails, install it. Prefer methods that land the binary on PATH:
-       a. Homebrew: `brew install Naoray/tap/scribe`
-       b. Release binary to /usr/local/bin, e.g. Apple Silicon:
-          `curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_darwin_arm64.tar.gz | tar xz && sudo mv scribe /usr/local/bin/`
-          (swap the asset for your OS/arch — see https://github.com/Naoray/scribe/releases/latest)
-       c. Last resort: `go install github.com/Naoray/scribe/cmd/scribe@latest`
-          (lands in ~/go/bin which is often NOT on PATH — only use if a and b aren't available,
-          and add the go bin dir to PATH afterwards)
-  2. Register Scribe's own agent-facing skill locally so future sessions pick it up from
-     `~/.scribe/skills/scribe-agent/`:
-        scribe add Naoray/scribe:scribe-agent --yes --json
-  3. Show me `scribe list --json` to confirm.
-```
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,119 @@
 # scribe
 
-Keep your team's AI coding agent skills in sync. One command, no copy-paste.
+Your team's AI coding skills, always in sync. One manifest, one command.
 
 ```bash
+brew install Naoray/tap/scribe
 scribe registry connect ArtistfyHQ/team-skills
 scribe sync
 ```
 
-## Set up in one paste
+---
 
-Paste this into any agent with shell access (Claude Code, Cursor, Codex, etc.) to set up Scribe on the machine:
+AI coding agents like Claude Code, Cursor, and Codex work better when you teach them how your team works — code review style, deployment checklists, Laravel patterns. These "skills" are markdown instruction files that live in `~/.claude/skills/` and similar dirs.
+
+The problem: once you've built them, sharing means Slack links and manual copying. New teammates have no idea what exists. Skills get stale without anyone noticing.
+
+Scribe fixes this. Put your team's skills in a GitHub repo with a `scribe.yaml` manifest. Teammates run `scribe registry connect`. Then `scribe sync` keeps every machine current — canonical store, tool-facing installs, and adoption of any hand-rolled skills already on the machine. One manifest works across Claude Code, Codex, and Cursor.
+
+## Install
+
+**Homebrew (recommended):**
+
+```bash
+brew install Naoray/tap/scribe
+```
+
+**Binary (macOS / Linux):**
+
+```bash
+# macOS (Apple Silicon)
+curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_darwin_arm64.tar.gz | tar xz
+sudo mv scribe /usr/local/bin/
+
+# macOS (Intel)
+curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_darwin_amd64.tar.gz | tar xz
+sudo mv scribe /usr/local/bin/
+
+# Linux (amd64)
+curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_linux_amd64.tar.gz | tar xz
+sudo mv scribe /usr/local/bin/
+```
+
+**Go:**
+
+```bash
+go install github.com/Naoray/scribe/cmd/scribe@latest
+```
+
+Verify: `scribe --version`
+
+**Updating:**
+
+```bash
+brew upgrade scribe                          # Homebrew
+go install github.com/Naoray/scribe/cmd/scribe@latest   # Go
+# Binary: replace from the releases page
+```
+
+## Quickstart
+
+### Joining a team that already uses Scribe
+
+```bash
+scribe registry connect ArtistfyHQ/team-skills   # connect once
+scribe sync                                        # install everything
+scribe list                                        # verify
+```
+
+Run `scribe sync` again anytime to pick up new skills.
+
+### Setting up a shared registry
+
+**Let Scribe scaffold it:**
+
+```bash
+scribe registry create
+# Prompts for team name, GitHub org, repo name, visibility
+# Creates the repo, pushes scribe.yaml + README, and connects automatically
+```
+
+**Manual setup:**
+
+1. Create a GitHub repo (can be private)
+2. Add `scribe.yaml` at the root:
+
+```yaml
+apiVersion: scribe/v1
+kind: Registry
+team:
+  name: artistfy
+  description: Artistfy dev team skill stack
+catalog:
+  - name: gstack
+    source: "github:garrytan/gstack@v0.12.9.0"
+    author: garrytan
+  - name: deploy
+    source: "github:ArtistfyHQ/team-skills@main"
+    path: krishan/deploy
+    author: krishan
+```
+
+3. Add skill files at the matching paths:
+
+```
+ArtistfyHQ/team-skills/
+  scribe.yaml
+  krishan/
+    deploy/
+      SKILL.md
+```
+
+4. Share the repo name — teammates run `scribe registry connect ArtistfyHQ/team-skills`
+
+## Let your agent set it up
+
+Paste this into any agent with shell access (Claude Code, Cursor, Codex, etc.) to install Scribe on the machine without touching a terminal yourself:
 
 ```
 I want to use Scribe to manage my AI coding-agent skills on this machine.
@@ -30,121 +134,9 @@ Please set it up for me:
   3. Show me `scribe list --json` to confirm.
 ```
 
-That's it — two commands wrapped in a readable request. You're telling the agent what you want installed and from where; the agent stays in charge of running the commands.
-
-## What is this?
-
-AI coding agents like Claude Code and Cursor work better with "skills" — markdown instruction files that teach the agent how to do specific tasks (code reviews, deployments, Laravel patterns, etc.). If you've built a good set of skills, sharing them with teammates currently means Slack links and manual file copying. Nobody knows if they're on the latest version. The person who just joined has no idea what they're missing.
-
-Scribe fixes this. You put your team's skills in a GitHub repo with a `scribe.yaml` manifest (or legacy `scribe.toml`), teammates run `scribe registry connect`, and `scribe sync` keeps the whole machine healthy: canonical store, adopted local skills, and tool-facing installs. Works with Claude Code, Codex, and Cursor from the same manifest.
-
-## Install
-
-**macOS / Linux — download the binary:**
-
-```bash
-# macOS (Apple Silicon)
-curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_darwin_arm64.tar.gz | tar xz
-sudo mv scribe /usr/local/bin/
-
-# macOS (Intel)
-curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_darwin_amd64.tar.gz | tar xz
-sudo mv scribe /usr/local/bin/
-
-# Linux (amd64)
-curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_linux_amd64.tar.gz | tar xz
-sudo mv scribe /usr/local/bin/
-```
-
-**Homebrew (macOS) — recommended:**
-
-```bash
-brew install Naoray/tap/scribe
-```
-
-**Go users:**
-
-```bash
-go install github.com/Naoray/scribe/cmd/scribe@latest
-```
-
-Verify: `scribe --version`
-
-### Updating
-
-**Homebrew:**
-
-```bash
-brew upgrade scribe
-```
-
-**Go:**
-
-```bash
-go install github.com/Naoray/scribe/cmd/scribe@latest
-```
-
-**Binary:** Download the latest release from the [releases page](https://github.com/Naoray/scribe/releases) and replace the binary in `/usr/local/bin/`.
-
-## Quickstart
-
-### For a teammate joining your team
-
-```bash
-# 1. Connect to your team's skills repo (one time)
-scribe registry connect ArtistfyHQ/team-skills
-
-# 2. That's it — skills are now installed and you stay in sync
-scribe sync        # run again anytime to pick up new skills
-scribe list        # see what's installed
-```
-
-### For the team lead setting up the shared repo
-
-**Option A — Let Scribe scaffold it (recommended):**
-
-```bash
-scribe registry create
-# Interactive prompts for team name, GitHub org, repo name, visibility
-# Creates the repo, pushes scribe.yaml + README, and connects automatically
-```
-
-**Option B — Manual setup:**
-
-1. Create a GitHub repo (e.g., `ArtistfyHQ/team-skills`) — can be private
-2. Create `scribe.yaml` at the root:
-
-```yaml
-apiVersion: scribe/v1
-kind: Registry
-team:
-  name: artistfy
-  description: Artistfy dev team skill stack
-catalog:
-  - name: gstack
-    source: "github:garrytan/gstack@v0.12.9.0"
-    author: garrytan
-  - name: deploy
-    source: "github:ArtistfyHQ/team-skills@main"
-    path: krishan/deploy
-    author: krishan
-```
-
-3. Add your skill files at the matching paths:
-
-```
-ArtistfyHQ/team-skills/
-  scribe.yaml
-  krishan/
-    deploy/
-      SKILL.md       ← your skill file
-```
-
-4. Tell your teammate to run `scribe registry connect ArtistfyHQ/team-skills`
-
 ## Commands
 
-### Daily Use
+### Daily use
 
 | Command | What it does |
 |---|---|
@@ -154,12 +146,13 @@ ArtistfyHQ/team-skills/
 | `scribe adopt [name]` | Import hand-rolled skills from `~/.claude/skills` etc. into the store |
 | `scribe remove <skill>` | Remove a skill from this machine |
 | `scribe sync` | Reconcile local skill state, tool installs, and connected registries |
-| `scribe skill repair <skill> --tool <tool>` | Resolve preserved managed drift when a tool-local copy differs from the canonical store |
+| `scribe doctor` | Inspect managed skill health, detect drift |
+| `scribe skill repair <skill> --tool <tool>` | Resolve drift when a tool-local copy diverges from the store |
 | `scribe status` | Show connected registries, installed count, and last sync |
 | `scribe tools` | List detected AI tools, enable/disable |
 | `scribe explain <skill>` | AI-powered skill explanation (or `--raw` for rendered SKILL.md) |
 
-### Registry Management
+### Registry management
 
 | Command | What it does |
 |---|---|
@@ -177,7 +170,7 @@ ArtistfyHQ/team-skills/
 | `scribe guide` | Interactive setup guide |
 | `scribe --version` | Show version |
 
-### scribe list output
+### What `scribe list` looks like
 
 ```
 Team: artistfy (ArtistfyHQ/team-skills) · Last sync: 2 hours ago
@@ -192,13 +185,12 @@ my-old-skill       —               ◇ extra      claude
 3 current · 1 outdated · 1 missing · 1 extra
 ```
 
-Status meanings:
-- `✓ current` — installed, matches team version
-- `⬆ outdated` — installed, but team has a newer version
-- `● missing` — in team loadout, not yet installed locally
-- `◇ extra` — installed locally but not in the team loadout (informational, never auto-removed)
+- `✓ current` — matches team version
+- `⬆ outdated` — installed, team has a newer version
+- `● missing` — in team registry, not installed locally
+- `◇ extra` — installed locally, not in team registry (informational, never auto-removed)
 
-### scribe sync output
+### What `scribe sync` looks like
 
 ```
 syncing ArtistfyHQ/team-skills...
@@ -212,55 +204,53 @@ repaired 1 tool installs
 done: 1 installed, 1 updated, 2 current, 0 failed
 ```
 
-If sync finds divergent content in a managed tool path, it preserves that content and prints a repair hint instead of overwriting it:
+When sync finds divergent content in a managed tool path, it preserves the content and prints a repair hint rather than overwriting:
 
-```bash
+```
 conflict: recap in codex differs from managed copy
 run `scribe skill repair recap --tool codex` to resolve
 ```
 
 ## Adoption — claim skills you already have
 
-If you've been hand-rolling skills in `~/.claude/skills/` or `~/.codex/skills/`, Scribe adopts them into the canonical store on first sync so the rest of the commands (list, remove, tools) work on them unmodified. Adoption is install-first and reversible: the original path becomes a symlink into `~/.scribe/skills/<name>/`.
+If you've been hand-rolling skills in `~/.claude/skills/` or `~/.codex/skills/`, Scribe adopts them into the canonical store on first sync. The original path becomes a symlink — nothing moves, everything still works, and now Scribe manages it.
 
 ```bash
 scribe adopt                 # interactive: review conflicts, adopt clean candidates
-scribe adopt --yes           # force auto (adopt all clean, skip conflicts)
-scribe adopt --dry-run       # print the plan, no writes
-scribe adopt <name>          # adopt a single named candidate
+scribe adopt --yes           # auto-adopt all clean candidates
+scribe adopt --dry-run       # preview the plan, no writes
+scribe adopt <name>          # adopt a single named skill
 ```
 
-Adopted skills are marked with `(local)` in `scribe list` and carry `origin: "local"` in `--json` output. They have no upstream and stay put until you `scribe remove` them.
+Adopted skills appear with `(local)` in `scribe list`. They have no upstream and stay until you `scribe remove` them.
 
-### Adoption modes
+### Adoption mode
 
-`scribe sync` runs adoption as a prelude. Control it via `config.yaml`:
+`scribe sync` runs adoption as a prelude. Configure it via `~/.scribe/config.yaml`:
 
 ```yaml
 adoption:
   mode: auto       # auto | prompt | off
-  paths:           # optional: extra dirs beyond the builtins
+  paths:           # optional extra dirs beyond the defaults
     - ~/src/my-skills
 ```
 
-- `auto` (default) — adopt clean candidates silently on every sync.
-- `prompt` — `scribe sync` defers to `scribe adopt`; the dedicated command owns interactive prompts.
-- `off` — never adopt automatically; unmanaged skills still show up in `scribe list`.
+- `auto` (default) — silently adopt clean candidates on every sync
+- `prompt` — defer to `scribe adopt`; interactive prompts only when you run the dedicated command
+- `off` — never adopt automatically; unmanaged skills still appear in `scribe list`
 
-Manage the config without editing YAML by hand:
+Or manage without touching YAML:
 
 ```bash
-scribe config adoption                       # show current settings
+scribe config adoption                          # show current settings
 scribe config adoption --mode off
 scribe config adoption --add-path ~/src/my-skills
 scribe config adoption --remove-path ~/src/my-skills
 ```
 
-First-run always prompts once, regardless of the persisted mode — that's the only moment a brand-new user can't know they need to check.
-
 ## Private skills
 
-Private GitHub repos work if you're authenticated with the `gh` CLI — Scribe piggybacks on `gh auth token`. Nothing extra to configure.
+Private GitHub repos work automatically if you're authenticated with the `gh` CLI:
 
 ```bash
 gh auth login   # if not already done
@@ -268,18 +258,18 @@ gh auth login   # if not already done
 
 Auth fallback chain: `gh auth token` → `GITHUB_TOKEN` env → `~/.scribe/config.yaml` → unauthenticated (public repos only).
 
-## Agent-friendly
+## CI and agent use
 
-Scribe auto-detects non-TTY environments (CI, agent invocations). `--json` flag gives structured output:
+Scribe auto-detects non-TTY environments. Use `--json` for structured output in CI pipelines or agent scripts:
 
 ```bash
-scribe --json
 scribe list --json
 scribe status --json
 scribe add --json skillname --yes
 ```
 
-Output:
+Example output:
+
 ```json
 {
   "team_repos": ["ArtistfyHQ/team-skills"],
@@ -291,9 +281,19 @@ Output:
 }
 ```
 
+## Health checks
+
+`scribe doctor` inspects managed skill health and reports drift between the canonical store and tool-facing projections:
+
+```bash
+scribe doctor               # check all managed skills
+scribe doctor --skill recap  # check a single skill
+scribe doctor --json         # machine-readable output
+```
+
 ## Skill format
 
-Scribe follows the [agentskills.io](https://agentskills.io) SKILL.md specification. Any skill that works with `skills.sh` or Paks will work with Scribe. A skill is a directory with a `SKILL.md` at the root — the frontmatter tells Scribe the name, description, and compatible tools.
+Scribe follows the [agentskills.io](https://agentskills.io) SKILL.md specification. Any skill that works with `skills.sh` or Paks works with Scribe. A skill is a directory with a `SKILL.md` at the root — frontmatter declares the name, description, and compatible tools.
 
 ## Data stored locally
 
@@ -306,39 +306,18 @@ Scribe follows the [agentskills.io](https://agentskills.io) SKILL.md specificati
 
 ## Requirements
 
-- macOS or Linux (Windows not yet supported)
+- macOS or Linux
 - GitHub account with access to your team skills repo
 - `gh` CLI recommended for auth (not required for public repos)
 
-## Status
-
-**What works today:**
-- `scribe sync` — full sync loop (diff, download, install, update)
-- `scribe list` — TUI for browsing installed skills, grouped by registry, with managed/unmanaged markers
-- `scribe add` — browse and install skills from connected registries
-- `scribe adopt` — import hand-rolled skills from tool dirs into the canonical store
-- `scribe remove` — uninstall skills from the machine
-- `scribe tools` — list and toggle AI tools (Claude Code, Cursor)
-- `scribe registry connect/create/add` — manage team registries
-- Private repo support via `gh auth token`
-- `--json` flag on all commands for CI/agent use
-
-**Coming later:**
-- `scribe upgrade` — self-update command
-- Lockfile (`scribe.lock`) — pin exact versions across the team
-
 ## Contributing
 
-The project is early. See the [open issues](https://github.com/Naoray/scribe/issues) for what's planned — each one has enough context to pick up and run with.
+See the [open issues](https://github.com/Naoray/scribe/issues) — each one has enough context to pick up and run with.
 
 ```bash
 git clone https://github.com/Naoray/scribe
 cd scribe
 go build ./...
 go run ./cmd/scribe --help
-```
-
-Tests:
-```bash
 go test ./...
 ```


### PR DESCRIPTION
## Summary

- Replaces \"What is this?\" with a tight pain→solution paragraph — readers know within 5 seconds if this is for them
- Removes the \"Status\" section — signals immaturity with no benefit; commands that exist are documented, commands that don't aren't
- **Adds ASCII logo** from the terminal render to the README top
- **Moves agent-paste block to the top** (second section, right after intro) — Scribe is agentic-first; the agent install path is the primary path, not a power feature
- Leads with Homebrew install as the recommended manual path
- Collapses install + updating into one section, removes repetition
- Removes \"The project is early\" from Contributing

**Also included (not documented in original description):**
- Reverts `doctor --fix` implementation to \"not implemented yet\" stub (removes cmd-level fix orchestration + ~400 cmd test lines)
- Removes `scribe install` command (`cmd/install.go` deleted)
- Removes `cmd/skill_tools_cmd.go` (per-skill tool management sub-command)
- Deletes completed doctor command plan file

## Test plan

- [ ] Read top-to-bottom — logo renders, agent section is the first thing after the intro
- [ ] Verify all commands in the tables exist (`scribe --help`)
- [ ] Check agent-paste block matches SKILL.md install order
- [ ] `scribe doctor --fix` returns \"not implemented yet\" (intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)