### PR TITLE
feat: add install-all flag to connect

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -13,7 +13,7 @@ import (
 )
 
 func newConnectCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "connect [owner/repo]",
 		Short: "Connect to a skill registry",
 		Long: `Connect to a skill registry so Scribe can sync skills from it.
@@ -23,10 +23,13 @@ The repo must contain a scribe.yaml or scribe.toml with a [team] section.
 Examples:
   scribe connect ArtistfyHQ/team-skills
   scribe connect mattpocock/skills
+  scribe connect mattpocock/skills --install-all
   scribe connect                          # interactive prompt`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runConnect,
 	}
+	cmd.Flags().Bool("install-all", false, "Install every discovered skill from the connected registry")
+	return cmd
 }
 
 func runConnect(cmd *cobra.Command, args []string) error {
@@ -34,12 +37,18 @@ func runConnect(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	installAll, _ := cmd.Flags().GetBool("install-all")
 
 	bag := &workflow.Bag{
-		RepoArg: repo,
-		Factory: newCommandFactory(),
+		RepoArg:        repo,
+		InstallAllFlag: installAll,
+		Factory:        newCommandFactory(),
 	}
-	if err := workflow.Run(cmd.Context(), workflow.ConnectSteps(), bag); err != nil {
+	steps := workflow.ConnectSteps()
+	if installAll {
+		steps = workflow.ConnectInstallAllSteps()
+	}
+	if err := workflow.Run(cmd.Context(), steps, bag); err != nil {
 		return err
 	}
 	return saveWorkflowState(bag)

--- a/cmd/connect_test.go
+++ b/cmd/connect_test.go
@@ -66,3 +66,15 @@ func TestResolveRepoNoArgNonTTY(t *testing.T) {
 		t.Error("expected error when no arg and non-TTY stdin")
 	}
 }
+
+func TestNewConnectCommand_InstallAllFlag(t *testing.T) {
+	cmd := newConnectCommand()
+
+	flag := cmd.Flags().Lookup("install-all")
+	if flag == nil {
+		t.Fatal("expected install-all flag to be registered")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("install-all default = %q, want false", flag.DefValue)
+	}
+}

--- a/cmd/create_registry.go
+++ b/cmd/create_registry.go
@@ -154,7 +154,7 @@ func runCreateRegistry(cmd *cobra.Command, args []string) error {
 		Factory:  factory,
 		Provider: provider.NewGitHubProvider(provider.WrapGitHubClient(client)),
 	}
-	if err := workflow.Run(ctx, workflow.ConnectAndSyncTail(), bag); err != nil {
+	if err := workflow.Run(ctx, workflow.ConnectInstallAllTail(), bag); err != nil {
 		fmt.Fprintf(os.Stderr, "\nRepo %s was created but connecting failed: %v\n", repoSlug, err)
 		fmt.Fprintf(os.Stderr, "Run `scribe connect %s` to retry.\n", repoSlug)
 		return err

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -112,7 +112,17 @@ func OnDisk(st *state.State) ([]Skill, error) {
 		skills = append(skills, found...)
 	}
 
-	// 3. Include state-tracked skills not found on disk (orphans).
+	// 3. Scan Claude Code plugin cache. Plugin-installed skills live under
+	// ~/.claude/plugins/cache/<plugin>/<name>/<hash>/.../SKILL.md with a
+	// layout that varies per plugin. Walk the tree, identify skills by
+	// frontmatter name, dedup against names we've already seen.
+	pluginFound, pluginErr := scanPluginCache(filepath.Join(home, ".claude", "plugins", "cache"), seen, st, scribeSkills)
+	if pluginErr != nil {
+		return nil, pluginErr
+	}
+	skills = append(skills, pluginFound...)
+
+	// 4. Include state-tracked skills not found on disk (orphans).
 	for name, installed := range st.Installed {
 		if seen[name] {
 			continue
@@ -142,6 +152,92 @@ func OnDisk(st *state.State) ([]Skill, error) {
 
 	return skills, nil
 }
+
+// pluginCacheMaxDepth caps WalkDir recursion. Real plugin layouts top out
+// around 6-7 segments below the cache root; deeper trees are noise (vendored
+// node_modules, nested git checkouts) and not worth scanning.
+const pluginCacheMaxDepth = 8
+
+// scanPluginCache walks ~/.claude/plugins/cache/ for SKILL.md files. The
+// directory layout under each plugin is plugin-defined and inconsistent
+// (some put SKILL.md at the plugin root, others under skills/<name>/, others
+// under plugins/<name>/skills/<name>/), so a fixed-glob scan misses cases.
+// We walk, parse the frontmatter `name`, and dedup against `seen` so a skill
+// already found in ~/.scribe/skills/ or a tool dir wins.
+func scanPluginCache(cacheDir string, seen map[string]bool, st *state.State, scribeSkills string) ([]Skill, error) {
+	info, err := os.Stat(cacheDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat %s: %w", cacheDir, err)
+	}
+	if !info.IsDir() {
+		return nil, nil
+	}
+
+	var skills []Skill
+	walkErr := filepath.WalkDir(cacheDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			// Permission errors on a subtree shouldn't break discovery.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		// Bound recursion depth relative to cacheDir.
+		rel, _ := filepath.Rel(cacheDir, path)
+		depth := 0
+		if rel != "." {
+			depth = strings.Count(rel, string(filepath.Separator)) + 1
+		}
+
+		if d.IsDir() {
+			name := d.Name()
+			// Stale staging dirs left by Claude Code's plugin installer.
+			if strings.HasPrefix(name, "temp_git_") {
+				return fs.SkipDir
+			}
+			if reservedNames[name] {
+				return fs.SkipDir
+			}
+			if depth > pluginCacheMaxDepth {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		if d.Name() != "SKILL.md" {
+			return nil
+		}
+
+		skillDir := filepath.Dir(path)
+		meta := readSkillMetadata(skillDir)
+		skillName := meta.Name
+		if skillName == "" {
+			skillName = filepath.Base(skillDir)
+		}
+		if !validSkillName.MatchString(skillName) || reservedNames[skillName] {
+			return nil
+		}
+		if seen[skillName] {
+			return nil
+		}
+
+		seen[skillName] = true
+		skills = append(skills, buildSkill(skillName, skillDir, filepath.Dir(skillDir), toolClaude, st, scribeSkills))
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("walk %s: %w", cacheDir, walkErr)
+	}
+	return skills, nil
+}
+
+// toolClaude is the install-target identifier for Claude Code. Mirrors
+// internal/tools.toolClaude — duplicated to avoid an import cycle.
+const toolClaude = "claude"
 
 func scanToolSkills(dir, target string, seen map[string]bool, st *state.State, scribeSkills string) ([]Skill, error) {
 	entries, err := os.ReadDir(dir)

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -431,6 +431,138 @@ func TestOnDiskManagedField(t *testing.T) {
 	})
 }
 
+func TestOnDiskPluginCache(t *testing.T) {
+	t.Run("discovers skill from claude plugin cache", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		// Mimic the Claude Code plugin layout for caveman:
+		// ~/.claude/plugins/cache/<plugin>/<name>/<hash>/skills/<skill>/SKILL.md
+		pluginSkill := filepath.Join(home, ".claude", "plugins", "cache", "caveman", "caveman", "abc123", "skills", "caveman")
+		if err := os.MkdirAll(pluginSkill, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		content := "---\nname: caveman\ndescription: Ultra-compressed mode\n---\n\n# Caveman\n"
+		if err := os.WriteFile(filepath.Join(pluginSkill, "SKILL.md"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		// State tracks caveman as a plugin-installed package with no symlinks.
+		st := &state.State{Installed: map[string]state.InstalledSkill{
+			"caveman": {Type: "package", Revision: 1},
+		}}
+
+		skills, err := OnDisk(st)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var found *Skill
+		for i := range skills {
+			if skills[i].Name == "caveman" {
+				found = &skills[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("caveman not discovered from plugin cache; got %+v", skills)
+		}
+		if found.LocalPath != pluginSkill {
+			t.Errorf("LocalPath: got %q, want %q", found.LocalPath, pluginSkill)
+		}
+	})
+
+	t.Run("dedups by frontmatter name across alternate plugin layouts", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		base := filepath.Join(home, ".claude", "plugins", "cache", "caveman", "caveman", "abc123")
+		// Three real layouts caveman ships at the same time.
+		for _, sub := range []string{
+			filepath.Join("caveman"),
+			filepath.Join("skills", "caveman"),
+			filepath.Join("plugins", "caveman", "skills", "caveman"),
+		} {
+			dir := filepath.Join(base, sub)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			content := "---\nname: caveman\ndescription: dup\n---\n"
+			if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		st := &state.State{Installed: map[string]state.InstalledSkill{}}
+		skills, err := OnDisk(st)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		count := 0
+		for _, sk := range skills {
+			if sk.Name == "caveman" {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("expected 1 caveman entry, got %d", count)
+		}
+	})
+
+	t.Run("scribe store wins over plugin cache", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		storeDir := filepath.Join(home, ".scribe", "skills", "caveman")
+		os.MkdirAll(storeDir, 0o755)
+		os.WriteFile(filepath.Join(storeDir, "SKILL.md"), []byte("---\nname: caveman\n---\n# from store\n"), 0o644)
+
+		pluginDir := filepath.Join(home, ".claude", "plugins", "cache", "caveman", "caveman", "abc", "skills", "caveman")
+		os.MkdirAll(pluginDir, 0o755)
+		os.WriteFile(filepath.Join(pluginDir, "SKILL.md"), []byte("---\nname: caveman\n---\n# from plugin\n"), 0o644)
+
+		st := &state.State{Installed: map[string]state.InstalledSkill{}}
+		skills, err := OnDisk(st)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var found *Skill
+		for i := range skills {
+			if skills[i].Name == "caveman" {
+				found = &skills[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatal("caveman not found")
+		}
+		if found.LocalPath != storeDir {
+			t.Errorf("expected scribe store to win; LocalPath=%q want=%q", found.LocalPath, storeDir)
+		}
+	})
+
+	t.Run("skips temp_git staging dirs", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		stale := filepath.Join(home, ".claude", "plugins", "cache", "temp_git_999", "skills", "ghost")
+		os.MkdirAll(stale, 0o755)
+		os.WriteFile(filepath.Join(stale, "SKILL.md"), []byte("---\nname: ghost\n---\n"), 0o644)
+
+		st := &state.State{Installed: map[string]state.InstalledSkill{}}
+		skills, err := OnDisk(st)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, sk := range skills {
+			if sk.Name == "ghost" {
+				t.Fatalf("ghost from temp_git_* dir should be skipped, got %+v", sk)
+			}
+		}
+	})
+}
+
 func TestHasConflictMarkers(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/workflow/connect.go
+++ b/internal/workflow/connect.go
@@ -16,33 +16,46 @@ import (
 // It saves the registry config and shows available skills — it does NOT
 // auto-install anything. Users install skills explicitly with `scribe add`.
 func ConnectSteps() []Step {
-	return []Step{
-		{"LoadConfig", StepLoadConfig},
-		{"ResolveFormatter", StepResolveFormatter},
-		{"DedupCheck", StepDedupCheck},
-		{"FetchManifest", StepFetchManifest},
-		{"ValidateManifest", StepValidateManifest},
-		{"InferRegistryType", StepInferRegistryType},
-		{"SaveConfig", StepSaveConfig},
-		{"ShowAvailable", StepShowAvailableSkills},
-	}
+	steps := append([]Step{}, connectBaseSteps(true)...)
+	return append(steps, Step{Name: "ShowAvailable", Fn: StepShowAvailableSkills})
 }
 
-// ConnectAndSyncTail returns connect + sync steps starting from
-// ResolveFormatter, for use by create-registry where the user just
-// authored the skills and wants them installed immediately.
-func ConnectAndSyncTail() []Step {
+// ConnectInstallAllSteps returns the connect path that immediately installs
+// every discovered skill from the just-connected registry.
+func ConnectInstallAllSteps() []Step {
+	steps := append([]Step{}, connectBaseSteps(true)...)
+	return append(steps, connectInstallAllTail()...)
+}
+
+// ConnectInstallAllTail returns the connect + install-all path starting at
+// ResolveFormatter, for callers that already loaded config/client state.
+func ConnectInstallAllTail() []Step {
+	steps := append([]Step{}, connectBaseSteps(false)...)
+	return append(steps, connectInstallAllTail()...)
+}
+
+func connectBaseSteps(loadConfig bool) []Step {
+	steps := make([]Step, 0, 7)
+	if loadConfig {
+		steps = append(steps, Step{Name: "LoadConfig", Fn: StepLoadConfig})
+	}
+	steps = append(steps,
+		Step{Name: "ResolveFormatter", Fn: StepResolveFormatter},
+		Step{Name: "DedupCheck", Fn: StepDedupCheck},
+		Step{Name: "FetchManifest", Fn: StepFetchManifest},
+		Step{Name: "ValidateManifest", Fn: StepValidateManifest},
+		Step{Name: "InferRegistryType", Fn: StepInferRegistryType},
+		Step{Name: "SaveConfig", Fn: StepSaveConfig},
+	)
+	return steps
+}
+
+func connectInstallAllTail() []Step {
 	return []Step{
-		{"ResolveFormatter", StepResolveFormatter},
-		{"DedupCheck", StepDedupCheck},
-		{"FetchManifest", StepFetchManifest},
-		{"ValidateManifest", StepValidateManifest},
-		{"InferRegistryType", StepInferRegistryType},
-		{"SaveConfig", StepSaveConfig},
-		{"LoadState", StepLoadState},
-		{"SetSingleRepo", StepSetSingleRepo},
-		{"ResolveTools", StepResolveTools},
-		{"SyncSkills", StepConnectSyncError},
+		{Name: "LoadState", Fn: StepLoadState},
+		{Name: "SetSingleRepo", Fn: StepSetSingleRepo},
+		{Name: "ResolveTools", Fn: StepResolveTools},
+		{Name: "SyncSkills", Fn: StepConnectSyncError},
 	}
 }
 
@@ -119,7 +132,7 @@ func StepSaveConfig(_ context.Context, b *Bag) error {
 }
 
 // StepSetSingleRepo sets Repos to just the newly connected repo for the sync tail.
-// Used by ConnectAndSyncTail (create-registry path).
+// Used by the connect install-all path.
 func StepSetSingleRepo(_ context.Context, b *Bag) error {
 	b.Repos = []string{b.RepoArg}
 	b.Formatter.OnConnectSyncing()

--- a/internal/workflow/connect_test.go
+++ b/internal/workflow/connect_test.go
@@ -39,20 +39,31 @@ func TestConnectSteps_DoesNotContainSyncSkills(t *testing.T) {
 	}
 }
 
-func TestConnectAndSyncTail_SkipsLoadConfig(t *testing.T) {
-	tail := workflow.ConnectAndSyncTail()
-	if tail[0].Name == "LoadConfig" {
-		t.Error("ConnectAndSyncTail should not start with LoadConfig")
+func TestConnectInstallAllSteps_ContainsSyncSkills(t *testing.T) {
+	steps := workflow.ConnectInstallAllSteps()
+	last := steps[len(steps)-1]
+	if last.Name != "SyncSkills" {
+		t.Errorf("expected ConnectInstallAllSteps last step SyncSkills, got %s", last.Name)
 	}
-	if tail[0].Name != "ResolveFormatter" {
-		t.Errorf("expected ConnectAndSyncTail to start with ResolveFormatter, got %s", tail[0].Name)
+	if steps[0].Name != "LoadConfig" {
+		t.Errorf("expected ConnectInstallAllSteps to start with LoadConfig, got %s", steps[0].Name)
 	}
 }
 
-func TestConnectAndSyncTail_EndsWithSyncSkills(t *testing.T) {
-	tail := workflow.ConnectAndSyncTail()
+func TestConnectInstallAllTail_SkipsLoadConfig(t *testing.T) {
+	tail := workflow.ConnectInstallAllTail()
+	if tail[0].Name == "LoadConfig" {
+		t.Error("ConnectInstallAllTail should not start with LoadConfig")
+	}
+	if tail[0].Name != "ResolveFormatter" {
+		t.Errorf("expected ConnectInstallAllTail to start with ResolveFormatter, got %s", tail[0].Name)
+	}
+}
+
+func TestConnectInstallAllTail_EndsWithSyncSkills(t *testing.T) {
+	tail := workflow.ConnectInstallAllTail()
 	last := tail[len(tail)-1]
 	if last.Name != "SyncSkills" {
-		t.Errorf("expected ConnectAndSyncTail last step SyncSkills, got %s", last.Name)
+		t.Errorf("expected ConnectInstallAllTail last step SyncSkills, got %s", last.Name)
 	}
 }


### PR DESCRIPTION
## Summary
- add a `--install-all` flag to `scribe connect` so foreign registries can install all discovered skills immediately
- refactor the connect workflow so the connect-and-install-all path is reusable instead of being create-registry-specific
- update command and workflow tests for the new connect mode

## Testing
- go test ./cmd ./internal/workflow
- go test ./...