### PR TITLE
fix(list): meaningful version + scrollable preview in detail pane

### DIFF
--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -42,6 +42,7 @@ type detailFocus int
 const (
 	focusList detailFocus = iota
 	focusActions
+	focusPreview
 )
 
 type listRow = workflow.ListRow
@@ -62,6 +63,7 @@ type listModel struct {
 	selected       bool
 	focus          detailFocus
 	actionCursor   int
+	excerptOffset  int
 	substate       listSubstate
 	toolCursor     int
 	toolStatuses   []tools.Status

--- a/cmd/list_tui_keys.go
+++ b/cmd/list_tui_keys.go
@@ -385,8 +385,8 @@ func (m listModel) updatePreviewFocus(row listRow, key string) listModel {
 }
 
 // previewMaxOffset returns the largest valid scroll offset for the excerpt.
-// Keeping a small tail visible at the bottom feels nicer than letting the
-// last line scroll off entirely.
+// At max offset the final line sits at the top of the pane; we stop there
+// rather than letting it scroll off entirely.
 func previewMaxOffset(excerpt string) int {
 	total := strings.Count(excerpt, "\n") + 1
 	if total <= 1 {

--- a/cmd/list_tui_keys.go
+++ b/cmd/list_tui_keys.go
@@ -221,22 +221,43 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.selected = false
 		m.focus = focusList
 		m.actionCursor = 0
+		m.excerptOffset = 0
 		m.statusMsg = ""
 		return m, nil
 	case "tab":
-		if m.focus == focusList {
+		row := m.filtered[m.cursor]
+		switch m.focus {
+		case focusList:
 			m.focus = focusActions
 			m.actionCursor = 0
-		} else {
+		case focusActions:
+			if rowHasPreview(row) {
+				m.focus = focusPreview
+				m.excerptOffset = 0
+			} else {
+				m.focus = focusList
+			}
+		default:
 			m.focus = focusList
+			m.excerptOffset = 0
 		}
 		return m, nil
 	case "shift+tab":
-		if m.focus == focusActions {
+		row := m.filtered[m.cursor]
+		switch m.focus {
+		case focusList:
+			if rowHasPreview(row) {
+				m.focus = focusPreview
+				m.excerptOffset = 0
+			} else {
+				m.focus = focusActions
+				m.actionCursor = 0
+			}
+		case focusActions:
 			m.focus = focusList
-		} else {
+		default:
 			m.focus = focusActions
-			m.actionCursor = 0
+			m.excerptOffset = 0
 		}
 		return m, nil
 	}
@@ -252,6 +273,7 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				m.cursor--
 				m = m.ensureCursorVisible()
 				m.actionCursor = 0
+				m.excerptOffset = 0
 				m.statusMsg = ""
 			}
 		case "down", "j":
@@ -259,6 +281,7 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				m.cursor++
 				m = m.ensureCursorVisible()
 				m.actionCursor = 0
+				m.excerptOffset = 0
 				m.statusMsg = ""
 			}
 		case "right", "l", "enter":
@@ -267,6 +290,7 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		case "backspace":
 			m = m.backspaceSearch()
 			m.actionCursor = 0
+			m.excerptOffset = 0
 			m.statusMsg = ""
 			if !m.selected {
 				m.focus = focusList
@@ -294,7 +318,12 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	actions := m.actionsForRow(m.filtered[m.cursor])
+	row := m.filtered[m.cursor]
+	if m.focus == focusPreview {
+		return m.updatePreviewFocus(row, key), nil
+	}
+
+	actions := m.actionsForRow(row)
 	switch key {
 	case "up", "k":
 		if m.actionCursor > 0 {
@@ -303,6 +332,9 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "down", "j":
 		if m.actionCursor < len(actions)-1 {
 			m.actionCursor++
+		} else if rowHasPreview(row) {
+			m.focus = focusPreview
+			m.excerptOffset = 0
 		}
 	case "left", "h":
 		m.focus = focusList
@@ -314,6 +346,53 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.executeAction(action.key)
 	}
 	return m, nil
+}
+
+// rowHasPreview reports whether a skill row exposes any excerpt content.
+func rowHasPreview(row listRow) bool {
+	return strings.TrimSpace(row.Excerpt) != ""
+}
+
+func (m listModel) updatePreviewFocus(row listRow, key string) listModel {
+	maxOffset := previewMaxOffset(row.Excerpt)
+	switch key {
+	case "up", "k":
+		if m.excerptOffset > 0 {
+			m.excerptOffset--
+			return m
+		}
+		m.focus = focusActions
+		actions := m.actionsForRow(row)
+		if len(actions) > 0 {
+			m.actionCursor = len(actions) - 1
+		}
+	case "down", "j":
+		if m.excerptOffset < maxOffset {
+			m.excerptOffset++
+		}
+	case "left", "h":
+		m.focus = focusActions
+		actions := m.actionsForRow(row)
+		if len(actions) > 0 {
+			m.actionCursor = len(actions) - 1
+		}
+	case "home":
+		m.excerptOffset = 0
+	case "end":
+		m.excerptOffset = maxOffset
+	}
+	return m
+}
+
+// previewMaxOffset returns the largest valid scroll offset for the excerpt.
+// Keeping a small tail visible at the bottom feels nicer than letting the
+// last line scroll off entirely.
+func previewMaxOffset(excerpt string) int {
+	total := strings.Count(excerpt, "\n") + 1
+	if total <= 1 {
+		return 0
+	}
+	return total - 1
 }
 
 func (m listModel) updateCommandMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {

--- a/cmd/list_tui_render.go
+++ b/cmd/list_tui_render.go
@@ -743,27 +743,27 @@ func buildExcerptLines(excerpt string, width int) []string {
 }
 
 // wrapExcerptLine splits a single plain-text line into visual lines that fit
-// within the supplied cell width. Keeps plain text so style wrappers apply to
-// each piece uniformly.
+// within the supplied cell width. Cuts on rune boundaries so multi-byte
+// characters (emoji, CJK, accents) stay intact.
 func wrapExcerptLine(text string, width int) []string {
 	if width <= 0 || runewidth.StringWidth(text) <= width {
 		return []string{text}
 	}
 	var out []string
-	remaining := text
-	for runewidth.StringWidth(remaining) > width {
-		cut := len(remaining)
-		for cut > 0 && runewidth.StringWidth(remaining[:cut]) > width {
-			cut--
+	var segment strings.Builder
+	segWidth := 0
+	for _, r := range text {
+		rw := runewidth.RuneWidth(r)
+		if segWidth+rw > width && segment.Len() > 0 {
+			out = append(out, segment.String())
+			segment.Reset()
+			segWidth = 0
 		}
-		if cut <= 0 {
-			cut = 1
-		}
-		out = append(out, remaining[:cut])
-		remaining = remaining[cut:]
+		segment.WriteRune(r)
+		segWidth += rw
 	}
-	if remaining != "" {
-		out = append(out, remaining)
+	if segment.Len() > 0 {
+		out = append(out, segment.String())
 	}
 	return out
 }

--- a/cmd/list_tui_render.go
+++ b/cmd/list_tui_render.go
@@ -149,11 +149,13 @@ func (m listModel) viewSplit() string {
 		} else {
 			b.WriteString(ltDimStyle.Render("↑↓ browse skills · →/enter actions · esc close · q quit") + "\n")
 		}
+	case m.focus == focusPreview:
+		b.WriteString(ltDimStyle.Render("↑↓ scroll preview · ←/tab actions · esc close") + "\n")
 	default:
 		if m.isBrowseMode() {
 			b.WriteString(ltDimStyle.Render("↑↓ choose install · enter run · ←/tab back to list · esc close") + "\n")
 		} else {
-			b.WriteString(ltDimStyle.Render("↑↓ pick action · enter run · ←/tab back to list · esc close") + "\n")
+			b.WriteString(ltDimStyle.Render("↑↓ pick action · ↓ preview · enter run · ←/tab back · esc close") + "\n")
 		}
 	}
 	return b.String()
@@ -449,39 +451,7 @@ func (m listModel) renderDetailPane(row listRow, width int) string {
 	}
 	b.WriteString(ltDivStyle.Render(strings.Repeat("─", width-2)) + "\n")
 
-	type kv struct{ key, value string }
-	var pairs []kv
-
-	if row.HasStatus {
-		pairs = append(pairs, kv{"Status", row.Status.Display().Label})
-	}
-	if row.Local != nil && !row.Managed {
-		pairs = append(pairs, kv{"Managed", "no"})
-	}
-	if row.Version != "" {
-		pairs = append(pairs, kv{"Version", row.Version})
-	}
-	if row.Author != "" {
-		pairs = append(pairs, kv{"Author", row.Author})
-	}
-	if row.Group != "" {
-		pairs = append(pairs, kv{"Registry", row.Group})
-	}
-	if row.Origin == state.OriginLocal {
-		pairs = append(pairs, kv{"Source", "(local)"})
-	}
-	if len(row.Targets) > 0 {
-		pairs = append(pairs, kv{"Tools", strings.Join(row.Targets, ", ")})
-	}
-	if row.Local != nil && row.Local.LocalPath != "" {
-		path := row.Local.LocalPath
-		if home, err := os.UserHomeDir(); err == nil && strings.HasPrefix(path, home) {
-			path = "~" + strings.TrimPrefix(path, home)
-		}
-		pairs = append(pairs, kv{"Path", path})
-	}
-
-	for _, p := range pairs {
+	for _, p := range m.metadataPairsForRow(row) {
 		b.WriteString(ltMetaKeyStyle.Render(p.key) + ltMetaValStyle.Render(p.value) + "\n")
 	}
 
@@ -541,10 +511,111 @@ func (m listModel) renderDetailPane(row listRow, width int) string {
 	}
 
 	if row.Excerpt != "" {
-		b.WriteString(ltDivStyle.Render(strings.Repeat("─", width-2)) + "\n")
-		b.WriteString(renderExcerptPreview(row.Excerpt, width-2) + "\n")
+		b.WriteString(m.renderPreviewSection(row, width-2) + "\n")
 	}
 	return b.String()
+}
+
+func (m listModel) renderPreviewSection(row listRow, width int) string {
+	lines := buildExcerptLines(row.Excerpt, width)
+	focused := m.focus == focusPreview
+
+	heading := "preview"
+	headingStyle := ltDimStyle
+	if focused {
+		heading = "▸ preview"
+		headingStyle = ltCursorStyle
+	}
+
+	var out strings.Builder
+	out.WriteString(ltDivStyle.Render(strings.Repeat("─", width)) + "\n")
+	out.WriteString(headingStyle.Render(heading))
+	if len(lines) > 0 && focused {
+		out.WriteString(" " + ltDimStyle.Render(fmt.Sprintf("%d/%d", m.clampedExcerptOffset(lines)+1, len(lines))))
+	}
+	out.WriteString("\n")
+
+	if len(lines) == 0 {
+		out.WriteString(ltDimStyle.Render("(empty)"))
+		return out.String()
+	}
+
+	offset := m.clampedExcerptOffset(lines)
+	if offset > 0 {
+		out.WriteString(ltDimStyle.Render(fmt.Sprintf("↑ %d more above", offset)) + "\n")
+	}
+	out.WriteString(strings.Join(lines[offset:], "\n"))
+	return out.String()
+}
+
+func (m listModel) clampedExcerptOffset(lines []string) int {
+	if m.excerptOffset < 0 {
+		return 0
+	}
+	if len(lines) == 0 {
+		return 0
+	}
+	if m.excerptOffset > len(lines)-1 {
+		return len(lines) - 1
+	}
+	return m.excerptOffset
+}
+
+type metaPair struct{ key, value string }
+
+// metadataPairsForRow collects the Status/Version/Author/... key-value pairs
+// shown in the detail pane header. Declarative table — each row is a single
+// call; empty values are dropped by the closure so conditions live at the
+// call site as expressions, not nested if-blocks.
+func (m listModel) metadataPairsForRow(row listRow) []metaPair {
+	pairs := make([]metaPair, 0, 8)
+	add := func(key, value string) {
+		if value != "" {
+			pairs = append(pairs, metaPair{key, value})
+		}
+	}
+
+	add("Status", statusLabel(row))
+	add("Managed", managedLabel(row))
+	add("Version", row.Version)
+	add("Author", row.Author)
+	add("Registry", row.Group)
+	add("Source", originLabel(row.Origin))
+	add("Tools", strings.Join(row.Targets, ", "))
+	add("Path", skillPathLabel(row))
+	return pairs
+}
+
+func statusLabel(row listRow) string {
+	if !row.HasStatus {
+		return ""
+	}
+	return row.Status.Display().Label
+}
+
+func managedLabel(row listRow) string {
+	if row.Local == nil || row.Managed {
+		return ""
+	}
+	return "no"
+}
+
+func originLabel(o state.Origin) string {
+	if o == state.OriginLocal {
+		return "(local)"
+	}
+	return ""
+}
+
+func skillPathLabel(row listRow) string {
+	if row.Local == nil || row.Local.LocalPath == "" {
+		return ""
+	}
+	path := row.Local.LocalPath
+	if home, err := os.UserHomeDir(); err == nil && strings.HasPrefix(path, home) {
+		path = "~" + strings.TrimPrefix(path, home)
+	}
+	return path
 }
 
 func (m listModel) renderToolsEditor(width int) string {
@@ -610,7 +681,9 @@ func (m listModel) renderToolsEditor(width int) string {
 	return lipgloss.NewStyle().Width(width - 2).Render(strings.TrimRight(b.String(), "\n"))
 }
 
-func renderExcerptPreview(excerpt string, width int) string {
+// buildExcerptLines parses the raw SKILL.md excerpt into styled, width-wrapped
+// display lines. Each slice entry is one visual line suitable for scrolling.
+func buildExcerptLines(excerpt string, width int) []string {
 	var lines []string
 	prevWasHeading := false
 	for _, raw := range strings.Split(excerpt, "\n") {
@@ -652,7 +725,9 @@ func renderExcerptPreview(excerpt string, width int) string {
 		if text == "" {
 			continue
 		}
-		lines = append(lines, renderInlineCode(style, text))
+		for _, wrapped := range wrapExcerptLine(text, width) {
+			lines = append(lines, renderInlineCode(style, wrapped))
+		}
 		if isHeading {
 			lines = append(lines, "")
 		} else if prevWasHeading {
@@ -664,7 +739,33 @@ func renderExcerptPreview(excerpt string, width int) string {
 	for len(lines) > 0 && lines[len(lines)-1] == "" {
 		lines = lines[:len(lines)-1]
 	}
-	return lipgloss.NewStyle().Width(width).Render(strings.Join(lines, "\n"))
+	return lines
+}
+
+// wrapExcerptLine splits a single plain-text line into visual lines that fit
+// within the supplied cell width. Keeps plain text so style wrappers apply to
+// each piece uniformly.
+func wrapExcerptLine(text string, width int) []string {
+	if width <= 0 || runewidth.StringWidth(text) <= width {
+		return []string{text}
+	}
+	var out []string
+	remaining := text
+	for runewidth.StringWidth(remaining) > width {
+		cut := len(remaining)
+		for cut > 0 && runewidth.StringWidth(remaining[:cut]) > width {
+			cut--
+		}
+		if cut <= 0 {
+			cut = 1
+		}
+		out = append(out, remaining[:cut])
+		remaining = remaining[cut:]
+	}
+	if remaining != "" {
+		out = append(out, remaining)
+	}
+	return out
 }
 
 func renderInlineCode(base lipgloss.Style, text string) string {

--- a/internal/sync/events.go
+++ b/internal/sync/events.go
@@ -52,14 +52,37 @@ type SkillStatus struct {
 }
 
 // DisplayVersion returns the best human-readable version for this skill.
+// Prefers semver tags as-is, else a short SHA when the ref is a branch/HEAD,
+// else the installed revision counter.
 func (sk SkillStatus) DisplayVersion() string {
 	if sk.LoadoutRef != "" {
-		return sk.LoadoutRef
+		if isVersionTag(sk.LoadoutRef) {
+			return sk.LoadoutRef
+		}
+		if sk.LatestSHA != "" {
+			return ShortSHA(sk.LatestSHA)
+		}
+		if sk.LoadoutRef != "HEAD" {
+			return sk.LoadoutRef
+		}
 	}
 	if sk.Installed != nil {
 		return sk.Installed.DisplayVersion()
 	}
 	return ""
+}
+
+// isVersionTag reports whether a ref looks like a semver tag (v1.2.3).
+func isVersionTag(ref string) bool {
+	return strings.HasPrefix(ref, "v") && strings.ContainsRune(ref, '.')
+}
+
+// ShortSHA truncates a commit SHA to 7 characters for display.
+func ShortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
 }
 
 // DisplayAuthor returns the author or "—" if unknown.

--- a/internal/workflow/list_load.go
+++ b/internal/workflow/list_load.go
@@ -16,6 +16,10 @@ import (
 	"github.com/Naoray/scribe/internal/tools"
 )
 
+// excerptLineBudget caps how many SKILL.md content lines we buffer for preview.
+// Large enough for meaningful scroll, small enough to avoid holding big files.
+const excerptLineBudget = 200
+
 // ListRow is the UI-agnostic row shape used by list surfaces.
 type ListRow struct {
 	Name      string
@@ -113,7 +117,7 @@ func BuildRows(ctx context.Context, bag *Bag) ([]ListRow, []string, error) {
 				row.Targets = ss.Installed.Tools
 			}
 			if local != nil && local.LocalPath != "" {
-				row.Excerpt = readExcerpt(local.LocalPath, 8)
+				row.Excerpt = readExcerpt(local.LocalPath, excerptLineBudget)
 			}
 			rows = append(rows, row)
 		}
@@ -143,7 +147,7 @@ func BuildLocalRows(skills []discovery.Skill, st *state.State) []ListRow {
 			}
 		}
 		if sk.LocalPath != "" {
-			row.Excerpt = readExcerpt(sk.LocalPath, 8)
+			row.Excerpt = readExcerpt(sk.LocalPath, excerptLineBudget)
 		}
 		if row.Managed {
 			managedRows = append(managedRows, row)


### PR DESCRIPTION
## Summary

- `scribe list` detail pane no longer shows the bare `HEAD` ref as a version. For branch/HEAD refs, `SkillStatus.DisplayVersion()` now returns a short SHA (7 chars). Semver tags still pass through as-is; installed revision counter remains the final fallback.
- The bottom-right excerpt preview is now focusable. Tab cycles List → Actions → Preview → List; arrow-down past the last action auto-enters the preview. Inside preview, ↑/↓ scroll, ↑ at offset 0 returns focus to the actions column, Home/End jump ends.
- The excerpt buffer grew 8 → 200 lines so there's real content to scroll through.
- `metadataPairsForRow` rewritten as a declarative table — closure enforces the empty-skip contract, per-field accessors own the conditional logic, no more nested if-chains.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all green
- [ ] Manual: open `scribe list`, focus a branch-pinned skill, confirm short SHA instead of `HEAD`
- [ ] Manual: Tab through List → Actions → Preview; arrow-down past last action drops into preview; ↑/↓ scroll; ↑ at top returns to actions
- [ ] Manual: esc clears focus and preview offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)