### PR TITLE
fix(list): accurate cursor scroll, pinned summary, grid actions

### DIFF
--- a/cmd/list_tui_keys.go
+++ b/cmd/list_tui_keys.go
@@ -881,27 +881,50 @@ func buildGroupCounts(rows []listRow) map[string]int {
 
 func (m listModel) ensureCursorVisible() listModel {
 	visible := m.contentHeight()
-	headersBetween := 0
-	prevGroup := ""
-	if m.offset > 0 && m.offset < len(m.filtered) {
-		prevGroup = m.filtered[m.offset-1].Group
-	}
-	for i := m.offset; i <= m.cursor && i < len(m.filtered); i++ {
-		if m.filtered[i].Group != prevGroup {
-			headersBetween++
-			prevGroup = m.filtered[i].Group
-		}
-	}
-	effectiveVisible := visible - headersBetween
-	if effectiveVisible < 3 {
-		effectiveVisible = 3
+	if visible < 3 {
+		visible = 3
 	}
 
 	if m.cursor < m.offset {
 		m.offset = m.cursor
 	}
-	if m.cursor >= m.offset+effectiveVisible {
-		m.offset = m.cursor - effectiveVisible + 1
+	for m.offset < m.cursor && !m.cursorFitsAt(m.offset, visible) {
+		m.offset++
 	}
 	return m
+}
+
+// cursorFitsAt simulates renderRows' line budget to decide whether the
+// cursor row will actually be drawn when the viewport starts at `offset`.
+// Must stay in sync with renderRows — accounts for the top/bottom "more"
+// indicators and group-header rows that eat into the capacity.
+func (m listModel) cursorFitsAt(offset, capacity int) bool {
+	linesUsed := 0
+	if offset > 0 {
+		linesUsed++
+	}
+	prevGroup := ""
+	if offset > 0 && offset < len(m.filtered) {
+		prevGroup = m.filtered[offset-1].Group
+	}
+	for i := offset; i < len(m.filtered); i++ {
+		row := m.filtered[i]
+		headerLines := 0
+		if row.Group != prevGroup {
+			headerLines = 1
+		}
+		needed := headerLines + 1
+		if remainingAfter := len(m.filtered) - (i + 1); remainingAfter > 0 {
+			needed++
+		}
+		if linesUsed+needed > capacity {
+			return i > m.cursor
+		}
+		linesUsed += headerLines + 1
+		prevGroup = row.Group
+		if i == m.cursor {
+			return true
+		}
+	}
+	return true
 }

--- a/cmd/list_tui_render.go
+++ b/cmd/list_tui_render.go
@@ -71,7 +71,13 @@ func (m listModel) viewListFull() string {
 	b.WriteString(m.renderQueryLine() + "\n")
 
 	contentHeight := m.contentHeight()
-	m.renderRows(&b, contentHeight, m.width-4, false)
+	var rowsBuf strings.Builder
+	m.renderRows(&rowsBuf, contentHeight, m.width-4, false)
+	content := rowsBuf.String()
+	b.WriteString(content)
+	for i := strings.Count(content, "\n"); i < contentHeight; i++ {
+		b.WriteString("\n")
+	}
 
 	b.WriteString("\n")
 	b.WriteString(m.renderSummary() + "\n")
@@ -488,32 +494,88 @@ func (m listModel) renderDetailPane(row listRow, width int) string {
 	}
 
 	actions := m.actionsForRow(row)
-	for i, a := range actions {
-		isCursor := i == m.actionCursor && m.focus == focusActions
-		prefix := "  "
-		if isCursor {
-			prefix = ltCursorStyle.Render("▸") + " "
-		}
-		if a.disabled {
-			label := ltDimStyle.Render(a.label)
-			reason := ""
-			if a.reason != "" {
-				reason = " " + ltReasonStyle.Render(a.reason)
-			}
-			b.WriteString(prefix + label + reason + "\n")
-		} else {
-			label := a.style.Render(a.label)
-			if isCursor {
-				label = ltCursorStyle.Render(a.label)
-			}
-			b.WriteString(prefix + label + "\n")
-		}
-	}
+	b.WriteString(m.renderActionGrid(actions, width-2))
 
 	if row.Excerpt != "" {
 		b.WriteString(m.renderPreviewSection(row, width-2) + "\n")
 	}
 	return b.String()
+}
+
+// renderActionGrid lays actions out in a 2-column grid (column-major, so the
+// flat actionCursor still walks top-to-bottom naturally) when the pane is
+// wide enough. Falls back to a single column on narrow panes. Collapsing
+// the action list saves vertical room for the preview below.
+func (m listModel) renderActionGrid(actions []actionItem, width int) string {
+	const cols = 2
+	const minColWidth = 18
+
+	var b strings.Builder
+	colWidth := width / cols
+	if colWidth < minColWidth || len(actions) < 2 {
+		for i, a := range actions {
+			isCursor := i == m.actionCursor && m.focus == focusActions
+			b.WriteString(m.formatActionCell(a, isCursor, 0) + "\n")
+		}
+		return b.String()
+	}
+
+	rowsCount := (len(actions) + cols - 1) / cols
+	for r := 0; r < rowsCount; r++ {
+		leftIdx := r
+		rightIdx := r + rowsCount
+		left := m.formatActionCell(actions[leftIdx], leftIdx == m.actionCursor && m.focus == focusActions, colWidth)
+		var right string
+		if rightIdx < len(actions) {
+			right = m.formatActionCell(actions[rightIdx], rightIdx == m.actionCursor && m.focus == focusActions, 0)
+		}
+		b.WriteString(left + right + "\n")
+	}
+	if m.focus == focusActions && m.actionCursor >= 0 && m.actionCursor < len(actions) {
+		if a := actions[m.actionCursor]; a.disabled && a.reason != "" {
+			b.WriteString("  " + ltReasonStyle.Render(a.reason) + "\n")
+		}
+	}
+	return b.String()
+}
+
+// formatActionCell renders a single action. When width > 0 the cell is
+// right-padded to that display width so the next column aligns. Padding is
+// based on the unstyled text length because lipgloss emits zero-width ANSI
+// escapes that would inflate rune-width measurements.
+func (m listModel) formatActionCell(a actionItem, isCursor bool, width int) string {
+	rawPrefix := "  "
+	styledPrefix := rawPrefix
+	if isCursor {
+		styledPrefix = ltCursorStyle.Render("▸") + " "
+	}
+
+	rawLabel := a.label
+	var styledLabel string
+	switch {
+	case a.disabled:
+		styledLabel = ltDimStyle.Render(rawLabel)
+	case isCursor:
+		styledLabel = ltCursorStyle.Render(rawLabel)
+	default:
+		styledLabel = a.style.Render(rawLabel)
+	}
+
+	cell := styledPrefix + styledLabel
+	used := runewidth.StringWidth(rawPrefix + rawLabel)
+
+	// Only append the reason when rendering single-column (width == 0);
+	// grid cells drop it to keep columns narrow.
+	if width == 0 && a.disabled && a.reason != "" {
+		reason := " " + ltReasonStyle.Render(a.reason)
+		cell += reason
+		used += runewidth.StringWidth(" " + a.reason)
+	}
+
+	if width > 0 && used < width {
+		cell += strings.Repeat(" ", width-used)
+	}
+	return cell
 }
 
 func (m listModel) renderPreviewSection(row listRow, width int) string {

--- a/cmd/list_tui_test.go
+++ b/cmd/list_tui_test.go
@@ -503,6 +503,61 @@ func TestViewListFull_DoesNotOverflowViewportAndKeepsTopChrome(t *testing.T) {
 	}
 }
 
+func TestEnsureCursorVisible_ReservesSlotsForMoreAboveAndBelowIndicators(t *testing.T) {
+	// Regression: ensureCursorVisible must mirror renderRows' budget so the
+	// cursor row is actually drawn. Before the fix, the top/bottom "↑/↓ more"
+	// indicators were not subtracted from the viewport, so the cursor could
+	// sit one or two rows past the last rendered line and the list appeared
+	// frozen on arrow presses until offset caught up.
+	rows := make([]listRow, 80)
+	for i := range rows {
+		rows[i] = listRow{Name: "s", Group: "g"}
+	}
+	m := listModel{
+		width:    80,
+		height:   27, // contentHeight = 27 - 7 = 20
+		rows:     rows,
+		filtered: rows,
+		cursor:   20,
+	}
+	m = m.ensureCursorVisible()
+
+	if !m.cursorFitsAt(m.offset, m.contentHeight()) {
+		t.Fatalf("cursor (%d) does not fit at offset %d with viewport %d", m.cursor, m.offset, m.contentHeight())
+	}
+	if m.offset == 0 {
+		t.Fatalf("offset should have advanced past 0 to keep cursor visible, got offset=%d", m.offset)
+	}
+}
+
+func TestViewListFull_PadsContentToPinSummaryToBottom(t *testing.T) {
+	// Regression: the summary + help footer must sit at the bottom of the
+	// terminal, not float mid-screen when the filtered list is shorter than
+	// the viewport.
+	rows := []listRow{
+		{Name: "alpha", Group: "local"},
+		{Name: "beta", Group: "local"},
+	}
+	m := listModel{
+		width:       80,
+		height:      25,
+		rows:        rows,
+		filtered:    rows,
+		groupCounts: map[string]int{"local": 2},
+		bag:         &workflow.Bag{},
+	}
+
+	view := m.viewListFull()
+	lines := strings.Split(strings.TrimRight(view, "\n"), "\n")
+	if len(lines) != m.height {
+		t.Fatalf("view rendered %d lines, want %d (full viewport):\n%s", len(lines), m.height, view)
+	}
+	// Commands help is the very last line when pinned to the terminal bottom.
+	if !strings.Contains(lines[len(lines)-1], "Commands:") {
+		t.Fatalf("last line should be the Commands help, got %q", lines[len(lines)-1])
+	}
+}
+
 func TestRefreshFilteredBuildsGroupCounts(t *testing.T) {
 	m := listModel{
 		rows: []listRow{


### PR DESCRIPTION
## Summary
- **Cursor scroll lag fixed.** `ensureCursorVisible` now mirrors `renderRows`' line budget (top/bottom "↑/↓ more" indicators + group headers) so the focused row is always actually drawn. Previously the cursor could slot one or two rows past the last rendered line and arrow keys felt frozen until offset caught up.
- **Summary pinned to terminal bottom.** `viewListFull` pads row output to `contentHeight`, so the `N current · X modified · …` summary and Commands help sit at the bottom of the viewport instead of floating mid-screen when the filtered list is short.
- **Detail actions in a 2-column grid.** Actions lay out column-major in the detail pane, freeing several rows for the preview. The flat `actionCursor` walks top-to-bottom naturally. Disabled-action reasons collapse to a single hint line beneath the grid so the context still surfaces for the focused row without inflating every cell.

## Test plan
- [x] `go test ./...` passes
- [x] New `TestEnsureCursorVisible_ReservesSlotsForMoreAboveAndBelowIndicators` — cursor past the visible budget triggers an offset bump
- [x] New `TestViewListFull_PadsContentToPinSummaryToBottom` — full viewport height, Commands line is last
- [ ] Manual: `scribe list`, walk cursor top-to-bottom with ↓ — focused row stays visible on every press
- [ ] Manual: shrink the list via `/search` — summary + Commands hug the terminal bottom
- [ ] Manual: open detail pane on a managed skill — actions render in 2 columns with preview below

🤖 Generated with [Claude Code](https://claude.com/claude-code)