### PR TITLE
fix: discover skills from Claude Code plugin cache (#103)

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -112,7 +112,17 @@ func OnDisk(st *state.State) ([]Skill, error) {
 		skills = append(skills, found...)
 	}
 
-	// 3. Include state-tracked skills not found on disk (orphans).
+	// 3. Scan Claude Code plugin cache. Plugin-installed skills live under
+	// ~/.claude/plugins/cache/<plugin>/<name>/<hash>/.../SKILL.md with a
+	// layout that varies per plugin. Walk the tree, identify skills by
+	// frontmatter name, dedup against names we've already seen.
+	pluginFound, pluginErr := scanPluginCache(filepath.Join(home, ".claude", "plugins", "cache"), seen, st, scribeSkills)
+	if pluginErr != nil {
+		return nil, pluginErr
+	}
+	skills = append(skills, pluginFound...)
+
+	// 4. Include state-tracked skills not found on disk (orphans).
 	for name, installed := range st.Installed {
 		if seen[name] {
 			continue
@@ -142,6 +152,92 @@ func OnDisk(st *state.State) ([]Skill, error) {
 
 	return skills, nil
 }
+
+// pluginCacheMaxDepth caps WalkDir recursion. Real plugin layouts top out
+// around 6-7 segments below the cache root; deeper trees are noise (vendored
+// node_modules, nested git checkouts) and not worth scanning.
+const pluginCacheMaxDepth = 8
+
+// scanPluginCache walks ~/.claude/plugins/cache/ for SKILL.md files. The
+// directory layout under each plugin is plugin-defined and inconsistent
+// (some put SKILL.md at the plugin root, others under skills/<name>/, others
+// under plugins/<name>/skills/<name>/), so a fixed-glob scan misses cases.
+// We walk, parse the frontmatter `name`, and dedup against `seen` so a skill
+// already found in ~/.scribe/skills/ or a tool dir wins.
+func scanPluginCache(cacheDir string, seen map[string]bool, st *state.State, scribeSkills string) ([]Skill, error) {
+	info, err := os.Stat(cacheDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat %s: %w", cacheDir, err)
+	}
+	if !info.IsDir() {
+		return nil, nil
+	}
+
+	var skills []Skill
+	walkErr := filepath.WalkDir(cacheDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			// Permission errors on a subtree shouldn't break discovery.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		// Bound recursion depth relative to cacheDir.
+		rel, _ := filepath.Rel(cacheDir, path)
+		depth := 0
+		if rel != "." {
+			depth = strings.Count(rel, string(filepath.Separator)) + 1
+		}
+
+		if d.IsDir() {
+			name := d.Name()
+			// Stale staging dirs left by Claude Code's plugin installer.
+			if strings.HasPrefix(name, "temp_git_") {
+				return fs.SkipDir
+			}
+			if reservedNames[name] {
+				return fs.SkipDir
+			}
+			if depth > pluginCacheMaxDepth {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		if d.Name() != "SKILL.md" {
+			return nil
+		}
+
+		skillDir := filepath.Dir(path)
+		meta := readSkillMetadata(skillDir)
+		skillName := meta.Name
+		if skillName == "" {
+			skillName = filepath.Base(skillDir)
+		}
+		if !validSkillName.MatchString(skillName) || reservedNames[skillName] {
+			return nil
+		}
+		if seen[skillName] {
+			return nil
+		}
+
+		seen[skillName] = true
+		skills = append(skills, buildSkill(skillName, skillDir, filepath.Dir(skillDir), toolClaude, st, scribeSkills))
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("walk %s: %w", cacheDir, walkErr)
+	}
+	return skills, nil
+}
+
+// toolClaude is the install-target identifier for Claude Code. Mirrors
+// internal/tools.toolClaude — duplicated to avoid an import cycle.
+const toolClaude = "claude"
 
 func scanToolSkills(dir, target string, seen map[string]bool, st *state.State, scribeSkills string) ([]Skill, error) {
 	entries, err := os.ReadDir(dir)

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -431,6 +431,138 @@ func TestOnDiskManagedField(t *testing.T) {
 	})
 }
 
+func TestOnDiskPluginCache(t *testing.T) {
+	t.Run("discovers skill from claude plugin cache", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		// Mimic the Claude Code plugin layout for caveman:
+		// ~/.claude/plugins/cache/<plugin>/<name>/<hash>/skills/<skill>/SKILL.md
+		pluginSkill := filepath.Join(home, ".claude", "plugins", "cache", "caveman", "caveman", "abc123", "skills", "caveman")
+		if err := os.MkdirAll(pluginSkill, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		content := "---\nname: caveman\ndescription: Ultra-compressed mode\n---\n\n# Caveman\n"
+		if err := os.WriteFile(filepath.Join(pluginSkill, "SKILL.md"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		// State tracks caveman as a plugin-installed package with no symlinks.
+		st := &state.State{Installed: map[string]state.InstalledSkill{
+			"caveman": {Type: "package", Revision: 1},
+		}}
+
+		skills, err := OnDisk(st)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var found *Skill
+		for i := range skills {
+			if skills[i].Name == "caveman" {
+				found = &skills[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("caveman not discovered from plugin cache; got %+v", skills)
+		}
+		if found.LocalPath != pluginSkill {
+			t.Errorf("LocalPath: got %q, want %q", found.LocalPath, pluginSkill)
+		}
+	})
+
+	t.Run("dedups by frontmatter name across alternate plugin layouts", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		base := filepath.Join(home, ".claude", "plugins", "cache", "caveman", "caveman", "abc123")
+		// Three real layouts caveman ships at the same time.
+		for _, sub := range []string{
+			filepath.Join("caveman"),
+			filepath.Join("skills", "caveman"),
+			filepath.Join("plugins", "caveman", "skills", "caveman"),
+		} {
+			dir := filepath.Join(base, sub)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			content := "---\nname: caveman\ndescription: dup\n---\n"
+			if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		st := &state.State{Installed: map[string]state.InstalledSkill{}}
+		skills, err := OnDisk(st)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		count := 0
+		for _, sk := range skills {
+			if sk.Name == "caveman" {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("expected 1 caveman entry, got %d", count)
+		}
+	})
+
+	t.Run("scribe store wins over plugin cache", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		storeDir := filepath.Join(home, ".scribe", "skills", "caveman")
+		os.MkdirAll(storeDir, 0o755)
+		os.WriteFile(filepath.Join(storeDir, "SKILL.md"), []byte("---\nname: caveman\n---\n# from store\n"), 0o644)
+
+		pluginDir := filepath.Join(home, ".claude", "plugins", "cache", "caveman", "caveman", "abc", "skills", "caveman")
+		os.MkdirAll(pluginDir, 0o755)
+		os.WriteFile(filepath.Join(pluginDir, "SKILL.md"), []byte("---\nname: caveman\n---\n# from plugin\n"), 0o644)
+
+		st := &state.State{Installed: map[string]state.InstalledSkill{}}
+		skills, err := OnDisk(st)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var found *Skill
+		for i := range skills {
+			if skills[i].Name == "caveman" {
+				found = &skills[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatal("caveman not found")
+		}
+		if found.LocalPath != storeDir {
+			t.Errorf("expected scribe store to win; LocalPath=%q want=%q", found.LocalPath, storeDir)
+		}
+	})
+
+	t.Run("skips temp_git staging dirs", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		stale := filepath.Join(home, ".claude", "plugins", "cache", "temp_git_999", "skills", "ghost")
+		os.MkdirAll(stale, 0o755)
+		os.WriteFile(filepath.Join(stale, "SKILL.md"), []byte("---\nname: ghost\n---\n"), 0o644)
+
+		st := &state.State{Installed: map[string]state.InstalledSkill{}}
+		skills, err := OnDisk(st)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, sk := range skills {
+			if sk.Name == "ghost" {
+				t.Fatalf("ghost from temp_git_* dir should be skipped, got %+v", sk)
+			}
+		}
+	})
+}
+
 func TestHasConflictMarkers(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

- `scribe explain <skill>` failed for skills installed via Claude Code's plugin system with `skill "X" is tracked but not on disk — try \`scribe sync\` first`.
- Discovery only scanned `~/.scribe/skills/`, `~/.claude/skills/`, and `~/.codex/skills/`. Plugin-installed skills live under `~/.claude/plugins/cache/<plugin>/<name>/<hash>/.../SKILL.md` and never got picked up.
- Added `scanPluginCache()` to `internal/discovery/discovery.go`: walks the cache (depth-bounded), skips Claude Code's `temp_git_*` staging dirs, identifies skills by frontmatter `name` (layout varies per plugin — caveman ships SKILL.md at 3 paths at once), dedups against names already found so the canonical scribe store still wins.

Fixes #103.

## Test plan

- [x] `go test ./...` — all green
- [x] New `TestOnDiskPluginCache` covers: discovery, multi-layout dedup, store precedence, `temp_git_*` skipping
- [x] Live `scribe explain caveman --raw` renders the SKILL.md instead of erroring