### PR TITLE
feat: packages store — stop projecting multi-skill repos into tool skill dirs

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -224,7 +224,7 @@ func doctorSkillNames(st *state.State, skillName string) []string {
 
 	names := make([]string, 0, len(st.Installed))
 	for name, installed := range st.Installed {
-		if installed.Type == "package" {
+		if installed.IsPackage() {
 			continue
 		}
 		names = append(names, name)

--- a/cmd/list_tui_render.go
+++ b/cmd/list_tui_render.go
@@ -661,7 +661,12 @@ func (m listModel) metadataPairsForRow(row listRow) []metaPair {
 	add("Author", row.Author)
 	add("Registry", row.Group)
 	add("Source", originLabel(row.Origin))
-	add("Tools", strings.Join(row.Targets, ", "))
+	if row.Kind == state.KindPackage {
+		add("Kind", "package")
+		add("Tools", "self-managed")
+	} else {
+		add("Tools", strings.Join(row.Targets, ", "))
+	}
 	add("Path", skillPathLabel(row))
 	return pairs
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -14,6 +14,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
 )
 
@@ -113,38 +115,55 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Uninstall from every tool that originally installed the skill, even if
-	// that tool is now disabled or missing from config. Otherwise disabling a
-	// tool after install would orphan its side of the skill on disk.
 	var errs []string
-	for _, name := range installed.Tools {
-		tool, err := tools.ResolveByName(cfg, name)
-		if err != nil {
-			errs = append(errs, fmt.Sprintf("%s: %v", name, err))
-			continue
-		}
-		if err := tool.Uninstall(key); err != nil {
-			errs = append(errs, fmt.Sprintf("%s: %v", name, err))
-		}
-	}
 
-	// Remove from canonical store.
-	storeDir, err := tools.StoreDir()
-	if err == nil {
-		skillDir := filepath.Join(storeDir, key)
-		if err := os.RemoveAll(skillDir); err != nil {
-			errs = append(errs, fmt.Sprintf("store: %v", err))
+	// Packages self-manage: best-effort uninstall command, then drop the
+	// package dir. Skip tool uninstallers and projection cleanup because
+	// packages were never projected in the first place.
+	if installed.Kind == state.KindPackage {
+		if uninstallErrs := runPackageUninstall(cmd, key, installed); len(uninstallErrs) > 0 {
+			errs = append(errs, uninstallErrs...)
 		}
-	}
+		pkgsDir, pdErr := tools.PackagesDir()
+		if pdErr == nil {
+			pkgDir := filepath.Join(pkgsDir, key)
+			if err := os.RemoveAll(pkgDir); err != nil {
+				errs = append(errs, fmt.Sprintf("package store: %v", err))
+			}
+		}
+	} else {
+		// Uninstall from every tool that originally installed the skill, even if
+		// that tool is now disabled or missing from config. Otherwise disabling a
+		// tool after install would orphan its side of the skill on disk.
+		for _, name := range installed.Tools {
+			tool, err := tools.ResolveByName(cfg, name)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+				continue
+			}
+			if err := tool.Uninstall(key); err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+			}
+		}
 
-	// Remove only the projections Scribe still believes it manages.
-	managedPaths := installed.ManagedPaths
-	if len(managedPaths) == 0 {
-		managedPaths = installed.Paths
-	}
-	for _, p := range managedPaths {
-		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
-			errs = append(errs, fmt.Sprintf("managed path %s: %v", p, err))
+		// Remove from canonical store.
+		storeDir, err := tools.StoreDir()
+		if err == nil {
+			skillDir := filepath.Join(storeDir, key)
+			if err := os.RemoveAll(skillDir); err != nil {
+				errs = append(errs, fmt.Sprintf("store: %v", err))
+			}
+		}
+
+		// Remove only the projections Scribe still believes it manages.
+		managedPaths := installed.ManagedPaths
+		if len(managedPaths) == 0 {
+			managedPaths = installed.Paths
+		}
+		for _, p := range managedPaths {
+			if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+				errs = append(errs, fmt.Sprintf("managed path %s: %v", p, err))
+			}
 		}
 	}
 
@@ -238,6 +257,45 @@ func findBareNameMatches(input string, keys []string) []string {
 		}
 	}
 	return matches
+}
+
+// runPackageUninstall executes the package's declared uninstall command, if
+// any. Resolution mirrors the install side: scribe.yaml's install.uninstall
+// field, else an uninstall.sh at the package root. Best-effort — non-zero
+// exit is returned as a warning, never fatal.
+func runPackageUninstall(cmd *cobra.Command, name string, installed state.InstalledSkill) []string {
+	pkgsDir, err := tools.PackagesDir()
+	if err != nil {
+		return []string{fmt.Sprintf("packages dir: %v", err)}
+	}
+	pkgDir := filepath.Join(pkgsDir, name)
+
+	// Best-effort: skip silently if the dir is already gone.
+	if _, err := os.Stat(pkgDir); err != nil {
+		return nil
+	}
+
+	// Prefer scribe.yaml → install.uninstall; fall back to uninstall.sh.
+	var uninstallCmd string
+	if plan, err := sync.ResolvePackageInstall(pkgDir); err == nil && plan.Uninstall != "" {
+		uninstallCmd = plan.Uninstall
+	} else if _, err := os.Stat(filepath.Join(pkgDir, "uninstall.sh")); err == nil {
+		uninstallCmd = "sh uninstall.sh"
+	}
+	if uninstallCmd == "" {
+		return nil
+	}
+
+	exec := &sync.ShellExecutor{}
+	_, stderr, err := sync.RunPackageCommand(cmd.Context(), exec, pkgDir, uninstallCmd, 0)
+	if err != nil {
+		warn := fmt.Sprintf("uninstall command: %v", err)
+		if stderr != "" {
+			warn += " (" + strings.TrimSpace(stderr) + ")"
+		}
+		return []string{warn}
+	}
+	return nil
 }
 
 // findManagingRegistries returns registry repos that manage the given skill key.

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -1,11 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/paths"
 	"github.com/Naoray/scribe/internal/state"
 )
 
@@ -133,5 +137,48 @@ func TestRemoveLeavesConflictResidue(t *testing.T) {
 	}
 	if _, err := os.Stat(residue); err != nil {
 		t.Fatalf("conflict residue missing: %v", err)
+	}
+}
+
+func TestRunPackageUninstall_RunsScribeYAMLCommand(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	pkgsDir, _ := paths.PackagesDir()
+	pkgDir := filepath.Join(pkgsDir, "gstack")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	marker := filepath.Join(pkgDir, "UNINSTALLED")
+	manifest := []byte("install:\n  command: ./setup\n  uninstall: touch " + marker + "\n")
+	if err := os.WriteFile(filepath.Join(pkgDir, "scribe.yaml"), manifest, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	warnings := runPackageUninstall(cmd, "gstack", state.InstalledSkill{Kind: state.KindPackage})
+	if len(warnings) > 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("uninstall command did not run: %v", err)
+	}
+}
+
+func TestRunPackageUninstall_NoManifestNoop(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	pkgsDir, _ := paths.PackagesDir()
+	pkgDir := filepath.Join(pkgsDir, "bare")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	warnings := runPackageUninstall(cmd, "bare", state.InstalledSkill{Kind: state.KindPackage})
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
 	}
 }

