### PR TITLE
feat: deny-list for explicitly removed skills

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/Naoray/scribe/internal/app"
 	"github.com/Naoray/scribe/internal/workflow"
 )
 
@@ -16,7 +17,7 @@ Without arguments, shows an interactive picker of all available skills.
 Pass skill names to install specific skills, or use --all to install everything.`,
 		Example: `  scribe install              # interactive picker
   scribe install tdd commit   # install specific skills
-  scribe install --all        # install everything available`,
+  scribe install --all        # install everything available, except skills you removed`,
 		RunE: runInstall,
 	}
 	cmd.Flags().Bool("all", false, "Install all available skills without prompting")
@@ -27,16 +28,61 @@ Pass skill names to install specific skills, or use --all to install everything.
 func runInstall(cmd *cobra.Command, args []string) error {
 	allFlag, _ := cmd.Flags().GetBool("all")
 	repoFlag, _ := cmd.Flags().GetString("registry")
+	factory := newCommandFactory()
+
+	if len(args) > 0 {
+		if err := clearRemovedBeforeInstall(factory, args, repoFlag); err != nil {
+			return err
+		}
+	}
 
 	bag := &workflow.Bag{
-		Args:           args,
-		InstallAllFlag: allFlag,
-		RepoFlag:       repoFlag,
-		Factory:        newCommandFactory(),
+		Args:             args,
+		InstallAllFlag:   allFlag,
+		RepoFlag:         repoFlag,
+		Factory:          factory,
 		FilterRegistries: filterRegistries,
 	}
 	if err := workflow.Run(cmd.Context(), workflow.InstallSteps(), bag); err != nil {
 		return err
 	}
 	return saveWorkflowState(bag)
+}
+
+func clearRemovedBeforeInstall(factory *app.Factory, names []string, repoFlag string) error {
+	if len(names) == 0 {
+		return nil
+	}
+	st, err := factory.State()
+	if err != nil {
+		return err
+	}
+
+	registry := ""
+	if repoFlag != "" {
+		cfg, err := factory.Config()
+		if err != nil {
+			return err
+		}
+		repos := make([]string, 0, len(cfg.Registries))
+		for _, r := range cfg.Registries {
+			repos = append(repos, r.Repo)
+		}
+		resolved, err := resolveRegistry(repoFlag, repos)
+		if err != nil {
+			return err
+		}
+		registry = resolved
+	}
+
+	changed := false
+	for _, name := range names {
+		if st.ClearRemovedByUser(name, registry) {
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	return st.Save()
 }

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/state"
+)
+
+func TestClearRemovedBeforeInstallClearsAllRegistriesForName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	st.RemovedByUser = []state.RemovedSkill{
+		{Name: "recap", Registry: "acme/skills"},
+		{Name: "recap", Registry: "other/skills"},
+		{Name: "deploy", Registry: "acme/skills"},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := clearRemovedBeforeInstall(newCommandFactory(), []string{"recap"}, ""); err != nil {
+		t.Fatalf("clearRemovedBeforeInstall: %v", err)
+	}
+
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load after clear: %v", err)
+	}
+	if loaded.IsRemovedByUser("acme/skills", "recap") || loaded.IsRemovedByUser("other/skills", "recap") {
+		t.Fatal("recap deny-list entries should be cleared across registries")
+	}
+	if !loaded.IsRemovedByUser("acme/skills", "deploy") {
+		t.Fatal("deploy deny-list entry should remain")
+	}
+}
+
+func TestClearRemovedBeforeInstallScopesRegistryFlag(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := &config.Config{
+		Registries: []config.RegistryConfig{
+			{Repo: "acme/skills", Enabled: true},
+			{Repo: "other/skills", Enabled: true},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("cfg.Save: %v", err)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	st.RemovedByUser = []state.RemovedSkill{
+		{Name: "recap", Registry: "acme/skills"},
+		{Name: "recap", Registry: "other/skills"},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := clearRemovedBeforeInstall(newCommandFactory(), []string{"recap"}, "acme/skills"); err != nil {
+		t.Fatalf("clearRemovedBeforeInstall: %v", err)
+	}
+
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load after clear: %v", err)
+	}
+	if loaded.IsRemovedByUser("acme/skills", "recap") {
+		t.Fatal("acme/skills recap entry should be cleared")
+	}
+	if !loaded.IsRemovedByUser("other/skills", "recap") {
+		t.Fatal("other/skills recap entry should remain")
+	}
+}

--- a/cmd/registry_forget.go
+++ b/cmd/registry_forget.go
@@ -62,6 +62,7 @@ func forgetRegistry(repo string) error {
 	}
 	cfg.Registries = kept
 	st.ClearRegistryFailure(resolved)
+	st.ClearRemovedByRegistry(resolved)
 
 	if err := cfg.Save(); err != nil {
 		return err

--- a/cmd/registry_forget_test.go
+++ b/cmd/registry_forget_test.go
@@ -27,6 +27,10 @@ func TestForgetRegistryRemovesConfigAndFailureState(t *testing.T) {
 		t.Fatalf("state.Load(): %v", err)
 	}
 	st.RecordRegistryFailure("acme/skills", nil, 3)
+	st.RemovedByUser = []state.RemovedSkill{
+		{Name: "recap", Registry: "acme/skills"},
+		{Name: "recap", Registry: "other/skills"},
+	}
 	if err := st.Save(); err != nil {
 		t.Fatalf("st.Save(): %v", err)
 	}
@@ -49,6 +53,12 @@ func TestForgetRegistryRemovesConfigAndFailureState(t *testing.T) {
 	}
 	if got := loadedState.RegistryFailure("acme/skills"); got.Consecutive != 0 {
 		t.Fatalf("registry failure not cleared: %+v", got)
+	}
+	if loadedState.IsRemovedByUser("acme/skills", "recap") {
+		t.Fatal("acme/skills deny-list entries should be cleared")
+	}
+	if !loadedState.IsRemovedByUser("other/skills", "recap") {
+		t.Fatal("other/skills deny-list entry should remain")
 	}
 }
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -29,8 +29,8 @@ func newRemoveCommand() *cobra.Command {
 		Long: `Remove a skill by name or full key (e.g. "deploy" or "Artistfy-hq/deploy").
 
 If the bare name is ambiguous across registries, an interactive picker is shown
-(or an error in non-TTY mode). Skills managed by a registry will be re-installed
-on the next sync unless the registry is disconnected.`,
+(or an error in non-TTY mode). Removing a registry-managed skill records that
+intent so future syncs keep it removed until you install it again.`,
 		Args: cobra.ExactArgs(1),
 		RunE: runRemove,
 	}
@@ -83,16 +83,15 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 	installed := st.Installed[key]
 
-	// Check if managed by a registry.
+	// Load config for tool resolution.
 	cfg, err := factory.Config()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
-	managedBy := findManagingRegistries(key, cfg.Registries)
+	managedBy := registriesFromSources(installed.Sources)
 
-	// Warn about registry re-install.
 	if len(managedBy) > 0 && !useJSON {
-		fmt.Fprintf(os.Stderr, "⚠  %s is managed by %s — it will re-install on next sync\n",
+		fmt.Fprintf(os.Stderr, "⚠  %s is managed by %s — future syncs will keep it removed until you install it again\n",
 			key, strings.Join(managedBy, ", "))
 	}
 
@@ -167,7 +166,8 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Remove from state and save.
+	// Remove from state, record registry removal intent, and save.
+	st.RecordRemovedByUser(key, installed.Sources)
 	st.Remove(key)
 	if err := st.Save(); err != nil {
 		return fmt.Errorf("save state: %w", err)
@@ -195,6 +195,20 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(os.Stderr, "Removed %s\n", key)
 	return nil
+}
+
+func registriesFromSources(sources []state.SkillSource) []string {
+	seen := map[string]bool{}
+	var registries []string
+	for _, src := range sources {
+		if src.Registry == "" || seen[src.Registry] {
+			continue
+		}
+		seen[src.Registry] = true
+		registries = append(registries, src.Registry)
+	}
+	sort.Strings(registries)
+	return registries
 }
 
 // resolveRemoveTarget matches input against installed skill keys.

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -182,3 +182,45 @@ func TestRunPackageUninstall_NoManifestNoop(t *testing.T) {
 		t.Errorf("expected no warnings, got %v", warnings)
 	}
 }
+
+func TestRemoveRecordsRemovalIntentForAllSources(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	st := &state.State{
+		SchemaVersion: 5,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Revision: 1,
+				Sources: []state.SkillSource{
+					{Registry: "acme/skills", Ref: "main"},
+					{Registry: "other/skills", Ref: "main"},
+				},
+				Tools: []string{},
+			},
+		},
+		RemovedByUser: []state.RemovedSkill{},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	cmd := newRemoveCommand()
+	cmd.SetArgs([]string{"recap", "--yes", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := loaded.Installed["recap"]; ok {
+		t.Fatal("recap should be removed from installed state")
+	}
+	if !loaded.IsRemovedByUser("acme/skills", "recap") {
+		t.Fatal("recap should be deny-listed for acme/skills")
+	}
+	if !loaded.IsRemovedByUser("other/skills", "recap") {
+		t.Fatal("recap should be deny-listed for other/skills")
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -17,12 +17,22 @@ import (
 
 // State is the contents of ~/.scribe/state.json.
 type State struct {
-	SchemaVersion      int                          `json:"schema_version"`
-	LastSync           time.Time                    `json:"last_sync,omitempty"`
-	Installed          map[string]InstalledSkill    `json:"installed"`
+	SchemaVersion int                       `json:"schema_version"`
+	LastSync      time.Time                 `json:"last_sync,omitempty"`
+	Installed     map[string]InstalledSkill `json:"installed"`
+	// Schema v5 is shared with the kits/snippets pivot; its projection, kit,
+	// and snippet indexes are additive siblings of this deny-list.
+	RemovedByUser      []RemovedSkill               `json:"removed_by_user"`
 	Migrations         map[string]bool              `json:"migrations,omitempty"`
 	RegistryFailures   map[string]RegistryFailure   `json:"registry_failures,omitempty"`
 	BinaryUpdateChecks map[string]BinaryUpdateCheck `json:"binary_update_checks,omitempty"`
+}
+
+// RemovedSkill records a user's intent not to reinstall a registry skill.
+type RemovedSkill struct {
+	Name      string    `json:"name"`
+	Registry  string    `json:"registry"`
+	RemovedAt time.Time `json:"removed_at"`
 }
 
 type BinaryUpdateCheck struct {
@@ -136,6 +146,7 @@ type legacyState struct {
 	Team               *legacyTeamState             `json:"team,omitempty"`
 	LastSync           *time.Time                   `json:"last_sync,omitempty"`
 	Installed          map[string]json.RawMessage   `json:"installed"`
+	RemovedByUser      []RemovedSkill               `json:"removed_by_user,omitempty"`
 	BinaryUpdateChecks map[string]BinaryUpdateCheck `json:"binary_update_checks,omitempty"`
 }
 
@@ -212,13 +223,13 @@ func Load() (*State, error) {
 
 	data, err := os.ReadFile(path)
 	if errors.Is(err, fs.ErrNotExist) {
-		return &State{SchemaVersion: 4, Installed: make(map[string]InstalledSkill), Migrations: map[string]bool{}, RegistryFailures: map[string]RegistryFailure{}, BinaryUpdateChecks: map[string]BinaryUpdateCheck{}}, nil
+		return &State{SchemaVersion: 5, Installed: make(map[string]InstalledSkill), RemovedByUser: []RemovedSkill{}, Migrations: map[string]bool{}, RegistryFailures: map[string]RegistryFailure{}, BinaryUpdateChecks: map[string]BinaryUpdateCheck{}}, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("read state: %w", err)
 	}
 	if len(bytes.TrimSpace(data)) == 0 {
-		return &State{SchemaVersion: 4, Installed: make(map[string]InstalledSkill), Migrations: map[string]bool{}, RegistryFailures: map[string]RegistryFailure{}, BinaryUpdateChecks: map[string]BinaryUpdateCheck{}}, nil
+		return &State{SchemaVersion: 5, Installed: make(map[string]InstalledSkill), RemovedByUser: []RemovedSkill{}, Migrations: map[string]bool{}, RegistryFailures: map[string]RegistryFailure{}, BinaryUpdateChecks: map[string]BinaryUpdateCheck{}}, nil
 	}
 	return parseAndMigrate(data)
 }
@@ -231,6 +242,7 @@ func Load() (*State, error) {
 //  5. Schema v3: bump the state schema while preserving existing Sources.
 //  6. Schema v4: normalize branch-backed LastSHA values to the locally cached
 //     SKILL.md blob SHA so blob-SHA diffs do not force needless reinstalls.
+//  7. Schema v5: initialize the user removal deny-list.
 func parseAndMigrate(data []byte) (*State, error) {
 	var legacy legacyState
 	if err := json.Unmarshal(data, &legacy); err != nil {
@@ -240,6 +252,7 @@ func parseAndMigrate(data []byte) (*State, error) {
 	s := &State{
 		SchemaVersion:      legacy.SchemaVersion,
 		Installed:          make(map[string]InstalledSkill, len(legacy.Installed)),
+		RemovedByUser:      append([]RemovedSkill(nil), legacy.RemovedByUser...),
 		Migrations:         map[string]bool{},
 		RegistryFailures:   map[string]RegistryFailure{},
 		BinaryUpdateChecks: map[string]BinaryUpdateCheck{},
@@ -356,6 +369,12 @@ func parseAndMigrate(data []byte) (*State, error) {
 		normalizeBranchSourceSHAs(s)
 		s.SchemaVersion = 4
 	}
+	if s.SchemaVersion < 5 {
+		if s.RemovedByUser == nil {
+			s.RemovedByUser = []RemovedSkill{}
+		}
+		s.SchemaVersion = 5
+	}
 	seedManagedPaths(s)
 
 	return s, nil
@@ -427,6 +446,86 @@ func (s *State) RecordInstall(name string, skill InstalledSkill) {
 // Remove deletes a skill from state (does not touch disk files).
 func (s *State) Remove(name string) {
 	delete(s.Installed, name)
+}
+
+// RecordRemovedByUser records user removal intent for each registry source.
+func (s *State) RecordRemovedByUser(name string, sources []SkillSource) {
+	if s.RemovedByUser == nil {
+		s.RemovedByUser = []RemovedSkill{}
+	}
+	now := time.Now().UTC()
+	for _, src := range sources {
+		if src.Registry == "" {
+			continue
+		}
+		replaced := false
+		for i := range s.RemovedByUser {
+			if s.RemovedByUser[i].Name == name && s.RemovedByUser[i].Registry == src.Registry {
+				s.RemovedByUser[i].RemovedAt = now
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			s.RemovedByUser = append(s.RemovedByUser, RemovedSkill{
+				Name:      name,
+				Registry:  src.Registry,
+				RemovedAt: now,
+			})
+		}
+	}
+}
+
+// IsRemovedByUser reports whether the registry/name pair is deny-listed.
+func (s *State) IsRemovedByUser(registry, name string) bool {
+	if s == nil {
+		return false
+	}
+	for _, removed := range s.RemovedByUser {
+		if removed.Registry == registry && removed.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ClearRemovedByUser removes deny-list entries for name. If registry is empty,
+// all registries for that name are cleared.
+func (s *State) ClearRemovedByUser(name, registry string) bool {
+	if s == nil || len(s.RemovedByUser) == 0 {
+		return false
+	}
+	kept := s.RemovedByUser[:0]
+	changed := false
+	for _, removed := range s.RemovedByUser {
+		matchName := removed.Name == name
+		matchRegistry := registry == "" || removed.Registry == registry
+		if matchName && matchRegistry {
+			changed = true
+			continue
+		}
+		kept = append(kept, removed)
+	}
+	s.RemovedByUser = kept
+	return changed
+}
+
+// ClearRemovedByRegistry removes all deny-list entries scoped to registry.
+func (s *State) ClearRemovedByRegistry(registry string) bool {
+	if s == nil || len(s.RemovedByUser) == 0 {
+		return false
+	}
+	kept := s.RemovedByUser[:0]
+	changed := false
+	for _, removed := range s.RemovedByUser {
+		if removed.Registry == registry {
+			changed = true
+			continue
+		}
+		kept = append(kept, removed)
+	}
+	s.RemovedByUser = kept
+	return changed
 }
 
 func (s *State) HasMigration(name string) bool {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -24,8 +24,8 @@ func TestLoadMissing(t *testing.T) {
 	if len(s.Installed) != 0 {
 		t.Errorf("expected empty Installed, got %d entries", len(s.Installed))
 	}
-	if s.SchemaVersion != 4 {
-		t.Errorf("expected SchemaVersion=4, got %d", s.SchemaVersion)
+	if s.SchemaVersion != 5 {
+		t.Errorf("expected SchemaVersion=5, got %d", s.SchemaVersion)
 	}
 	if s.BinaryUpdateChecks == nil {
 		t.Fatal("expected BinaryUpdateChecks to be initialized")
@@ -63,8 +63,8 @@ func TestSaveAndLoad(t *testing.T) {
 	if loaded.LastSync.IsZero() {
 		t.Error("expected LastSync to be set")
 	}
-	if loaded.SchemaVersion != 4 {
-		t.Errorf("expected SchemaVersion=4, got %d", loaded.SchemaVersion)
+	if loaded.SchemaVersion != 5 {
+		t.Errorf("expected SchemaVersion=5, got %d", loaded.SchemaVersion)
 	}
 
 	skill, ok := loaded.Installed["gstack"]
@@ -384,7 +384,85 @@ func TestRegistryFailureTracking(t *testing.T) {
 	}
 }
 
+func TestRemovedByUserRoundTripAndClear(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	st.RecordRemovedByUser("recap", []state.SkillSource{
+		{Registry: "acme/skills"},
+		{Registry: "other/skills"},
+	})
+	if !st.IsRemovedByUser("acme/skills", "recap") {
+		t.Fatal("expected recap to be removed for acme/skills")
+	}
+
+	if err := st.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load after save: %v", err)
+	}
+	if len(loaded.RemovedByUser) != 2 {
+		t.Fatalf("RemovedByUser len = %d, want 2", len(loaded.RemovedByUser))
+	}
+	if !loaded.ClearRemovedByUser("recap", "acme/skills") {
+		t.Fatal("ClearRemovedByUser scoped to registry = false, want true")
+	}
+	if loaded.IsRemovedByUser("acme/skills", "recap") {
+		t.Fatal("acme/skills recap entry should be cleared")
+	}
+	if !loaded.IsRemovedByUser("other/skills", "recap") {
+		t.Fatal("other/skills recap entry should remain")
+	}
+	if !loaded.ClearRemovedByRegistry("other/skills") {
+		t.Fatal("ClearRemovedByRegistry = false, want true")
+	}
+	if len(loaded.RemovedByUser) != 0 {
+		t.Fatalf("RemovedByUser len = %d, want 0", len(loaded.RemovedByUser))
+	}
+}
+
 // --- Migration tests ---
+
+func TestStateMigrateV4ToV5InitializesRemovedByUser(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".scribe")
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "state.json"), []byte(`{
+		"schema_version": 4,
+		"installed": {
+			"recap": {
+				"revision": 2,
+				"installed_hash": "abc",
+				"sources": [{"registry": "acme/skills", "ref": "main"}],
+				"installed_at": "2026-01-01T00:00:00Z",
+				"tools": ["claude"],
+				"paths": []
+			}
+		}
+	}`), 0o644)
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if st.SchemaVersion != 5 {
+		t.Fatalf("SchemaVersion = %d, want 5", st.SchemaVersion)
+	}
+	if st.RemovedByUser == nil {
+		t.Fatal("RemovedByUser is nil, want empty slice")
+	}
+	if len(st.RemovedByUser) != 0 {
+		t.Fatalf("RemovedByUser len = %d, want 0", len(st.RemovedByUser))
+	}
+}
 
 func TestMigrationNamespacesKeys(t *testing.T) {
 	home := t.TempDir()
@@ -436,8 +514,8 @@ func TestMigrationNamespacesKeys(t *testing.T) {
 		t.Errorf("expected Revision=1, got %d", skill.Revision)
 	}
 
-	if s.SchemaVersion != 4 {
-		t.Errorf("expected SchemaVersion=4, got %d", s.SchemaVersion)
+	if s.SchemaVersion != 5 {
+		t.Errorf("expected SchemaVersion=5, got %d", s.SchemaVersion)
 	}
 }
 
@@ -627,8 +705,8 @@ func TestStateMigrateV2ToV3(t *testing.T) {
 	if skill.Sources[0].Registry != "ArtistfyHQ/team-skills" || skill.Sources[0].LastSHA != "def456" {
 		t.Errorf("unexpected migrated sources: %v", skill.Sources)
 	}
-	if s.SchemaVersion != 4 {
-		t.Errorf("expected SchemaVersion=4, got %d", s.SchemaVersion)
+	if s.SchemaVersion != 5 {
+		t.Errorf("expected SchemaVersion=5, got %d", s.SchemaVersion)
 	}
 }
 
@@ -665,8 +743,8 @@ func TestMigrationSchemaV2(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	if s.SchemaVersion != 4 {
-		t.Errorf("expected SchemaVersion=4, got %d", s.SchemaVersion)
+	if s.SchemaVersion != 5 {
+		t.Errorf("expected SchemaVersion=5, got %d", s.SchemaVersion)
 	}
 
 	// Qualified key should become bare.
@@ -731,8 +809,8 @@ func TestMigrationPreservesRevisionAndHash(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	if s.SchemaVersion != 4 {
-		t.Errorf("SchemaVersion: got %d, want 4", s.SchemaVersion)
+	if s.SchemaVersion != 5 {
+		t.Errorf("SchemaVersion: got %d, want 5", s.SchemaVersion)
 	}
 	skill := s.Installed["gstack"]
 	if skill.Revision != 5 {
@@ -902,8 +980,8 @@ func TestMigrationBareKeyCollisionCollapses(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	if s.SchemaVersion != 4 {
-		t.Errorf("expected SchemaVersion 4, got %d", s.SchemaVersion)
+	if s.SchemaVersion != 5 {
+		t.Errorf("expected SchemaVersion 5, got %d", s.SchemaVersion)
 	}
 
 	// Should have exactly one "deploy" key, not two.
@@ -981,8 +1059,8 @@ func TestMigrationSchemaV4NormalizesBranchBlobSHA(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	if s.SchemaVersion != 4 {
-		t.Errorf("SchemaVersion: got %d, want 4", s.SchemaVersion)
+	if s.SchemaVersion != 5 {
+		t.Errorf("SchemaVersion: got %d, want 5", s.SchemaVersion)
 	}
 
 	xray, ok := s.Installed["xray"]
@@ -1034,7 +1112,7 @@ func TestMigrationSeedsManagedPathsFromPaths(t *testing.T) {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(`{
-		"schema_version": 4,
+		"schema_version": 5,
 		"installed": {
 			"recap": {
 				"revision": 1,
@@ -1067,7 +1145,7 @@ func TestMigrationSchemaV4Idempotent(t *testing.T) {
 	dir := filepath.Join(home, ".scribe")
 	os.MkdirAll(dir, 0o755)
 	os.WriteFile(filepath.Join(dir, "state.json"), []byte(`{
-		"schema_version": 4,
+		"schema_version": 5,
 		"last_sync": "2026-04-11T00:00:00Z",
 		"installed": {
 			"xray": {
@@ -1086,8 +1164,8 @@ func TestMigrationSchemaV4Idempotent(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	if s.SchemaVersion != 4 {
-		t.Errorf("SchemaVersion: got %d, want 4", s.SchemaVersion)
+	if s.SchemaVersion != 5 {
+		t.Errorf("SchemaVersion: got %d, want 5", s.SchemaVersion)
 	}
 	xray := s.Installed["xray"]
 	if len(xray.Sources) != 1 {
@@ -1176,7 +1254,7 @@ func TestOriginPreservedOnSchemaV4Load(t *testing.T) {
 	dir := filepath.Join(home, ".scribe")
 	os.MkdirAll(dir, 0o755)
 	os.WriteFile(filepath.Join(dir, "state.json"), []byte(`{
-		"schema_version": 4,
+		"schema_version": 5,
 		"installed": {
 			"my-adopted-skill": {
 				"revision": 2,

--- a/internal/sync/events.go
+++ b/internal/sync/events.go
@@ -146,6 +146,13 @@ type SkillInstalledMsg struct {
 // SkillSkippedMsg is sent when a skill is already current — no action needed.
 type SkillSkippedMsg struct{ Name string }
 
+// SkillSkippedByDenyListMsg is sent when a user removed a registry skill and
+// sync is preserving that removal intent.
+type SkillSkippedByDenyListMsg struct {
+	Name     string
+	Registry string
+}
+
 // SkillErrorMsg is sent when a skill fails to install. Sync continues.
 type SkillErrorMsg struct {
 	Name string

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -269,6 +269,11 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 			summary.Skipped++
 
 		case StatusMissing, StatusOutdated:
+			if st.IsRemovedByUser(teamRepo, sk.Name) {
+				s.emit(SkillSkippedByDenyListMsg{Name: sk.Name, Registry: teamRepo})
+				summary.Skipped++
+				continue
+			}
 			if sk.Status == StatusMissing && s.SkipMissing {
 				s.emit(SkillSkippedMsg{Name: sk.Name})
 				summary.Skipped++

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -95,6 +95,47 @@ func TestRunWithDiff_DoesNotOverwriteTargetReadme(t *testing.T) {
 	}
 }
 
+func TestRunWithDiff_SkipsRemovedByUser(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var events []any
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{
+			files: []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}},
+		},
+		Emit: func(msg any) { events = append(events, msg) },
+	}
+	st := &state.State{
+		Installed:     map[string]state.InstalledSkill{},
+		RemovedByUser: []state.RemovedSkill{{Name: "recap", Registry: "acme/skills", RemovedAt: time.Now()}},
+	}
+	statuses := []sync.SkillStatus{{
+		Name:   "recap",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "recap", Source: "github:acme/skills@main"},
+	}}
+
+	if err := syncer.RunWithDiff(context.Background(), "acme/skills", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+	if _, ok := st.Installed["recap"]; ok {
+		t.Fatal("recap should not be installed when deny-listed")
+	}
+
+	found := false
+	for _, ev := range events {
+		if msg, ok := ev.(sync.SkillSkippedByDenyListMsg); ok {
+			found = true
+			if msg.Name != "recap" || msg.Registry != "acme/skills" {
+				t.Fatalf("deny-list skip msg = %+v", msg)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected SkillSkippedByDenyListMsg")
+	}
+}
+
 func TestApply_PackageMissing_Approved(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -136,6 +136,43 @@ func TestRunWithDiff_SkipsRemovedByUser(t *testing.T) {
 	}
 }
 
+func TestRunWithDiff_RemovedByUserIsRegistryScoped(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{
+			files: []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}},
+		},
+	}
+	st := &state.State{
+		Installed:     map[string]state.InstalledSkill{},
+		RemovedByUser: []state.RemovedSkill{{Name: "recap", Registry: "acme/skills", RemovedAt: time.Now()}},
+	}
+	statuses := []sync.SkillStatus{{
+		Name:   "recap",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "recap", Source: "github:example/registry@main"},
+	}}
+
+	if err := syncer.RunWithDiff(context.Background(), "acme/skills", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff acme: %v", err)
+	}
+	if _, ok := st.Installed["recap"]; ok {
+		t.Fatal("recap should not install from deny-listed acme/skills")
+	}
+
+	if err := syncer.RunWithDiff(context.Background(), "other/skills", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff other: %v", err)
+	}
+	installed, ok := st.Installed["recap"]
+	if !ok {
+		t.Fatal("recap should install from other/skills")
+	}
+	if len(installed.Sources) != 1 || installed.Sources[0].Registry != "other/skills" {
+		t.Fatalf("installed sources = %+v, want other/skills", installed.Sources)
+	}
+}
+
 func TestApply_PackageMissing_Approved(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/workflow/formatter.go
+++ b/internal/workflow/formatter.go
@@ -17,6 +17,7 @@ type Formatter interface {
 	OnSkillDownloading(name string)
 	OnSkillInstalled(name string, updated bool)
 	OnSkillSkipped(name string, status sync.SkillStatus)
+	OnSkillSkippedByDenyList(name, registry string)
 	OnSkillError(name string, err error)
 	OnSyncComplete(summary sync.SyncCompleteMsg)
 	OnReconcileConflict(name string, conflict state.ProjectionConflict)

--- a/internal/workflow/formatter_json.go
+++ b/internal/workflow/formatter_json.go
@@ -14,6 +14,7 @@ type jsonFormatter struct {
 	registries []registryResult
 	current    *registryResult
 	summary    sync.SyncCompleteMsg
+	denied     []denyListSkip
 	adoption   adoptionResult
 	reconcile  *reconcileResult
 }
@@ -46,6 +47,11 @@ type skillResult struct {
 	Status  string `json:"status,omitempty"`
 	Version string `json:"version,omitempty"`
 	Error   string `json:"error,omitempty"`
+}
+
+type denyListSkip struct {
+	Name     string `json:"name"`
+	Registry string `json:"registry"`
 }
 
 type registryResult struct {
@@ -96,6 +102,18 @@ func (f *jsonFormatter) OnSkillSkipped(name string, status sync.SkillStatus) {
 		Action:  "skipped",
 		Status:  status.Status.String(),
 		Version: ver,
+	})
+}
+
+func (f *jsonFormatter) OnSkillSkippedByDenyList(name, registry string) {
+	f.denied = append(f.denied, denyListSkip{Name: name, Registry: registry})
+	if f.current == nil {
+		return
+	}
+	f.current.Skills = append(f.current.Skills, skillResult{
+		Name:   name,
+		Action: "skipped",
+		Status: "removed_by_user",
 	})
 }
 
@@ -266,6 +284,9 @@ func (f *jsonFormatter) Flush() error {
 	}
 	if f.reconcile != nil {
 		out["reconcile"] = f.reconcile
+	}
+	if len(f.denied) > 0 {
+		out["skipped_by_deny_list"] = f.denied
 	}
 	return json.NewEncoder(f.out).Encode(out)
 }

--- a/internal/workflow/formatter_test.go
+++ b/internal/workflow/formatter_test.go
@@ -76,8 +76,9 @@ func TestJSONFormatter(t *testing.T) {
 		Status:    sync.StatusCurrent,
 		Installed: &state.InstalledSkill{Revision: 2},
 	})
+	fmtr.OnSkillSkippedByDenyList("removed", "acme/skills")
 	fmtr.OnSkillError("broken", fmt.Errorf("download failed"))
-	fmtr.OnSyncComplete(sync.SyncCompleteMsg{Installed: 1, Skipped: 1, Failed: 1})
+	fmtr.OnSyncComplete(sync.SyncCompleteMsg{Installed: 1, Skipped: 2, Failed: 1})
 
 	if err := fmtr.Flush(); err != nil {
 		t.Fatalf("Flush() error: %v", err)
@@ -99,12 +100,19 @@ func TestJSONFormatter(t *testing.T) {
 	}
 
 	skills := reg["skills"].([]any)
-	if len(skills) != 3 {
-		t.Errorf("expected 3 skills, got %d", len(skills))
+	if len(skills) != 4 {
+		t.Errorf("expected 4 skills, got %d", len(skills))
 	}
 
 	summary := result["summary"].(map[string]any)
 	if summary["installed"].(float64) != 1 {
 		t.Errorf("expected installed=1, got: %v", summary["installed"])
+	}
+	denied := result["skipped_by_deny_list"].([]any)
+	if len(denied) != 1 {
+		t.Fatalf("expected 1 deny-list skip, got %d", len(denied))
+	}
+	if denied[0].(map[string]any)["name"] != "removed" {
+		t.Fatalf("unexpected deny-list skip payload: %v", denied[0])
 	}
 }

--- a/internal/workflow/formatter_text.go
+++ b/internal/workflow/formatter_text.go
@@ -56,6 +56,10 @@ func (f *textFormatter) OnSkillSkipped(name string, status sync.SkillStatus) {
 	fmt.Fprintf(f.out, "  %-20s ok (%s)\n", name, ver)
 }
 
+func (f *textFormatter) OnSkillSkippedByDenyList(name, registry string) {
+	fmt.Fprintf(f.out, "  %-20s skipped (removed by user from %s)\n", name, registry)
+}
+
 func (f *textFormatter) OnSkillError(name string, err error) {
 	fmt.Fprintf(f.errOut, "  %-20s error: %v\n", name, err)
 }

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -279,6 +279,8 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 				b.Formatter.OnSkillResolved(m.Name, m.SkillStatus)
 			case sync.SkillSkippedMsg:
 				b.Formatter.OnSkillSkipped(m.Name, resolved[m.Name])
+			case sync.SkillSkippedByDenyListMsg:
+				b.Formatter.OnSkillSkippedByDenyList(m.Name, m.Registry)
 			case sync.SkillDownloadingMsg:
 				b.Formatter.OnSkillDownloading(m.Name)
 			case sync.SkillInstalledMsg:

--- a/internal/workflow/sync_adopt_test.go
+++ b/internal/workflow/sync_adopt_test.go
@@ -47,6 +47,7 @@ func (r *adoptRecorder) OnSkillResolved(_ string, _ isync.SkillStatus)          
 func (r *adoptRecorder) OnSkillDownloading(_ string)                              {}
 func (r *adoptRecorder) OnSkillInstalled(_ string, _ bool)                        {}
 func (r *adoptRecorder) OnSkillSkipped(_ string, _ isync.SkillStatus)             {}
+func (r *adoptRecorder) OnSkillSkippedByDenyList(_, _ string)                     {}
 func (r *adoptRecorder) OnSkillError(_ string, _ error)                           {}
 func (r *adoptRecorder) OnSyncComplete(_ isync.SyncCompleteMsg)                   {}
 func (r *adoptRecorder) OnReconcileConflict(_ string, _ state.ProjectionConflict) {}


### PR DESCRIPTION
Closes solo todo #458.\n\n`scribe remove` now means "remove and don't bring back unless I ask." The next `scribe sync` no longer reinstalls registry-managed skills the user explicitly removed.\n\n## Schema migration\n- state.json schema v4 → v5\n- Adds top-level `removed_by_user []RemovedSkill` (each entry keyed on `(registry, name)`)\n- Migration is additive; missing field → empty slice on read\n- **Note:** Coordinated with the parallel kits/snippets pivot (todo #368) which also bumps to v5 with projection/kit indexes — both ship as additive v5 changes. Follow-up todo filed.\n\n## Behavior\n- `scribe remove <name>` writes entries (one per registry source)\n- `scribe sync` skips deny-listed entries; `--json` reports them under `skipped_by_deny_list`\n- `scribe install <name>` removes matching entries (re-affirms intent)\n- `scribe registry forget <r>` clears entries scoped to that registry\n\n## Test plan\n- [x] go test ./... -count=1\n- [x] manual: install foo, remove foo --yes, sync → not reinstalled\n- [x] manual: install foo again → deny-list entry cleared, foo back