### PR TITLE
feat: wrap scribe-agent bootstrap in self-destructing setup markers

### DIFF
--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -7,7 +7,8 @@ description: Use when the user wants to install, list, sync, remove, or manage A
 
 {{- if .NeedsBootstrap }}
 
-## First-run bootstrap (do this before anything else)
+===setup-start===
+**Execute this one-shot bootstrap, then use the Edit tool to delete the entire block from `===setup-start===` through `===setup-end===` (inclusive) from this file. A setup block is one-shot — leaving it causes re-runs on every invocation.**
 
 Before running any command in this skill, check that `scribe` is installed and that this skill is registered locally. If either is missing, bootstrap them now.
 
@@ -78,7 +79,8 @@ scribe list --json
 
 Confirm the final `scribe list --json` includes `scribe-agent`. If anything in this bootstrap fails, report the failing command and its stderr verbatim - do not guess around it.
 
-Once bootstrap succeeds, proceed with the user's request using the command reference below.
+Once bootstrap succeeds, delete this entire block (both marker lines included) and proceed with the user's request using the command reference below.
+===setup-end===
 
 {{- else if .ShowDailyUpgradePrompt }}
 

--- a/internal/agent/bootstrap_test.go
+++ b/internal/agent/bootstrap_test.go
@@ -44,7 +44,7 @@ func TestEnsureScribeAgentInstallsWhenMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read SKILL.md: %v", err)
 	}
-	if !strings.Contains(string(got), "## First-run bootstrap (do this before anything else)") {
+	if !strings.Contains(string(got), "===setup-start===") {
 		t.Fatal("bootstrap section missing from rendered skill")
 	}
 	if strings.Contains(string(got), "## Keep `scribe` current") {
@@ -242,7 +242,7 @@ func TestEnsureScribeAgentReinstallsOnVersionMismatch(t *testing.T) {
 	if !strings.Contains(string(got), "## Keep `scribe` current") {
 		t.Fatal("steady-state upgrade prompt missing from rendered skill")
 	}
-	if strings.Contains(string(got), "## First-run bootstrap (do this before anything else)") {
+	if strings.Contains(string(got), "===setup-start===") {
 		t.Fatal("bootstrap section should not be present in steady state")
 	}
 }
@@ -286,7 +286,7 @@ func TestRenderScribeAgentBootstrapWhenBinaryMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("renderScribeAgentMarkdown() error = %v", err)
 	}
-	if !strings.Contains(string(rendered), "## First-run bootstrap (do this before anything else)") {
+	if !strings.Contains(string(rendered), "===setup-start===") {
 		t.Fatal("bootstrap section missing when binary is absent")
 	}
 	if strings.Contains(string(rendered), "## Keep `scribe` current") {
@@ -306,7 +306,7 @@ func TestRenderScribeAgentSteadyStateWhenInstalled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("renderScribeAgentMarkdown() error = %v", err)
 	}
-	if strings.Contains(string(rendered), "## First-run bootstrap (do this before anything else)") {
+	if strings.Contains(string(rendered), "===setup-start===") {
 		t.Fatal("bootstrap section should not render in steady state")
 	}
 	if !strings.Contains(string(rendered), "## Keep `scribe` current") {
@@ -322,7 +322,7 @@ func TestRenderScribeAgentBootstrapWhenSkillMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("renderScribeAgentMarkdown() error = %v", err)
 	}
-	if !strings.Contains(string(rendered), "## First-run bootstrap (do this before anything else)") {
+	if !strings.Contains(string(rendered), "===setup-start===") {
 		t.Fatal("bootstrap section missing when skill is absent")
 	}
 	if strings.Contains(string(rendered), "## Keep `scribe` current") {


### PR DESCRIPTION
## Summary

- Wraps the `NeedsBootstrap` branch of `SKILL.md.tmpl` in new `===setup-start===` / `===setup-end===` markers
- The block carries its own inline prune instruction — after Claude completes bootstrap, it uses Edit to strip the block from SKILL.md
- Test assertions updated to match the new marker literal

## Why

Setup instructions are one-shot. Leaving them in a rendered skill re-triggers the check on every invocation and pollutes Claude's context. A self-describing marker convention:

- Requires no external state (doesn't depend on `scribe-agent` skill being loaded)
- Works consistently across every skill author and every session
- Can be applied by any skill that has install-time or first-run work (see `Naoray/skills:plan-my-day` for another use case — filling a `<private_calendar_name_list>` placeholder)

## Test plan

- [x] `go test ./...` passes
- [x] Bootstrap assertion still catches the section when `NeedsBootstrap=true`
- [x] Steady-state (`ShowDailyUpgradePrompt=true`) does not render the markers

## Follow-ups

- A dedicated spec document for the marker convention was considered but skipped for now — the convention is simple enough to explain inline where it's used
- Related: #104 (`--install-all` flag on `registry connect`), #106 (first-class `source:` frontmatter field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)