--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -114,7 +114,7 @@ func runSkillEdit(cmd *cobra.Command, args []string) error {
 	if !ok {
 		return fmt.Errorf("skill %q is not installed (run `scribe list` to see managed skills)", name)
 	}
-	if installed.Type == "package" {
+	if installed.IsPackage() {
 		return fmt.Errorf("skill %q is a package — per-skill tool pinning does not apply", name)
 	}
 

--- a/cmd/skill_projection_repair.go
+++ b/cmd/skill_projection_repair.go
@@ -25,7 +25,7 @@ func repairSkillProjections(cfg *config.Config, st *state.State, name string) (s
 	if !ok {
 		return skillProjectionRepairResult{}, fmt.Errorf("skill %q is not installed", name)
 	}
-	if installed.Type == "package" {
+	if installed.IsPackage() {
 		return skillProjectionRepairResult{}, fmt.Errorf("skill %q is a package — tool projection repair does not apply", name)
 	}
 

--- a/cmd/skill_tools.go
+++ b/cmd/skill_tools.go
@@ -32,7 +32,7 @@ func applySkillToolSelection(cfg *config.Config, st *state.State, name string, m
 	if !ok {
 		return skillEditResult{}, fmt.Errorf("skill %q is not installed (run `scribe list` to see managed skills)", name)
 	}
-	if installed.Type == "package" {
+	if installed.IsPackage() {
 		return skillEditResult{}, fmt.Errorf("skill %q is a package — per-skill tool pinning does not apply", name)
 	}
 

--- a/cmd/skill_tools_cmd.go
+++ b/cmd/skill_tools_cmd.go
@@ -62,7 +62,7 @@ func runSkillTools(cmd *cobra.Command, args []string) error {
 	if !ok {
 		return fmt.Errorf("skill %q is not installed — run `scribe list` to see managed skills", name)
 	}
-	if installed.Type == "package" {
+	if installed.IsPackage() {
 		return fmt.Errorf("skill %q is a package — per-skill tool assignment does not apply", name)
 	}
 

--- a/docs/superpowers/specs/2026-04-17-packages-store-design.md
+++ b/docs/superpowers/specs/2026-04-17-packages-store-design.md
@@ -1,0 +1,207 @@
+# Packages Store Design
+
+Date: 2026-04-17
+Status: Proposed
+
+## Problem
+
+Repos installed via `scribe install <owner>/<repo>` are not always skills. Some
+are multi-skill bundles / self-installing CLI toolkits. Current example:
+`Naoray/gstack`. Its repo contains:
+
+- A root `SKILL.md`
+- Dozens of sibling directories each with their own `SKILL.md` (`codex/`,
+  `ship/`, `browse/`, …)
+- Tool-specific projections (`.cursor/skills/…`, `.openclaw/…`, `.codex/…`)
+- Build artifacts (`node_modules/`, `bin/`, `scripts/`)
+
+Scribe stores the whole tree under `~/.scribe/skills/gstack/` and creates a
+directory symlink from `~/.codex/skills/gstack` → canonical. Codex then walks
+the target recursively and trips on every nested `SKILL.md` — several of which
+have invalid YAML frontmatter (unquoted colons in `description:`). Result:
+
+```
+⚠ /Users/.../gstack/openclaw/skills/gstack-openclaw-office-hours/SKILL.md:
+  invalid YAML: mapping values are not allowed in this context
+⚠ Skipped loading 3 skill(s) due to invalid SKILL.md files.
+```
+
+Fixing the YAML treats the symptom. Root cause: scribe is projecting an
+entire package repo as if it were a single skill.
+
+## Proposal
+
+Split storage into two top-level kinds under `~/.scribe/`:
+
+```
+~/.scribe/
+  skills/<name>/     # single-authorship skills; dir-symlinked into tool skill dirs (today's behavior)
+  packages/<name>/   # multi-skill bundles / self-installing toolkits; NOT projected
+```
+
+Codex and Claude only walk their own skill dirs (`~/.codex/skills/`,
+`~/.claude/skills/`). Packages never live there → zero nested-skill leak.
+
+Packages own their tool wiring. They run their declared install script once
+when scribe installs them. Scribe tracks their state for list / update /
+remove — it does not symlink their contents into agent skill dirs.
+
+### Detection rule (automatic, no config required)
+
+On `scribe install <ref>`:
+
+1. Fetch repo / payload into a staging area.
+2. Walk for any `SKILL.md` below the root (`find ./*/**/SKILL.md`).
+   - Has nested `SKILL.md` → **package**.
+   - No `SKILL.md` at root but repo has install script (`setup`, `install.sh`,
+     package.json "scripts.install", Makefile `install` target) → **package**.
+   - Otherwise (root SKILL.md and no nested) → **skill**.
+3. Route to the matching store:
+   - skill → `~/.scribe/skills/<name>/` (today's flow, unchanged)
+   - package → `~/.scribe/packages/<name>/` (new flow)
+
+No manifest flag required. Users can override with `kind: package` in
+`scribe.yaml` if auto-detection is wrong.
+
+### Package install flow
+
+```
+Fetch repo → stage/
+  detect → package
+  move stage/ → ~/.scribe/packages/<name>/
+  run install command (see order below) in package dir
+  record state entry kind=package, paths=[package dir], tools=[] (no projection)
+```
+
+Install command resolution, first match wins:
+1. `scribe.yaml` → `install.command` field
+2. Executable `setup` at repo root
+3. `install.sh` at repo root
+4. `package.json` → `scripts.install` via `bun install` / `npm install`
+5. `Makefile` target `install`
+6. No install command → no-op, still tracked
+
+Stdout/stderr from the install command streams to scribe output as an event;
+non-zero exit fails the install and rolls back the package dir.
+
+### Package uninstall flow
+
+`scribe remove <name>` for a package:
+1. Run uninstall command if declared (`scribe.yaml` → `install.uninstall`, or
+   `uninstall.sh` at repo root). Best-effort — non-zero exit logged, not
+   aborted.
+2. Delete `~/.scribe/packages/<name>/`.
+3. Delete state entry.
+
+No tool projection cleanup needed — none was created.
+
+### Migration for existing installs
+
+First `scribe sync` after upgrade:
+
+For each state entry in `kind=skill` (legacy default):
+- If canonical dir is in `skills/` AND contains nested `SKILL.md` → reclassify:
+  1. Move `~/.scribe/skills/<name>/` → `~/.scribe/packages/<name>/`.
+  2. Remove tool projection symlinks (`~/.claude/skills/<name>`, etc.).
+  3. Update state entry: `kind=package`, clear `tools`/`paths`, new
+     `canonical_dir`.
+  4. Emit `PackageReclassifiedMsg{Name, OldPath, NewPath, InstallHint}`
+     carrying a hint to run the package's setup if needed (we don't auto-run
+     during migration — user chose to install when it was a skill, re-running
+     setup is their call).
+
+No repair required for clean skill installs — unchanged.
+
+### Non-projection invariant
+
+Packages must never be symlinked into `~/.{claude,codex,cursor,…}/skills/`.
+Reconcile gains a guard: if state entry `kind=package`, skip projection
+entirely; if a stale projection is detected pointing at a package canonical,
+remove it and emit a repair event.
+
+### State schema
+
+Add `kind` field to installed entries:
+
+```json
+{
+  "installed": {
+    "gstack": {
+      "kind": "package",
+      "canonical_dir": "/Users/.../.scribe/packages/gstack",
+      "installed_at": "...",
+      "install_command": "./setup",
+      "paths": [],
+      "tools": []
+    },
+    "brand-guidelines": {
+      "kind": "skill",
+      "canonical_dir": "/Users/.../.scribe/skills/brand-guidelines",
+      "paths": ["/Users/.../.claude/skills/brand-guidelines"],
+      "tools": ["claude"]
+    }
+  }
+}
+```
+
+Missing `kind` on legacy entries is treated as `skill` (migration rule above
+may flip them).
+
+### List output
+
+TUI and JSON output separate into two sections:
+
+```
+Skills  (42)
+  brand-guidelines    Apply Anthropic brand colors            v1.0.0   claude, codex
+  canvas-design       Create visual art in .png/.pdf          v1.2.0   claude
+
+Packages  (2)
+  gstack              Fast headless browser QA + toolkit      v3.1.0   self-managed
+  mattpocock/skills   Matt's TypeScript skill bundle          v0.4.0   self-managed
+```
+
+JSON:
+```json
+{
+  "skills":   [ ... ],
+  "packages": [ ... ]
+}
+```
+
+Packages display `self-managed` in the tools column because scribe does not
+project them.
+
+## Alternatives considered
+
+1. **Quote description YAML on install** — fixes the symptom, not the cause;
+   we'd still be exposing dozens of unintended skills from every package repo.
+2. **Pruned-view projection** (earlier draft) — build a real target dir per
+   tool, symlink only non-nested-SKILL entries. Works but "many symlinks to
+   recreate a skill dir" is odd and fragile; explicit kind split is cleaner.
+3. **Projection allowlist in scribe.yaml** — forces every package author to
+   declare what to project. Too much burden; breaks convenience-first.
+
+## Open questions
+
+- Does `scribe.yaml` still apply to packages? Likely only `install.command` and
+  `uninstall.command` fields are meaningful; other fields (version, files)
+  ignored. TBD in impl.
+- Should packages have an `update` command (re-run install) or just git
+  pull + re-run install? Proposal: `scribe sync` pulls + re-runs install if
+  HEAD sha changed.
+
+## Scope
+
+In scope:
+- Detection + routing
+- Package install/remove flows
+- Migration for existing gstack-style installs
+- List UI / JSON split
+- Reconcile guard for packages
+- Tests for each
+
+Out of scope for this PR:
+- Package sub-skill discovery (listing gstack's inner skills in scribe list)
+- `scribe install --kind=package` flag override (auto-detection covers MVP)
+- Cross-agent package manifest format (beyond `install.command`)

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -55,6 +55,10 @@ type Skill struct {
 	Conflicted  bool     // SKILL.md contains unresolved merge conflict markers
 	Revision    int      // from state
 	Managed     bool     // tracked in state AND LocalPath is inside ~/.scribe/skills/
+	// IsPackage reports whether this row represents a ~/.scribe/packages/<name>/
+	// tree package rather than a regular skill. Packages self-install and
+	// don't get projected into tool skill dirs.
+	IsPackage bool
 }
 
 // OnDisk scans ~/.scribe/skills/ plus tool-facing install locations that are
@@ -122,16 +126,46 @@ func OnDisk(st *state.State) ([]Skill, error) {
 	}
 	skills = append(skills, pluginFound...)
 
-	// 4. Include state-tracked skills not found on disk (orphans).
+	// 4. Scan ~/.scribe/packages/ — these entries never appear in tool skill
+	// dirs, so surface them here directly from the packages store (and from
+	// state as a fallback) so the list view can show them.
+	packagesRoot := filepath.Join(home, ".scribe", "packages")
+	pkgEntries, err := os.ReadDir(packagesRoot)
+	if err == nil {
+		for _, entry := range pkgEntries {
+			if !entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if seen[name] {
+				continue
+			}
+			pkgDir := filepath.Join(packagesRoot, name)
+			sk := Skill{
+				Name:      name,
+				LocalPath: pkgDir,
+				Managed:   true,
+				IsPackage: true,
+			}
+			if installed, ok := st.Installed[name]; ok {
+				sk.Revision = installed.Revision
+			}
+			seen[name] = true
+			skills = append(skills, sk)
+		}
+	}
+
+	// 5. Include state-tracked skills not found on disk (orphans).
 	for name, installed := range st.Installed {
 		if seen[name] {
 			continue
 		}
 		skills = append(skills, Skill{
-			Name:     name,
-			Targets:  installed.Tools,
-			Revision: installed.Revision,
-			Managed:  true, // state-tracked → managed regardless of disk presence
+			Name:      name,
+			Targets:   installed.Tools,
+			Revision:  installed.Revision,
+			Managed:   true, // state-tracked → managed regardless of disk presence
+			IsPackage: installed.IsPackage(),
 		})
 	}
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -50,7 +50,7 @@ func InspectManagedSkills(cfg *config.Config, st *state.State, name string) (Rep
 	for _, skillName := range names {
 		skill := st.Installed[skillName]
 
-		if skill.Type == "package" {
+		if skill.IsPackage() {
 			continue
 		}
 
@@ -193,7 +193,7 @@ func inspectCanonicalMetadata(skillName string) ([]Issue, error) {
 
 func inspectProjectionDrift(cfg *config.Config, skillName string, skill state.InstalledSkill, availableTools []string) (Issue, bool) {
 	expectedTools := skill.EffectiveTools(availableTools)
-	if skill.Type == "package" {
+	if skill.IsPackage() {
 		return Issue{}, false
 	}
 

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -32,6 +32,19 @@ func StoreDir() (string, error) {
 	return filepath.Join(home, ".scribe", "skills"), nil
 }
 
+// PackagesDir returns the path to ~/.scribe/packages/.
+// Packages are self-installing multi-skill bundles that Scribe tracks but
+// never projects into tool skill dirs. They live alongside (not inside) the
+// canonical skill store so tools like Codex can walk ~/.codex/skills/ without
+// tripping on nested SKILL.md files from a package's inner skills.
+func PackagesDir() (string, error) {
+	home, err := homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".scribe", "packages"), nil
+}
+
 // ConfigPath returns the path to ~/.scribe/config.toml.
 func ConfigPath() (string, error) {
 	home, err := homeDir()

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -66,8 +66,36 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 		byName[tool.Name()] = tool
 	}
 
+	pkgsDir, pkgErr := tools.PackagesDir()
+	if pkgErr != nil {
+		return summary, nil, pkgErr
+	}
+
 	for name, skill := range st.Installed {
-		if skill.Type == "package" {
+		if skill.IsPackage() {
+			// Non-projection invariant: packages own their own wiring.
+			// Still scan for stale tool symlinks that resolve back to the
+			// package dir so a legacy skills/<name> → packages/<name> flip
+			// cleans up any prior projections on the next sync.
+			pkgDir := filepath.Join(pkgsDir, name)
+			for _, path := range projectionPaths(skill) {
+				if path == "" {
+					continue
+				}
+				if isManagedProjection(path, pkgDir) {
+					if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+						return summary, actions, err
+					}
+					summary.Removed++
+					actions = append(actions, Action{Kind: ActionRemoved, Name: name, Tool: inferToolName(path, byName, name), Path: path})
+				}
+			}
+			// Wipe tracked paths — packages never project.
+			if len(skill.Paths) > 0 || len(skill.ManagedPaths) > 0 {
+				skill.Paths = nil
+				skill.ManagedPaths = nil
+				st.Installed[name] = skill
+			}
 			continue
 		}
 

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -224,3 +224,96 @@ func TestReconcileRemovesStaleManagedProjection(t *testing.T) {
 		t.Fatalf("toolPath still exists: %v", err)
 	}
 }
+
+func TestReconcileSkipsPackages(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Stage a tree package as if sync wrote it.
+	pkgsDir, err := tools.PackagesDir()
+	if err != nil {
+		t.Fatalf("PackagesDir: %v", err)
+	}
+	pkgDir := filepath.Join(pkgsDir, "gstack")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "SKILL.md"), []byte("# pkg\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"gstack": {Revision: 1, Kind: state.KindPackage, Tools: []string{}, Paths: []string{}},
+	}}
+
+	engine := reconcile.Engine{Tools: []tools.Tool{tools.ClaudeTool{}, tools.CodexTool{}}, Now: func() time.Time { return time.Unix(1, 0).UTC() }}
+	summary, actions, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// No projections should be attempted for a package.
+	if summary.Installed != 0 {
+		t.Fatalf("Installed = %d, want 0 for a package", summary.Installed)
+	}
+	if summary.Relinked != 0 || summary.Removed != 0 {
+		t.Fatalf("summary = %+v, want all-zero for a package", summary)
+	}
+	for _, a := range actions {
+		if a.Name == "gstack" {
+			t.Fatalf("unexpected action for package: %+v", a)
+		}
+	}
+
+	// No tool-side symlinks should have been created.
+	if _, err := os.Lstat(filepath.Join(home, ".claude", "skills", "gstack")); err == nil {
+		t.Error("claude skills/gstack symlink was created for a package")
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".codex", "skills", "gstack")); err == nil {
+		t.Error("codex skills/gstack symlink was created for a package")
+	}
+}
+
+func TestReconcileRemovesStalePackageProjection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Simulate a legacy install: skill was projected into ~/.claude/skills/
+	// and then reclassified into packages/. Reconcile should clean the
+	// stale projection up next pass.
+	pkgsDir, _ := tools.PackagesDir()
+	pkgDir := filepath.Join(pkgsDir, "gstack")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "SKILL.md"), []byte("# pkg\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	stale := filepath.Join(home, ".claude", "skills", "gstack")
+	if err := os.MkdirAll(filepath.Dir(stale), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(pkgDir, stale); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"gstack": {
+			Revision:     1,
+			Kind:         state.KindPackage,
+			ManagedPaths: []string{stale},
+		},
+	}}
+	engine := reconcile.Engine{Tools: []tools.Tool{tools.ClaudeTool{}}, Now: func() time.Time { return time.Unix(1, 0).UTC() }}
+	summary, _, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Removed != 1 {
+		t.Fatalf("Removed = %d, want 1", summary.Removed)
+	}
+	if _, err := os.Lstat(stale); !os.IsNotExist(err) {
+		t.Errorf("stale package projection still exists: %v", err)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -63,6 +63,21 @@ const (
 	ToolsModePinned ToolsMode = "pinned"
 )
 
+// Kind classifies how a tracked entry is stored and projected.
+//
+// KindSkill (zero-value, also legacy default) is the canonical skill case:
+// files in ~/.scribe/skills/<name>/ and dir-symlinked into tool skill dirs.
+//
+// KindPackage is a self-installing multi-skill bundle. Files live in
+// ~/.scribe/packages/<name>/ and are NEVER projected into agent skill dirs.
+// Reconcile, discovery, and the list TUI all treat packages as opaque.
+type Kind string
+
+const (
+	KindSkill   Kind = ""
+	KindPackage Kind = "package"
+)
+
 // InstalledSkill records everything needed to detect updates and uninstall.
 type InstalledSkill struct {
 	Revision      int                  `json:"revision"`
@@ -76,6 +91,12 @@ type InstalledSkill struct {
 	Conflicts     []ProjectionConflict `json:"projection_conflicts,omitempty"`
 	Origin        Origin               `json:"origin,omitempty"`
 
+	// Kind distinguishes auto-detected tree packages (files under
+	// ~/.scribe/packages/<name>/) from regular skills. Missing value on
+	// legacy entries defaults to KindSkill; the first sync after upgrade
+	// may flip an entry to KindPackage via the reclassification pass.
+	Kind Kind `json:"kind,omitempty"`
+
 	// Package-specific fields (omitted for regular skills).
 	Type       string    `json:"type,omitempty"`
 	InstallCmd string    `json:"install_cmd,omitempty"`
@@ -83,6 +104,13 @@ type InstalledSkill struct {
 	CmdHash    string    `json:"cmd_hash,omitempty"`
 	Approval   string    `json:"approval,omitempty"`
 	ApprovedAt time.Time `json:"approved_at,omitempty"`
+}
+
+// IsPackage reports whether this state entry is a tree-package (new kind
+// field) or a legacy manifest-declared command-only package (Type field).
+// Both flavours skip projection into tool skill dirs.
+func (i InstalledSkill) IsPackage() bool {
+	return i.Kind == KindPackage || i.Type == "package"
 }
 
 // SkillSource records a registry that provides this skill.
@@ -137,6 +165,7 @@ type legacyInstalledSkill struct {
 	Sources       []SkillSource `json:"sources,omitempty"`
 	Origin        Origin        `json:"origin,omitempty"`
 	ToolsMode     ToolsMode     `json:"tools_mode,omitempty"`
+	Kind          Kind          `json:"kind,omitempty"`
 }
 
 // DisplayVersion returns the version string shown in `scribe list`.
@@ -482,6 +511,14 @@ func (s *State) RecordScribeBinaryUpdateSuccessAt(at time.Time) {
 // legacyToSkill converts a legacyInstalledSkill to an InstalledSkill,
 // carrying over all fields that map directly.
 func legacyToSkill(ls legacyInstalledSkill) InstalledSkill {
+	kind := ls.Kind
+	// Legacy manifest-declared command-only packages used Type="package"
+	// exclusively; treat them as KindPackage on load so downstream checks can
+	// simply consult Kind. We intentionally do NOT clear Type — downstream
+	// code may still rely on it for manifest-type (command-only) handling.
+	if kind == KindSkill && ls.Type == "package" {
+		kind = KindPackage
+	}
 	return InstalledSkill{
 		Revision:      ls.Revision,
 		InstalledHash: ls.InstalledHash,
@@ -492,6 +529,7 @@ func legacyToSkill(ls legacyInstalledSkill) InstalledSkill {
 		Paths:         ls.Paths,
 		ManagedPaths:  append([]string(nil), ls.Paths...),
 		Origin:        ls.Origin,
+		Kind:          kind,
 		Type:          ls.Type,
 		InstallCmd:    ls.InstallCmd,
 		UpdateCmd:     ls.UpdateCmd,
@@ -528,7 +566,7 @@ func normalizeBranchSourceSHAs(s *State) {
 	}
 
 	for name, skill := range s.Installed {
-		if skill.Type == "package" {
+		if skill.IsPackage() {
 			continue
 		}
 		changed := false
@@ -551,7 +589,7 @@ func normalizeBranchSourceSHAs(s *State) {
 
 func seedManagedPaths(s *State) {
 	for name, skill := range s.Installed {
-		if skill.Type == "package" {
+		if skill.IsPackage() {
 			// Packages own their own install lifecycle and their Paths
 			// (if any) are command-output, not tool projections.
 			continue

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -85,6 +85,86 @@ func TestSaveAndLoad(t *testing.T) {
 	}
 }
 
+func TestKindRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	s, _ := state.Load()
+	s.RecordInstall("gstack", state.InstalledSkill{
+		Revision: 1,
+		Kind:     state.KindPackage,
+	})
+	s.RecordInstall("brand", state.InstalledSkill{
+		Revision: 1,
+		// Kind omitted — legacy skill default.
+	})
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := loaded.Installed["gstack"].Kind; got != state.KindPackage {
+		t.Errorf("gstack kind = %q, want %q", got, state.KindPackage)
+	}
+	if !loaded.Installed["gstack"].IsPackage() {
+		t.Error("gstack IsPackage() = false, want true")
+	}
+	if got := loaded.Installed["brand"].Kind; got != state.KindSkill {
+		t.Errorf("brand kind = %q, want skill (empty)", got)
+	}
+	if loaded.Installed["brand"].IsPackage() {
+		t.Error("brand IsPackage() = true, want false")
+	}
+}
+
+func TestLegacyTypePackageMigratesToKind(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Hand-craft a state.json representing a legacy (pre-Kind) manifest
+	// package entry: Type="package" only, no Kind.
+	scribeDir := filepath.Join(home, ".scribe")
+	if err := os.MkdirAll(scribeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	legacy := []byte(`{
+		"schema_version": 4,
+		"installed": {
+			"superpowers": {
+				"revision": 1,
+				"type": "package",
+				"install_cmd": "echo install",
+				"installed_at": "2026-04-17T00:00:00Z",
+				"tools": [],
+				"paths": []
+			}
+		}
+	}`)
+	if err := os.WriteFile(filepath.Join(scribeDir, "state.json"), legacy, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	sp, ok := loaded.Installed["superpowers"]
+	if !ok {
+		t.Fatal("superpowers not loaded")
+	}
+	if sp.Kind != state.KindPackage {
+		t.Errorf("expected legacy type=package to migrate into Kind=package; got Kind=%q", sp.Kind)
+	}
+	if sp.Type != "package" {
+		t.Errorf("expected Type to remain for command-only packages; got %q", sp.Type)
+	}
+	if !sp.IsPackage() {
+		t.Error("IsPackage() should be true")
+	}
+}
+
 func TestBinaryUpdateChecksRoundTrip(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/state/tools_resolve.go
+++ b/internal/state/tools_resolve.go
@@ -11,7 +11,7 @@ package state
 // full available list. This mirrors the existing behavior where packages install
 // independently of tool-facing symlinks.
 func (s InstalledSkill) EffectiveTools(available []string) []string {
-	if s.Type == "package" {
+	if s.IsPackage() {
 		return append([]string(nil), available...)
 	}
 	if s.ToolsMode != ToolsModePinned {

--- a/internal/sync/detect.go
+++ b/internal/sync/detect.go
@@ -1,0 +1,110 @@
+package sync
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+// Kind classifies a fetched repo payload.
+//
+// KindSkill: single-authorship skill; dir-symlinked into tool skill dirs.
+// KindPackage: multi-skill bundle or self-installing toolkit; stored under
+// ~/.scribe/packages/<name>/ and never projected into agent skill dirs.
+type Kind string
+
+const (
+	KindSkill   Kind = "skill"
+	KindPackage Kind = "package"
+)
+
+// installScriptNames names the bootstrap entry points a package may ship at
+// its repo root. Presence of any (executable or not) marks a payload as a
+// self-installing package when the root SKILL.md is absent.
+var installScriptNames = map[string]bool{
+	"setup":       true,
+	"install.sh":  true,
+	"install":     true,
+	"bootstrap":   true,
+	"Makefile":    true,
+	"package.json": true,
+}
+
+// DetectKind classifies a fetched file tree as either a skill or a package.
+//
+// Rules (first match wins):
+//  1. Any SKILL.md at a non-root path (e.g. "browse/SKILL.md") → package.
+//  2. No SKILL.md at the root AND the tree has a recognised install script
+//     (setup, install.sh, bootstrap, Makefile, package.json) → package.
+//  3. Otherwise → skill.
+//
+// This mirrors the spec at docs/superpowers/specs/2026-04-17-packages-store-design.md.
+// The detection runs against in-memory SkillFile slices before the tree is
+// written to disk, so nothing is persisted until routing is decided.
+func DetectKind(files []tools.SkillFile) Kind {
+	hasRootSkill := false
+	hasNestedSkill := false
+	hasInstallScript := false
+
+	for _, f := range files {
+		path := filepath.ToSlash(filepath.Clean(f.Path))
+		base := filepath.Base(path)
+
+		if base == "SKILL.md" {
+			if !strings.Contains(path, "/") {
+				hasRootSkill = true
+			} else {
+				hasNestedSkill = true
+			}
+			continue
+		}
+		if !strings.Contains(path, "/") && installScriptNames[base] {
+			hasInstallScript = true
+		}
+	}
+
+	if hasNestedSkill {
+		return KindPackage
+	}
+	if !hasRootSkill && hasInstallScript {
+		return KindPackage
+	}
+	return KindSkill
+}
+
+// DetectKindFromDir classifies an existing on-disk directory. Used by the
+// migration pass: first sync after upgrade walks ~/.scribe/skills/<name>/
+// for each installed skill and reclassifies any that look like packages.
+func DetectKindFromDir(dir string) (Kind, error) {
+	var files []tools.SkillFile
+	// We don't actually need contents — DetectKind only looks at paths.
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			// Skip Scribe's version snapshot dir and vendor-ish noise.
+			name := d.Name()
+			if path != dir && (name == "versions" || name == ".git" || name == "node_modules") {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		// Ignore Scribe-managed merge-base files so they don't skew detection.
+		if rel == ".scribe-base.md" {
+			return nil
+		}
+		files = append(files, tools.SkillFile{Path: rel})
+		return nil
+	})
+	if err != nil {
+		return KindSkill, err
+	}
+	return DetectKind(files), nil
+}

--- a/internal/sync/detect_test.go
+++ b/internal/sync/detect_test.go
@@ -1,0 +1,147 @@
+package sync_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/sync"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+func TestDetectKind(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []tools.SkillFile
+		want  sync.Kind
+	}{
+		{
+			name: "plain skill: root SKILL.md only",
+			files: []tools.SkillFile{
+				{Path: "SKILL.md"},
+			},
+			want: sync.KindSkill,
+		},
+		{
+			name: "plain skill: SKILL.md plus resources",
+			files: []tools.SkillFile{
+				{Path: "SKILL.md"},
+				{Path: "scripts/deploy.sh"},
+				{Path: "README.md"},
+			},
+			want: sync.KindSkill,
+		},
+		{
+			name: "package: root SKILL.md AND nested SKILL.md",
+			files: []tools.SkillFile{
+				{Path: "SKILL.md"},
+				{Path: "browse/SKILL.md"},
+			},
+			want: sync.KindPackage,
+		},
+		{
+			name: "package: only nested SKILL.md, no root",
+			files: []tools.SkillFile{
+				{Path: "codex/SKILL.md"},
+				{Path: "ship/SKILL.md"},
+			},
+			want: sync.KindPackage,
+		},
+		{
+			name: "package: no SKILL.md anywhere but has setup script",
+			files: []tools.SkillFile{
+				{Path: "setup"},
+				{Path: "lib/main.js"},
+			},
+			want: sync.KindPackage,
+		},
+		{
+			name: "package: install.sh at root",
+			files: []tools.SkillFile{
+				{Path: "install.sh"},
+				{Path: "README.md"},
+			},
+			want: sync.KindPackage,
+		},
+		{
+			name: "package: package.json at root",
+			files: []tools.SkillFile{
+				{Path: "package.json"},
+				{Path: "src/index.ts"},
+			},
+			want: sync.KindPackage,
+		},
+		{
+			name: "skill: root SKILL.md wins over install script",
+			files: []tools.SkillFile{
+				{Path: "SKILL.md"},
+				{Path: "setup"},
+			},
+			want: sync.KindSkill,
+		},
+		{
+			name: "skill: empty tree",
+			files: []tools.SkillFile{},
+			want:  sync.KindSkill,
+		},
+		{
+			name: "package: deeply nested SKILL.md",
+			files: []tools.SkillFile{
+				{Path: "SKILL.md"},
+				{Path: "openclaw/skills/gstack-openclaw-office-hours/SKILL.md"},
+			},
+			want: sync.KindPackage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sync.DetectKind(tt.files)
+			if got != tt.want {
+				t.Errorf("DetectKind() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectKindFromDir(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel string) {
+		t.Helper()
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(p, []byte("ok"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	write("SKILL.md")
+	write("browse/SKILL.md")
+	write(".scribe-base.md")
+
+	kind, err := sync.DetectKindFromDir(dir)
+	if err != nil {
+		t.Fatalf("DetectKindFromDir: %v", err)
+	}
+	if kind != sync.KindPackage {
+		t.Errorf("got %q, want %q", kind, sync.KindPackage)
+	}
+}
+
+func TestDetectKindFromDir_Skill(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".scribe-base.md"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write base: %v", err)
+	}
+	kind, err := sync.DetectKindFromDir(dir)
+	if err != nil {
+		t.Fatalf("DetectKindFromDir: %v", err)
+	}
+	if kind != sync.KindSkill {
+		t.Errorf("got %q, want %q", kind, sync.KindSkill)
+	}
+}

--- a/internal/sync/events.go
+++ b/internal/sync/events.go
@@ -233,3 +233,31 @@ type PackageUpdateMsg struct{ Name string }
 
 // PackageUpdatedMsg is sent when a package update completes successfully.
 type PackageUpdatedMsg struct{ Name string }
+
+// PackageDetectedMsg is emitted when a fetched payload was classified as a
+// tree-package (nested SKILL.md or install script). Lets the UI show a
+// "stored as package" hint before the install command runs.
+type PackageDetectedMsg struct {
+	Name   string
+	Dir    string
+	Source string // where the install command came from (scribe.yaml, ./setup, …)
+}
+
+// PackageOutputMsg streams a package install/uninstall command's combined
+// output to the UI. Emitted once per command, after it finishes.
+type PackageOutputMsg struct {
+	Name   string
+	Stdout string
+	Stderr string
+}
+
+// PackageReclassifiedMsg is emitted by the migration pass when a legacy
+// skills/ install is moved into packages/ because its tree shape identifies
+// it as a package. InstallHint carries a note about whether setup should
+// be re-run (we don't auto-run during migration).
+type PackageReclassifiedMsg struct {
+	Name        string
+	OldPath     string
+	NewPath     string
+	InstallHint string
+}

--- a/internal/sync/package_install.go
+++ b/internal/sync/package_install.go
@@ -1,0 +1,139 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PackageInstallPlan describes how a staged package should self-install.
+// Resolution order (first match wins):
+//  1. scribe.yaml → install.command / install.uninstall
+//  2. executable setup at repo root
+//  3. install.sh at repo root
+//  4. package.json → run `bun install` when bun is available, else `npm install`
+//  5. Makefile target install (run via `make install`)
+//  6. No install command → empty Command (package is tracked but no-op)
+type PackageInstallPlan struct {
+	// Command is the shell command to run after writing the package dir.
+	// Executed from within the package directory.
+	Command string
+	// Uninstall, if set, is the command to run when `scribe remove <name>`
+	// is invoked for this package. Best-effort.
+	Uninstall string
+	// Source is a short description of where the command came from
+	// ("scribe.yaml", "./setup", "install.sh", "package.json", "Makefile").
+	Source string
+}
+
+// packageManifestInstall is the shallow subset of scribe.yaml this package
+// cares about. A full manifest is parsed elsewhere (internal/manifest); here
+// we only need the install block, so we decode straight into this shape.
+type packageManifestInstall struct {
+	Install struct {
+		Command   string `yaml:"command"`
+		Uninstall string `yaml:"uninstall"`
+	} `yaml:"install"`
+}
+
+// ResolvePackageInstall walks the given package directory and returns a plan
+// for how to execute its self-install. See PackageInstallPlan for the
+// resolution order. An absent plan (empty Command) is not an error — the
+// package is tracked but triggers no shell execution.
+func ResolvePackageInstall(pkgDir string) (PackageInstallPlan, error) {
+	if plan, ok, err := readScribeManifestInstall(pkgDir); err != nil {
+		return PackageInstallPlan{}, err
+	} else if ok {
+		return plan, nil
+	}
+
+	if isExecutableFile(filepath.Join(pkgDir, "setup")) {
+		return PackageInstallPlan{Command: "./setup", Source: "./setup"}, nil
+	}
+	if fileExists(filepath.Join(pkgDir, "install.sh")) {
+		return PackageInstallPlan{Command: "sh install.sh", Source: "install.sh"}, nil
+	}
+	if fileExists(filepath.Join(pkgDir, "package.json")) {
+		return PackageInstallPlan{
+			Command: "if command -v bun >/dev/null 2>&1; then bun install; else npm install; fi",
+			Source:  "package.json",
+		}, nil
+	}
+	if fileExists(filepath.Join(pkgDir, "Makefile")) {
+		return PackageInstallPlan{Command: "make install", Source: "Makefile"}, nil
+	}
+	return PackageInstallPlan{}, nil
+}
+
+func readScribeManifestInstall(pkgDir string) (PackageInstallPlan, bool, error) {
+	for _, name := range []string{"scribe.yaml", "scribe.yml"} {
+		path := filepath.Join(pkgDir, name)
+		data, err := os.ReadFile(path)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return PackageInstallPlan{}, false, fmt.Errorf("read %s: %w", name, err)
+		}
+		var pm packageManifestInstall
+		if err := yaml.Unmarshal(data, &pm); err != nil {
+			// Malformed scribe.yaml shouldn't crash install — a later phase
+			// can surface a warning; here we just fall through to script
+			// detection.
+			return PackageInstallPlan{}, false, nil
+		}
+		if pm.Install.Command == "" && pm.Install.Uninstall == "" {
+			return PackageInstallPlan{}, false, nil
+		}
+		return PackageInstallPlan{
+			Command:   pm.Install.Command,
+			Uninstall: pm.Install.Uninstall,
+			Source:    name,
+		}, true, nil
+	}
+	return PackageInstallPlan{}, false, nil
+}
+
+// RunPackageCommand executes cmd inside pkgDir using the provided executor.
+// Stdout/stderr are captured. Empty cmd is a no-op (returns nil). A non-nil
+// err indicates the command failed or the context was cancelled; callers
+// are expected to roll back on install errors.
+func RunPackageCommand(ctx context.Context, exec CommandExecutor, pkgDir, cmd string, timeout time.Duration) (string, string, error) {
+	if cmd == "" {
+		return "", "", nil
+	}
+	if timeout == 0 {
+		timeout = defaultPackageTimeout
+	}
+	full := fmt.Sprintf("cd %s && %s", shellQuote(pkgDir), cmd)
+	return exec.Execute(ctx, full, timeout)
+}
+
+// shellQuote wraps s in single quotes so it can be safely interpolated into
+// a sh -c command string. Any single quote inside is escaped via '\''.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	return info.Mode().Perm()&0o111 != 0
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular()
+}

--- a/internal/sync/package_migrate.go
+++ b/internal/sync/package_migrate.go
@@ -1,0 +1,112 @@
+package sync
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+// packageReclassifyMigrationName names the one-shot state migration that
+// reclassifies legacy skills/<name>/ installs into packages/<name>/ when
+// their on-disk shape identifies them as packages. The state layer gates on
+// state.Migrations[packageReclassifyMigrationName] so this runs exactly
+// once per machine.
+const packageReclassifyMigrationName = "packages_store_split_2026_04"
+
+// ReclassifyLegacyPackages scans state entries classified as skills, detects
+// any whose on-disk shape is actually a package (nested SKILL.md / install
+// script), and moves them to ~/.scribe/packages/<name>/. Tool projections
+// are removed and state is updated. Each move emits a
+// PackageReclassifiedMsg so the UI can surface a hint.
+//
+// Safe to call repeatedly — the caller guards with state.HasMigration and
+// marks it done after the first successful pass.
+func (s *Syncer) ReclassifyLegacyPackages(st *state.State) error {
+	if st.HasMigration(packageReclassifyMigrationName) {
+		return nil
+	}
+
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		return err
+	}
+	pkgsDir, err := tools.PackagesDir()
+	if err != nil {
+		return err
+	}
+
+	for name, skill := range st.Installed {
+		if skill.IsPackage() {
+			continue
+		}
+		oldDir := filepath.Join(storeDir, name)
+		info, statErr := os.Stat(oldDir)
+		if statErr != nil || !info.IsDir() {
+			continue
+		}
+		kind, detectErr := DetectKindFromDir(oldDir)
+		if detectErr != nil || kind != KindPackage {
+			continue
+		}
+
+		newDir := filepath.Join(pkgsDir, name)
+		if err := reclassifyOnDisk(oldDir, newDir); err != nil {
+			return fmt.Errorf("reclassify %s: %w", name, err)
+		}
+		removeStaleProjections(skill)
+
+		skill.Kind = state.KindPackage
+		skill.Tools = []string{}
+		skill.Paths = []string{}
+		skill.ManagedPaths = nil
+		st.Installed[name] = skill
+
+		s.emit(PackageReclassifiedMsg{
+			Name:        name,
+			OldPath:     oldDir,
+			NewPath:     newDir,
+			InstallHint: "run its setup/install script if it needs to re-wire tools",
+		})
+	}
+
+	st.MarkMigration(packageReclassifyMigrationName)
+	return st.Save()
+}
+
+// reclassifyOnDisk moves srcDir → dstDir. Parent of dstDir is created if
+// needed. If dstDir already exists (e.g. from a half-completed prior run),
+// it is removed first so the move is deterministic.
+func reclassifyOnDisk(srcDir, dstDir string) error {
+	if err := os.MkdirAll(filepath.Dir(dstDir), 0o755); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dstDir); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return os.Rename(srcDir, dstDir)
+}
+
+// removeStaleProjections deletes every tool-facing symlink Scribe created
+// for this skill. Best-effort — a missing link is fine. Errors other than
+// ErrNotExist are ignored here because the migration should not abort on
+// a single stale link.
+func removeStaleProjections(skill state.InstalledSkill) {
+	managed := skill.ManagedPaths
+	if len(managed) == 0 {
+		managed = skill.Paths
+	}
+	for _, p := range managed {
+		if p == "" {
+			continue
+		}
+		if err := os.Remove(p); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			// Swallow — migration should keep going.
+			_ = err
+		}
+	}
+}

--- a/internal/sync/package_migrate_test.go
+++ b/internal/sync/package_migrate_test.go
@@ -1,0 +1,125 @@
+package sync_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/paths"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/sync"
+)
+
+func TestReclassifyLegacyPackages(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	storeDir, _ := paths.StoreDir()
+	pkgsDir, _ := paths.PackagesDir()
+
+	// Stage a legacy package-style install under skills/.
+	oldDir := filepath.Join(storeDir, "gstack")
+	if err := os.MkdirAll(filepath.Join(oldDir, "browse"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(oldDir, "SKILL.md"), []byte("# root\n"), 0o644); err != nil {
+		t.Fatalf("write root SKILL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(oldDir, "browse", "SKILL.md"), []byte("# browse\n"), 0o644); err != nil {
+		t.Fatalf("write nested SKILL.md: %v", err)
+	}
+
+	// Fake tool-side projection that should be cleaned up.
+	toolProj := filepath.Join(home, ".claude", "skills", "gstack")
+	if err := os.MkdirAll(filepath.Dir(toolProj), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(oldDir, toolProj); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	// Stage a plain skill install — must not be touched.
+	plainSkillDir := filepath.Join(storeDir, "brand-guidelines")
+	if err := os.MkdirAll(plainSkillDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll plain: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(plainSkillDir, "SKILL.md"), []byte("# brand\n"), 0o644); err != nil {
+		t.Fatalf("write plain SKILL.md: %v", err)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	st.Installed["gstack"] = state.InstalledSkill{
+		Revision:     1,
+		Tools:        []string{"claude"},
+		Paths:        []string{toolProj},
+		ManagedPaths: []string{toolProj},
+	}
+	st.Installed["brand-guidelines"] = state.InstalledSkill{
+		Revision: 1,
+		Tools:    []string{"claude"},
+	}
+
+	var events []any
+	syncer := &sync.Syncer{Emit: func(msg any) { events = append(events, msg) }}
+	if err := syncer.ReclassifyLegacyPackages(st); err != nil {
+		t.Fatalf("ReclassifyLegacyPackages: %v", err)
+	}
+
+	// gstack should now live in packages/.
+	newDir := filepath.Join(pkgsDir, "gstack")
+	if _, err := os.Stat(newDir); err != nil {
+		t.Fatalf("package dir not moved: %v", err)
+	}
+	if _, err := os.Stat(oldDir); err == nil {
+		t.Error("old skills/ dir should be gone")
+	}
+
+	// Tool-side projection cleaned up.
+	if _, err := os.Lstat(toolProj); !os.IsNotExist(err) {
+		t.Errorf("tool projection not cleaned: %v", err)
+	}
+
+	// State reflects the reclassification.
+	gstack := st.Installed["gstack"]
+	if gstack.Kind != state.KindPackage {
+		t.Errorf("gstack kind = %q, want %q", gstack.Kind, state.KindPackage)
+	}
+	if len(gstack.Tools) != 0 || len(gstack.Paths) != 0 {
+		t.Errorf("expected empty Tools/Paths after reclassification; got %+v", gstack)
+	}
+
+	// Plain skill untouched.
+	brand := st.Installed["brand-guidelines"]
+	if brand.Kind != state.KindSkill {
+		t.Errorf("plain skill kind changed: %q", brand.Kind)
+	}
+	if _, err := os.Stat(plainSkillDir); err != nil {
+		t.Errorf("plain skill dir removed: %v", err)
+	}
+
+	// Reclassification event emitted.
+	var sawReclassified bool
+	for _, ev := range events {
+		if msg, ok := ev.(sync.PackageReclassifiedMsg); ok {
+			sawReclassified = true
+			if msg.Name != "gstack" {
+				t.Errorf("wrong name in reclassify event: %q", msg.Name)
+			}
+		}
+	}
+	if !sawReclassified {
+		t.Error("expected PackageReclassifiedMsg")
+	}
+
+	// Second call must be a no-op (migration marker prevents re-run).
+	events = nil
+	if err := syncer.ReclassifyLegacyPackages(st); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("second call should be a no-op; got %d events", len(events))
+	}
+}

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -318,6 +318,16 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 				}
 			}
 
+			// Auto-detect tree packages: repos with nested SKILL.md or an
+			// install script route into ~/.scribe/packages/<name>/ and
+			// never get projected into tool skill dirs. Skips this branch
+			// only when the manifest already declared a command-only
+			// package (handled above via sk.IsPackage).
+			if DetectKind(tFiles) == KindPackage {
+				s.applyTreePackage(ctx, sk, teamRepo, tFiles, st, &summary)
+				continue
+			}
+
 			// Check for local modifications before writing.
 			installed := lookupInstalled(st, sk.Name)
 			if installed != nil && sk.Status == StatusOutdated {
@@ -842,4 +852,123 @@ func (s *Syncer) updateSourceEntry(st *state.State, skillName, teamRepo string, 
 	existing := st.Installed[skillName]
 	existing.Sources = mergeSources(installed, newSource)
 	st.Installed[skillName] = existing
+}
+
+// applyTreePackage writes a fetched multi-skill repo into ~/.scribe/packages/
+// and runs its self-install command. Rolls back on failure. Never creates
+// tool projections; packages own their own wiring.
+func (s *Syncer) applyTreePackage(ctx context.Context, sk SkillStatus, teamRepo string, files []tools.SkillFile, st *state.State, summary *SyncCompleteMsg) {
+	installed := lookupInstalled(st, sk.Name)
+
+	// Before writing packages/<name>/, clear any stale skills/<name>/ dir
+	// plus its tool projections — these come from a prior install that
+	// routed the same repo through the skill path. See also the migration
+	// pass in Syncer.RunPackageReclassification for bulk cases.
+	if installed != nil && !installed.IsPackage() {
+		if err := s.pruneStaleSkillInstall(sk.Name, installed); err != nil {
+			s.emit(SkillErrorMsg{Name: sk.Name, Err: fmt.Errorf("prune stale skill install: %w", err)})
+			summary.Failed++
+			return
+		}
+	}
+
+	pkgDir, err := tools.WriteToPackageStore(sk.Name, files)
+	if err != nil {
+		s.emit(SkillErrorMsg{Name: sk.Name, Err: fmt.Errorf("write package store: %w", err)})
+		summary.Failed++
+		return
+	}
+
+	plan, err := ResolvePackageInstall(pkgDir)
+	if err != nil {
+		_ = os.RemoveAll(pkgDir)
+		s.emit(SkillErrorMsg{Name: sk.Name, Err: fmt.Errorf("resolve install: %w", err)})
+		summary.Failed++
+		return
+	}
+
+	s.emit(PackageDetectedMsg{Name: sk.Name, Dir: pkgDir, Source: plan.Source})
+
+	if plan.Command != "" {
+		if s.Executor == nil {
+			_ = os.RemoveAll(pkgDir)
+			s.emit(SkillErrorMsg{Name: sk.Name, Err: fmt.Errorf("no command executor configured")})
+			summary.Failed++
+			return
+		}
+		s.emit(PackageInstallingMsg{Name: sk.Name})
+		timeout := defaultPackageTimeout
+		if sk.Entry != nil && sk.Entry.Timeout > 0 {
+			timeout = time.Duration(sk.Entry.Timeout) * time.Second
+		}
+		stdout, stderr, runErr := RunPackageCommand(ctx, s.Executor, pkgDir, plan.Command, timeout)
+		s.emit(PackageOutputMsg{Name: sk.Name, Stdout: stdout, Stderr: stderr})
+		if runErr != nil {
+			// Roll back: a failed install must not leave a half-extracted tree
+			// behind where `scribe list` would later show it as healthy.
+			_ = os.RemoveAll(pkgDir)
+			s.emit(PackageErrorMsg{Name: sk.Name, Err: runErr, Stderr: stderr})
+			summary.Failed++
+			return
+		}
+	}
+
+	// Record state. Packages carry empty Tools/Paths because Scribe never
+	// projects them into tool skill dirs — the package ran its own install
+	// and anything it needs now lives wherever that script decided.
+	src, _ := manifest.ParseSource(entrySource(sk.Entry))
+	newSource := state.SkillSource{
+		Registry:   teamRepo,
+		Ref:        src.Ref,
+		LastSHA:    sk.LatestSHA,
+		LastSynced: time.Now().UTC(),
+	}
+
+	st.RecordInstall(sk.Name, state.InstalledSkill{
+		Revision:   nextRevision(installed),
+		Sources:    mergeSources(installed, newSource),
+		Tools:      []string{},
+		Paths:      []string{},
+		Kind:       state.KindPackage,
+		InstallCmd: plan.Command,
+		UpdateCmd:  plan.Uninstall, // retained for future `scribe sync` package updates
+	})
+	if err := st.Save(); err != nil {
+		s.emit(SkillErrorMsg{Name: sk.Name, Err: fmt.Errorf("save state after %s: %w", sk.Name, err)})
+	}
+
+	s.emit(PackageInstalledMsg{Name: sk.Name})
+	if sk.Status == StatusOutdated {
+		summary.Updated++
+	} else {
+		summary.Installed++
+	}
+}
+
+// pruneStaleSkillInstall removes any canonical skill dir and tool
+// projections created by a prior install that treated this name as a
+// skill. Used when the same repo now auto-detects as a package.
+func (s *Syncer) pruneStaleSkillInstall(name string, installed *state.InstalledSkill) error {
+	storeDir, err := tools.StoreDir()
+	if err == nil {
+		_ = os.RemoveAll(filepath.Join(storeDir, name))
+	}
+	managed := installed.ManagedPaths
+	if len(managed) == 0 {
+		managed = installed.Paths
+	}
+	for _, p := range managed {
+		if rmErr := os.Remove(p); rmErr != nil && !os.IsNotExist(rmErr) {
+			return rmErr
+		}
+	}
+	return nil
+}
+
+// entrySource returns sk.Entry.Source or "" when the entry is nil.
+func entrySource(e *manifest.Entry) string {
+	if e == nil {
+		return ""
+	}
+	return e.Source
 }

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -227,6 +227,13 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 // Emits events throughout. Updates state incrementally — a failed skill
 // does not prevent successful skills from being recorded.
 func (s *Syncer) Run(ctx context.Context, teamRepo string, st *state.State) error {
+	// First run after upgrading to the packages-store split: reclassify any
+	// legacy skills/<name>/ installs whose tree shape identifies them as
+	// packages. Idempotent — guarded by state.Migrations.
+	if err := s.ReclassifyLegacyPackages(st); err != nil {
+		s.emit(SkillErrorMsg{Name: "<migration>", Err: fmt.Errorf("reclassify legacy packages: %w", err)})
+	}
+
 	statuses, _, err := s.Diff(ctx, teamRepo, st)
 	if err != nil {
 		return fmt.Errorf("sync %s: %w", teamRepo, err)

--- a/internal/sync/tree_package_test.go
+++ b/internal/sync/tree_package_test.go
@@ -1,0 +1,207 @@
+package sync_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/paths"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/sync"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+// TestApply_TreePackage_DetectsAndInstalls verifies that a fetched repo with
+// nested SKILL.md plus a ./setup script gets routed to ~/.scribe/packages/,
+// the install script runs, and state records Kind=package with empty tools.
+func TestApply_TreePackage_DetectsAndInstalls(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	executor := &mockExecutor{}
+	var events []any
+
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{
+			files: []tools.SkillFile{
+				{Path: "SKILL.md", Content: []byte("# root\n")},
+				{Path: "browse/SKILL.md", Content: []byte("# browse\n")},
+				{Path: "setup", Content: []byte("#!/usr/bin/env sh\necho installed\n")},
+			},
+		},
+		Executor: executor,
+		Emit:     func(msg any) { events = append(events, msg) },
+	}
+
+	st := &state.State{Installed: make(map[string]state.InstalledSkill)}
+	statuses := []sync.SkillStatus{{
+		Name:   "gstack",
+		Status: sync.StatusMissing,
+		Entry: &manifest.Entry{
+			Name:   "gstack",
+			Source: "github:Naoray/gstack@main",
+		},
+	}}
+
+	if err := syncer.RunWithDiff(context.Background(), "Naoray/gstack", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+
+	pkgsDir, err := paths.PackagesDir()
+	if err != nil {
+		t.Fatalf("PackagesDir: %v", err)
+	}
+	pkgDir := filepath.Join(pkgsDir, "gstack")
+	if _, err := os.Stat(pkgDir); err != nil {
+		t.Fatalf("package dir not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(pkgDir, "browse", "SKILL.md")); err != nil {
+		t.Errorf("nested SKILL.md missing: %v", err)
+	}
+
+	// The install command should have been executed exactly once.
+	if len(executor.commands) != 1 {
+		t.Fatalf("expected 1 install command, got %d: %v", len(executor.commands), executor.commands)
+	}
+
+	// State should carry Kind=package with empty tool projections.
+	installed, ok := st.Installed["gstack"]
+	if !ok {
+		t.Fatal("gstack not recorded in state")
+	}
+	if installed.Kind != state.KindPackage {
+		t.Errorf("kind = %q, want %q", installed.Kind, state.KindPackage)
+	}
+	if len(installed.Tools) != 0 {
+		t.Errorf("tools should be empty, got %v", installed.Tools)
+	}
+	if len(installed.Paths) != 0 {
+		t.Errorf("paths should be empty, got %v", installed.Paths)
+	}
+
+	// Skills store must remain empty for this name — we didn't project.
+	storeDir, _ := paths.StoreDir()
+	if _, err := os.Stat(filepath.Join(storeDir, "gstack")); err == nil {
+		t.Error("packages must not also land in ~/.scribe/skills/")
+	}
+
+	// Detection + install events should have fired in order.
+	var sawDetected, sawInstalled bool
+	for _, ev := range events {
+		switch ev.(type) {
+		case sync.PackageDetectedMsg:
+			sawDetected = true
+		case sync.PackageInstalledMsg:
+			sawInstalled = true
+		}
+	}
+	if !sawDetected {
+		t.Error("expected PackageDetectedMsg")
+	}
+	if !sawInstalled {
+		t.Error("expected PackageInstalledMsg")
+	}
+}
+
+// TestApply_TreePackage_RollsBackOnInstallFailure verifies that a non-zero
+// exit from the install command deletes the package dir so the machine
+// doesn't end up with a half-extracted tree masquerading as installed.
+func TestApply_TreePackage_RollsBackOnInstallFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	executor := &mockExecutor{
+		stderr: "boom",
+		err:    fmt.Errorf("exit status 1"),
+	}
+	var events []any
+
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{
+			files: []tools.SkillFile{
+				{Path: "SKILL.md", Content: []byte("# root\n")},
+				{Path: "nested/SKILL.md", Content: []byte("# nested\n")},
+				{Path: "install.sh", Content: []byte("#!/usr/bin/env sh\nexit 1\n")},
+			},
+		},
+		Executor: executor,
+		Emit:     func(msg any) { events = append(events, msg) },
+	}
+
+	st := &state.State{Installed: make(map[string]state.InstalledSkill)}
+	statuses := []sync.SkillStatus{{
+		Name:   "crashy",
+		Status: sync.StatusMissing,
+		Entry: &manifest.Entry{
+			Name:   "crashy",
+			Source: "github:ex/crashy@main",
+		},
+	}}
+
+	if err := syncer.RunWithDiff(context.Background(), "ex/crashy", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+
+	pkgsDir, _ := paths.PackagesDir()
+	if _, err := os.Stat(filepath.Join(pkgsDir, "crashy")); err == nil {
+		t.Error("package dir should be rolled back on install failure")
+	}
+	if _, ok := st.Installed["crashy"]; ok {
+		t.Error("failed package should not be recorded in state")
+	}
+
+	var sawError bool
+	for _, ev := range events {
+		if _, ok := ev.(sync.PackageErrorMsg); ok {
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Error("expected PackageErrorMsg event")
+	}
+}
+
+// TestApply_TreePackage_NoInstallCommand_StillTracked verifies that a repo
+// with nested SKILL.md but no install script is still stored as a package
+// and recorded — but no command is executed.
+func TestApply_TreePackage_NoInstallCommand_StillTracked(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	executor := &mockExecutor{}
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{
+			files: []tools.SkillFile{
+				{Path: "SKILL.md", Content: []byte("# root\n")},
+				{Path: "nested/SKILL.md", Content: []byte("# nested\n")},
+			},
+		},
+		Executor: executor,
+		Emit:     func(msg any) {},
+	}
+
+	st := &state.State{Installed: make(map[string]state.InstalledSkill)}
+	statuses := []sync.SkillStatus{{
+		Name:   "bundle",
+		Status: sync.StatusMissing,
+		Entry: &manifest.Entry{
+			Name:   "bundle",
+			Source: "github:ex/bundle@main",
+		},
+	}}
+
+	if err := syncer.RunWithDiff(context.Background(), "ex/bundle", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+
+	if len(executor.commands) != 0 {
+		t.Errorf("no install command should have fired, got %v", executor.commands)
+	}
+	installed, ok := st.Installed["bundle"]
+	if !ok {
+		t.Fatal("bundle not recorded")
+	}
+	if installed.Kind != state.KindPackage {
+		t.Errorf("kind = %q, want package", installed.Kind)
+	}
+}

--- a/internal/tools/store.go
+++ b/internal/tools/store.go
@@ -101,6 +101,69 @@ func StoreDir() (string, error) {
 	return paths.StoreDir()
 }
 
+// PackagesDir returns the ~/.scribe/packages/ directory path.
+func PackagesDir() (string, error) {
+	return paths.PackagesDir()
+}
+
+// WriteToPackageStore writes all package files to ~/.scribe/packages/<name>/.
+// Returns the canonical package directory. Like WriteToStore it does a clean
+// rewrite, but it preserves no merge-base copy and does NOT apply any tool
+// projection — packages are self-installing and Scribe never links them into
+// agent skill dirs.
+//
+// File-mode handling: scripts named setup / install.sh / install / bootstrap
+// at the package root are made executable so the install runner can invoke
+// them directly. Everything else is written 0644.
+func WriteToPackageStore(name string, files []SkillFile) (string, error) {
+	if reservedNames[name] {
+		return "", fmt.Errorf("invalid package name %q: reserved name", name)
+	}
+	if strings.Contains(name, "..") || filepath.IsAbs(name) {
+		return "", fmt.Errorf("invalid package name %q: contains path traversal", name)
+	}
+
+	base, err := PackagesDir()
+	if err != nil {
+		return "", err
+	}
+	pkgDir := filepath.Join(base, name)
+
+	// Clean slate on update.
+	if err := os.RemoveAll(pkgDir); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return "", fmt.Errorf("clear package dir: %w", err)
+	}
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		return "", fmt.Errorf("create package dir: %w", err)
+	}
+
+	executableNames := map[string]bool{
+		"setup":      true,
+		"install.sh": true,
+		"install":    true,
+		"bootstrap":  true,
+	}
+
+	for _, f := range files {
+		dest := filepath.Join(pkgDir, f.Path)
+		if !strings.HasPrefix(filepath.Clean(dest), filepath.Clean(pkgDir)+string(filepath.Separator)) && filepath.Clean(dest) != filepath.Clean(pkgDir) {
+			return "", fmt.Errorf("invalid file path %q: escapes package directory", f.Path)
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return "", fmt.Errorf("create dir for %s: %w", f.Path, err)
+		}
+		mode := os.FileMode(0o644)
+		if !strings.Contains(filepath.ToSlash(f.Path), "/") && executableNames[filepath.Base(f.Path)] {
+			mode = 0o755
+		}
+		if err := os.WriteFile(dest, f.Content, mode); err != nil {
+			return "", fmt.Errorf("write %s: %w", f.Path, err)
+		}
+	}
+
+	return pkgDir, nil
+}
+
 // WriteCanonicalSkill rewrites the canonical SKILL.md content and refreshes the
 // stored merge base to match. Used by repair flows that promote a tool-local
 // single-file projection back into the canonical store.

--- a/internal/workflow/list.go
+++ b/internal/workflow/list.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/Naoray/scribe/internal/discovery"
+	"github.com/Naoray/scribe/internal/paths"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
@@ -88,9 +90,30 @@ func printLocalJSON(w io.Writer, skills []discovery.Skill, st *state.State) erro
 		Origin      string   `json:"origin,omitempty"`
 		Path        string   `json:"path,omitempty"`
 	}
+	type localPackageJSON struct {
+		Name        string   `json:"name"`
+		Description string   `json:"description,omitempty"`
+		Revision    int      `json:"revision,omitempty"`
+		Path        string   `json:"path,omitempty"`
+		InstallCmd  string   `json:"install_cmd,omitempty"`
+		Sources     []string `json:"sources,omitempty"`
+	}
 
-	out := make([]localSkillJSON, 0, len(skills))
+	skillsOut := make([]localSkillJSON, 0, len(skills))
+	// Emit one entry per discovered skill that is NOT tracked as a package.
+	// Package entries come from the state map because discovery walks
+	// ~/.scribe/skills/ and tool dirs, neither of which now hold packages.
 	for _, sk := range skills {
+		// A sub-skill whose Package name matches an installed package entry
+		// should not surface as a standalone skill — the package owns it.
+		if sk.Package != "" {
+			if inst, ok := st.Installed[sk.Package]; ok && inst.IsPackage() {
+				continue
+			}
+		}
+		if inst, ok := st.Installed[sk.Name]; ok && inst.IsPackage() {
+			continue
+		}
 		targets := sk.Targets
 		if targets == nil {
 			targets = []string{}
@@ -101,7 +124,7 @@ func printLocalJSON(w io.Writer, skills []discovery.Skill, st *state.State) erro
 			origin = "local"
 		}
 
-		out = append(out, localSkillJSON{
+		skillsOut = append(skillsOut, localSkillJSON{
 			Name:        sk.Name,
 			Description: sk.Description,
 			Package:     sk.Package,
@@ -114,9 +137,44 @@ func printLocalJSON(w io.Writer, skills []discovery.Skill, st *state.State) erro
 		})
 	}
 
+	packagesOut := make([]localPackageJSON, 0)
+	for name, inst := range st.Installed {
+		if !inst.IsPackage() {
+			continue
+		}
+		pkgsDir, _ := stateInstalledPackageDir(name)
+		srcRegistries := make([]string, 0, len(inst.Sources))
+		for _, s := range inst.Sources {
+			if s.Registry != "" {
+				srcRegistries = append(srcRegistries, s.Registry)
+			}
+		}
+		packagesOut = append(packagesOut, localPackageJSON{
+			Name:       name,
+			Revision:   inst.Revision,
+			Path:       pkgsDir,
+			InstallCmd: inst.InstallCmd,
+			Sources:    srcRegistries,
+		})
+	}
+
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	return enc.Encode(out)
+	return enc.Encode(map[string]any{
+		"skills":   skillsOut,
+		"packages": packagesOut,
+	})
+}
+
+// stateInstalledPackageDir resolves the canonical package directory for a
+// given package name. Returns the empty string if the packages root cannot
+// be resolved (we still emit the entry).
+func stateInstalledPackageDir(name string) (string, error) {
+	pkgs, err := paths.PackagesDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(pkgs, name), nil
 }
 
 func printMultiListJSON(ctx context.Context, w io.Writer, repos []string, syncer *sync.Syncer, st *state.State) (bool, error) {

--- a/internal/workflow/list_load.go
+++ b/internal/workflow/list_load.go
@@ -35,6 +35,7 @@ type ListRow struct {
 	Excerpt   string
 	Managed   bool
 	Origin    state.Origin
+	Kind      state.Kind
 }
 
 func BuildRows(ctx context.Context, bag *Bag) ([]ListRow, []string, error) {
@@ -112,6 +113,7 @@ func BuildRows(ctx context.Context, bag *Bag) ([]ListRow, []string, error) {
 			}
 			if installed, ok := bag.State.Installed[ss.Name]; ok {
 				row.Origin = installed.Origin
+				row.Kind = installed.Kind
 			}
 			if ss.Installed != nil {
 				row.Targets = ss.Installed.Tools
@@ -142,9 +144,13 @@ func BuildLocalRows(skills []discovery.Skill, st *state.State) []ListRow {
 		}
 		if installed, ok := st.Installed[sk.Name]; ok {
 			row.Origin = installed.Origin
+			row.Kind = installed.Kind
 			if len(installed.Sources) > 0 && installed.Sources[0].Registry != "" {
 				row.Group = installed.Sources[0].Registry
 			}
+		}
+		if sk.IsPackage {
+			row.Kind = state.KindPackage
 		}
 		if sk.LocalPath != "" {
 			row.Excerpt = readExcerpt(sk.LocalPath, excerptLineBudget)

--- a/internal/workflow/list_test.go
+++ b/internal/workflow/list_test.go
@@ -180,9 +180,14 @@ func TestPrintLocalJSON(t *testing.T) {
 			t.Fatalf("printLocalJSON error: %v", err)
 		}
 		var got []outputSkill
-		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		var wrapper struct {
+			Skills   []outputSkill `json:"skills"`
+			Packages []any         `json:"packages"`
+		}
+		if err := json.Unmarshal(buf.Bytes(), &wrapper); err != nil {
 			t.Fatalf("json.Unmarshal error: %v\nraw: %s", err, buf.String())
 		}
+		got = wrapper.Skills
 		if len(got) != 1 {
 			t.Fatalf("expected 1 skill, got %d", len(got))
 		}
@@ -217,9 +222,14 @@ func TestPrintLocalJSON(t *testing.T) {
 			t.Fatalf("printLocalJSON error: %v", err)
 		}
 		var got []outputSkill
-		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		var wrapper struct {
+			Skills   []outputSkill `json:"skills"`
+			Packages []any         `json:"packages"`
+		}
+		if err := json.Unmarshal(buf.Bytes(), &wrapper); err != nil {
 			t.Fatalf("json.Unmarshal error: %v\nraw: %s", err, buf.String())
 		}
+		got = wrapper.Skills
 		if len(got) != 1 {
 			t.Fatalf("expected 1 skill, got %d", len(got))
 		}
@@ -255,9 +265,14 @@ func TestPrintLocalJSON(t *testing.T) {
 			t.Fatalf("printLocalJSON error: %v", err)
 		}
 		var got []outputSkill
-		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		var wrapper struct {
+			Skills   []outputSkill `json:"skills"`
+			Packages []any         `json:"packages"`
+		}
+		if err := json.Unmarshal(buf.Bytes(), &wrapper); err != nil {
 			t.Fatalf("json.Unmarshal error: %v\nraw: %s", err, buf.String())
 		}
+		got = wrapper.Skills
 		if len(got) != 1 {
 			t.Fatalf("expected 1 skill, got %d", len(got))
 		}
@@ -319,14 +334,62 @@ func TestPrintLocalJSON(t *testing.T) {
 			t.Fatalf("printLocalJSON error: %v", err)
 		}
 		var got []outputSkill
-		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		var wrapper struct {
+			Skills   []outputSkill `json:"skills"`
+			Packages []any         `json:"packages"`
+		}
+		if err := json.Unmarshal(buf.Bytes(), &wrapper); err != nil {
 			t.Fatalf("json.Unmarshal error: %v\nraw: %s", err, buf.String())
 		}
+		got = wrapper.Skills
 		if got[0].Targets == nil {
 			t.Error("targets should be [] not null")
 		}
 		if len(got[0].Targets) != 0 {
 			t.Errorf("targets = %v, want empty array", got[0].Targets)
+		}
+	})
+
+	t.Run("packages surface in dedicated section", func(t *testing.T) {
+		st := &state.State{Installed: map[string]state.InstalledSkill{
+			"gstack": {
+				Revision:   2,
+				Kind:       state.KindPackage,
+				InstallCmd: "./setup",
+				Sources:    []state.SkillSource{{Registry: "Naoray/gstack"}},
+			},
+			"plain": {Revision: 1},
+		}}
+		skills := []discovery.Skill{
+			{Name: "plain", ContentHash: "h", Targets: []string{"claude"}, Managed: true},
+			// gstack intentionally absent from discovery — packages live
+			// under ~/.scribe/packages/ which plain list_test doesn't stage.
+		}
+		var buf bytes.Buffer
+		if err := printLocalJSON(&buf, skills, st); err != nil {
+			t.Fatalf("printLocalJSON: %v", err)
+		}
+		var out struct {
+			Skills []struct {
+				Name string `json:"name"`
+			} `json:"skills"`
+			Packages []struct {
+				Name       string `json:"name"`
+				Revision   int    `json:"revision"`
+				InstallCmd string `json:"install_cmd"`
+			} `json:"packages"`
+		}
+		if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+			t.Fatalf("unmarshal: %v\nraw: %s", err, buf.String())
+		}
+		if len(out.Skills) != 1 || out.Skills[0].Name != "plain" {
+			t.Errorf("skills = %+v, want just plain", out.Skills)
+		}
+		if len(out.Packages) != 1 || out.Packages[0].Name != "gstack" {
+			t.Fatalf("packages = %+v, want gstack", out.Packages)
+		}
+		if out.Packages[0].InstallCmd != "./setup" {
+			t.Errorf("install_cmd = %q", out.Packages[0].InstallCmd)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Splits `~/.scribe/` into **`skills/`** (projected into tool skill dirs as today) and **`packages/`** (self-installing toolkits, never projected). Auto-detects via nested-SKILL-md / install-script heuristics — no config required.
- Fixes gstack-style leaks where dir-symlinking a whole package repo into `~/.codex/skills/gstack` made codex walk dozens of nested SKILL.md files (several with broken YAML frontmatter). Packages now self-install; scribe only tracks state.
- Migrates existing legacy package-style installs on next `sync`: moves `skills/<name>/` → `packages/<name>/`, removes stale tool symlinks, emits `PackageReclassifiedMsg`.

Design doc: [`docs/superpowers/specs/2026-04-17-packages-store-design.md`](./docs/superpowers/specs/2026-04-17-packages-store-design.md).

### What changed

- **State schema**: new `Kind` field (`skill` | `package`), legacy missing = `skill`, legacy `Type="package"` migrates in-place on load. `state.IsPackage()` helper.
- **Detection**: `sync.DetectKind(stagingDir)` — nested SKILL.md, or no root SKILL.md + install script → package.
- **Install**: `tools.WriteToPackageStore` + `sync.ResolvePackageInstall` / `RunPackageCommand`. Resolution order: `scribe.yaml` → `setup` → `install.sh` → `package.json` `scripts.install` → `Makefile install`. Non-zero exit → rollback.
- **Reconcile**: skips packages entirely; strips stale tool symlinks pointing at a package canonical.
- **Migration**: `ReclassifyLegacyPackages` gated by `state.Migrations` marker (idempotent).
- **List / remove**: JSON output splits into `skills` / `packages`; TUI detail pane shows `Tools: self-managed` + `Kind: package`; remove runs declared uninstall command before deletion.

### Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all 23 packages pass)
- [ ] Manual smoke: `scribe install Naoray/gstack` from a clean `~/.scribe/`, verify it lands in `packages/gstack/`, no symlink in `~/.codex/skills/`, codex no longer complains about nested SKILL.md.
- [ ] Manual smoke: existing gstack install migrates on next `scribe sync`, stale `~/.codex/skills/gstack` and `~/.claude/skills/gstack` links removed, `PackageReclassifiedMsg` surfaced.
- [ ] Manual smoke: `scribe remove gstack` for a package runs uninstall command and deletes `~/.scribe/packages/gstack/`.

### Deferred / follow-up

- List TUI table column still shows name only for packages; `self-managed` appears only in the detail pane. Skills (N) / Packages (N) section headers with separate tables is a follow-up.
- `ResolvePackageInstall` silently falls back to script detection on malformed `scribe.yaml` — surfacing a warning event would be nice.
- Explicit package `update` command (distinct from re-running `install`) — today `applyTreePackage` reuses `InstallCmd` on `StatusOutdated`; mirrors existing manifest-package `applyPackage` behavior but a proper `update` hook can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)