### PR TITLE
fix(version): fall back to debug.ReadBuildInfo for go install builds

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
@@ -15,7 +16,25 @@ import (
 )
 
 // Version is set at build time via ldflags.
-var Version = "dev"
+var Version = resolveVersion("dev", readBuildInfo())
+
+func readBuildInfo() *debug.BuildInfo {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+	return info
+}
+
+func resolveVersion(initial string, info *debug.BuildInfo) string {
+	if initial != "dev" || info == nil {
+		return initial
+	}
+	if version := info.Main.Version; version != "" && version != "(devel)" {
+		return version
+	}
+	return initial
+}
 
 func newCommandFactory() *app.Factory {
 	return app.NewFactory()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Version is set at build time via ldflags.
-var Version = resolveVersion("dev", readBuildInfo())
+var Version = "dev"
 
 func readBuildInfo() *debug.BuildInfo {
 	info, ok := debug.ReadBuildInfo()
@@ -54,7 +54,7 @@ func newRootCmd() *cobra.Command {
 		Use:           "scribe",
 		Short:         "Manage local AI coding agent skills",
 		Long:          "Scribe manages local AI coding agent skills and keeps shared team registries in sync.",
-		Version:       Version,
+		Version:       resolveVersion(Version, readBuildInfo()),
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -5,9 +5,58 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"testing"
 )
+
+func TestResolveVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial string
+		info    *debug.BuildInfo
+		want    string
+	}{
+		{
+			name:    "keeps ldflags version",
+			initial: "v1.2.3",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "v9.9.9"},
+			},
+			want: "v1.2.3",
+		},
+		{
+			name:    "uses module version for dev builds",
+			initial: "dev",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "v0.12.3"},
+			},
+			want: "v0.12.3",
+		},
+		{
+			name:    "keeps dev for local devel builds",
+			initial: "dev",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+			},
+			want: "dev",
+		},
+		{
+			name:    "keeps dev without build info",
+			initial: "dev",
+			info:    nil,
+			want:    "dev",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveVersion(tt.initial, tt.info); got != tt.want {
+				t.Fatalf("resolveVersion(%q) = %q, want %q", tt.initial, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestRoot_JSONFlag_StdoutIsCleanJSON_EvenDuringBuiltinsBackfill(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())


### PR DESCRIPTION
Closes #110.

When the binary was built via `go install github.com/Naoray/scribe/cmd/scribe@vX.Y.Z`, no ldflags are passed and `Version` stays at its default `dev`. Fall back to `debug.ReadBuildInfo().Main.Version` so the user sees the real module version they installed.

Brew / goreleaser builds keep their injected version. Local `go build` from a working tree still reports `dev` (or `(devel)` from build info) — that's expected.

## Test plan
- [x] go test ./... -count=1
- [x] go build ./...
- [x] go install via temporary local module proxy → scribe --version reports tag
- [x] local go build → scribe --version reports dev