### PR TITLE
feat(cli): agent-first foundation packages (PR A of 3)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -63,7 +63,7 @@ Examples:
 	cmd.Flags().Bool("yes", false, "Skip confirmation prompts")
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.Flags().String("registry", "", "Limit search to a specific registry (owner/repo)")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func runAdd(cmd *cobra.Command, args []string) error {

--- a/cmd/adopt.go
+++ b/cmd/adopt.go
@@ -41,7 +41,7 @@ Examples:
 	cmd.Flags().Bool("dry-run", false, "Print plan without writing anything")
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.Flags().Bool("verbose", false, "Include paths and hashes in plan output")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func runAdopt(cmd *cobra.Command, args []string) error {

--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -34,7 +34,7 @@ func newBrowseCommand() *cobra.Command {
 	cmd.Flags().String("install", "", "Install a skill by exact name or owner/repo:skill")
 	cmd.Flags().String("registry", "", "Limit browse/install to one connected registry")
 	cmd.Flags().Bool("yes", false, "Skip confirmation prompt")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func runBrowse(cmd *cobra.Command, _ []string) error {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -39,7 +39,7 @@ Examples:
 	cmd.Flags().Bool("fix", false, "Normalize canonical skill metadata and repair affected projections")
 	cmd.Flags().String("skill", "", "Inspect a single managed skill")
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 type doctorIssueJSON struct {
@@ -63,7 +63,7 @@ type doctorFixResult struct {
 }
 
 type doctorSkillSnapshot struct {
-	Name        string
+	Name         string
 	Installed    state.InstalledSkill
 	SkillContent []byte
 	BaseContent  []byte

--- a/cmd/envFromArgs.go
+++ b/cmd/envFromArgs.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+
+	clienv "github.com/Naoray/scribe/internal/cli/env"
+)
+
+func envFromArgs(args []string) clienv.Mode {
+	jsonFlag := false
+	for _, arg := range args {
+		if arg == "--json" || strings.HasPrefix(arg, "--json=") {
+			jsonFlag = true
+			break
+		}
+	}
+	return clienv.Detect(os.Stdout, os.Stdin, jsonFlag)
+}

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -49,13 +49,15 @@ Falls back to rendering the SKILL.md directly if no LLM is available.`,
 	}
 	cmd.Flags().Bool("json", false, "Output structured JSON (for agents/scripts)")
 	cmd.Flags().Bool("raw", false, "Show rendered SKILL.md directly, skip AI explanation")
-	cmd.MarkFlagsMutuallyExclusive("json", "raw")
 	return cmd
 }
 
 func runExplain(cmd *cobra.Command, args []string) error {
 	jsonFlag, _ := cmd.Flags().GetBool("json")
 	rawFlag, _ := cmd.Flags().GetBool("raw")
+	if jsonFlag && rawFlag {
+		return fmt.Errorf("if any flags in the group [json raw] are set none of the others can be; [json raw] were all set")
+	}
 	factory := newCommandFactory()
 
 	st, err := factory.State()

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -49,7 +49,7 @@ Falls back to rendering the SKILL.md directly if no LLM is available.`,
 	}
 	cmd.Flags().Bool("json", false, "Output structured JSON (for agents/scripts)")
 	cmd.Flags().Bool("raw", false, "Show rendered SKILL.md directly, skip AI explanation")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func runExplain(cmd *cobra.Command, args []string) error {

--- a/cmd/guide.go
+++ b/cmd/guide.go
@@ -30,7 +30,7 @@ Examples:
 		RunE: runGuide,
 	}
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON (for CI/agents)")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 // Styles for guide output — kept local to cmd/ per architecture.

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -31,7 +31,7 @@ Examples:
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.Flags().Bool("remote", false, "Show available skills from registries (not installed)")
 	cmd.Flags().String("registry", "", "Show only this registry (owner/repo or repo name)")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func runList(cmd *cobra.Command, args []string) error {

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -24,7 +24,7 @@ func newRegistryCommand() *cobra.Command {
 	cmd.AddCommand(newRegistryAddCommand())
 	cmd.AddCommand(newRegistryCreateCommand())
 	cmd.AddCommand(newRegistryMigrateCommand())
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 // newRegistryMigrateCommand wires `scribe registry migrate` to the existing

--- a/cmd/registry_add.go
+++ b/cmd/registry_add.go
@@ -47,7 +47,7 @@ Examples:
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.Flags().String("registry", "", "Target registry (owner/repo)")
 	cmd.Flags().StringArray("install", nil, "Per-tool install command for package refs (tool=command, repeatable)")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func runRegistryAdd(cmd *cobra.Command, args []string) error {

--- a/cmd/registry_list.go
+++ b/cmd/registry_list.go
@@ -16,7 +16,7 @@ func newRegistryListCommand() *cobra.Command {
 		RunE:  runRegistryList,
 	}
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func runRegistryList(cmd *cobra.Command, args []string) error {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -36,7 +36,7 @@ intent so future syncs keep it removed until you install it again.`,
 	}
 	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 // removeResult is the JSON output for `scribe remove`.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -195,6 +195,7 @@ func newRootCmd() *cobra.Command {
 		newSyncCommand(),
 		newAdoptCommand(),
 		newStatusCommand(),
+		newSchemaCommand(cmd),
 		newResolveCommand(),
 		newRestoreCommand(),
 		newSkillCommand(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/mattn/go-isatty"
@@ -48,6 +49,8 @@ func newCommandFactory() *app.Factory {
 
 var rootCmd = newRootCmd()
 
+const jsonSupportedAnnotation = "json_supported"
+
 func Execute() {
 	err := rootCmd.Execute()
 	mode := envFromArgs(os.Args)
@@ -82,6 +85,15 @@ func newRootCmd() *cobra.Command {
 			ctx = context.WithValue(ctx, envelope.ScribeVersionKey, resolveVersion(Version, readBuildInfo()))
 			ctx = context.WithValue(ctx, envelope.CommandPathKey, c.CommandPath())
 			c.SetContext(ctx)
+
+			if jsonFlagPassed(c) && !commandSupportsJSON(c) {
+				return &clierrors.Error{
+					Code:        "JSON_NOT_SUPPORTED",
+					Message:     c.CommandPath() + " does not support --json yet",
+					Remediation: "scribe schema --all --json | jq 'keys' lists JSON-capable commands; this command is on the wave-3 migration list (see solo todo #469)",
+					Exit:        clierrors.ExitUsage,
+				}
+			}
 
 			if c.Name() == "help" || c.Name() == "version" || c.Name() == "migrate" || c.Name() == "upgrade" {
 				return nil
@@ -173,6 +185,7 @@ func newRootCmd() *cobra.Command {
 	}
 
 	cmd.RunE = runDefault
+	markJSONSupported(cmd)
 	cmd.PersistentFlags().Bool("json", false, "Output machine-readable JSON")
 	cmd.CompletionOptions = cobra.CompletionOptions{HiddenDefaultCmd: true}
 
@@ -224,7 +237,54 @@ func classifyExecuteError(err error) error {
 	if stderrors.As(err, &ce) {
 		return err
 	}
-	return clierrors.Wrap(err, "USAGE", clierrors.ExitUsage, clierrors.WithRemediation("run `scribe --help`"))
+	if isCobraUsageErr(err) {
+		return clierrors.Wrap(err, "USAGE", clierrors.ExitUsage,
+			clierrors.WithMessage(err.Error()),
+			clierrors.WithRemediation("scribe --help"),
+		)
+	}
+	return clierrors.Wrap(err, "GENERAL", clierrors.ExitGeneral, clierrors.WithMessage(err.Error()))
+}
+
+func isCobraUsageErr(err error) bool {
+	msg := err.Error()
+	for _, prefix := range []string{
+		"unknown command ",
+		"unknown flag ",
+		"unknown flag:",
+		"unknown shorthand flag",
+		"flag provided but not defined",
+		"required flag(s) ",
+		"accepts ",
+		"requires ",
+	} {
+		if strings.HasPrefix(msg, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func markJSONSupported(cmd *cobra.Command) *cobra.Command {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[jsonSupportedAnnotation] = "true"
+	return cmd
+}
+
+func jsonFlagPassed(cmd *cobra.Command) bool {
+	if root := cmd.Root(); root != nil {
+		if flag := root.PersistentFlags().Lookup("json"); flag != nil && flag.Changed {
+			return true
+		}
+	}
+	flag := cmd.Flag("json")
+	return flag != nil && flag.Changed
+}
+
+func commandSupportsJSON(cmd *cobra.Command) bool {
+	return cmd.Annotations[jsonSupportedAnnotation] == "true"
 }
 
 func wrapRunECommands(cmd *cobra.Command) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,15 +1,21 @@
 package cmd
 
 import (
+	"context"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"runtime/debug"
+	"time"
 
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
 	"github.com/Naoray/scribe/internal/agent"
 	"github.com/Naoray/scribe/internal/app"
+	"github.com/Naoray/scribe/internal/cli/envelope"
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/Naoray/scribe/internal/cli/output"
 	"github.com/Naoray/scribe/internal/firstrun"
 	"github.com/Naoray/scribe/internal/storemigrate"
 	"github.com/Naoray/scribe/internal/tools"
@@ -43,10 +49,23 @@ func newCommandFactory() *app.Factory {
 var rootCmd = newRootCmd()
 
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	err := rootCmd.Execute()
+	mode := envFromArgs(os.Args)
+	r := output.New(mode, os.Stdout, os.Stderr)
+	if err != nil {
+		err = classifyExecuteError(err)
+		var ce *clierrors.Error
+		if stderrors.As(err, &ce) {
+			_ = r.Error(ce)
+			if ce.Exit == clierrors.ExitOK {
+				ce.Exit = clierrors.ExitGeneral
+			}
+			os.Exit(ce.Exit)
+		}
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		os.Exit(clierrors.ExitGeneral)
 	}
+	_ = r.Flush()
 }
 
 func newRootCmd() *cobra.Command {
@@ -59,6 +78,11 @@ func newRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
+			ctx := context.WithValue(c.Context(), envelope.BootstrapStartKey, time.Now())
+			ctx = context.WithValue(ctx, envelope.ScribeVersionKey, resolveVersion(Version, readBuildInfo()))
+			ctx = context.WithValue(ctx, envelope.CommandPathKey, c.CommandPath())
+			c.SetContext(ctx)
+
 			if c.Name() == "help" || c.Name() == "version" || c.Name() == "migrate" || c.Name() == "upgrade" {
 				return nil
 			}
@@ -149,7 +173,7 @@ func newRootCmd() *cobra.Command {
 	}
 
 	cmd.RunE = runDefault
-	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	cmd.PersistentFlags().Bool("json", false, "Output machine-readable JSON")
 	cmd.CompletionOptions = cobra.CompletionOptions{HiddenDefaultCmd: true}
 
 	aliasConnect := newConnectCommand()
@@ -189,7 +213,50 @@ func newRootCmd() *cobra.Command {
 		newUpgradeAgentCommand(),
 	)
 
+	wrapRunECommands(cmd)
+
 	return cmd
+}
+
+func classifyExecuteError(err error) error {
+	var ce *clierrors.Error
+	if stderrors.As(err, &ce) {
+		return err
+	}
+	return clierrors.Wrap(err, "USAGE", clierrors.ExitUsage, clierrors.WithRemediation("run `scribe --help`"))
+}
+
+func wrapRunECommands(cmd *cobra.Command) {
+	if cmd.RunE != nil {
+		cmd.RunE = wrapRunE(cmd.RunE)
+	}
+	for _, child := range cmd.Commands() {
+		wrapRunECommands(child)
+	}
+}
+
+func wrapRunE(fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		runStart := time.Now()
+		ctx := context.WithValue(cmd.Context(), envelope.RunEStartKey, runStart)
+		cmd.SetContext(ctx)
+
+		err := fn(cmd, args)
+
+		duration := time.Since(runStart).Milliseconds()
+		bootstrap := int64(0)
+		if start, ok := cmd.Context().Value(envelope.BootstrapStartKey).(time.Time); ok {
+			bootstrap = runStart.Sub(start).Milliseconds()
+			if bootstrap < 0 {
+				bootstrap = 0
+			}
+		}
+		ctx = context.WithValue(cmd.Context(), envelope.DurationMSKey, duration)
+		ctx = context.WithValue(ctx, envelope.BootstrapMSKey, bootstrap)
+		cmd.SetContext(ctx)
+
+		return err
+	}
 }
 
 // runStoreMigration executes the v1 → v2 on-disk migration if the marker is

--- a/cmd/root_exit_test.go
+++ b/cmd/root_exit_test.go
@@ -15,18 +15,24 @@ func TestRootExitSubprocessMatrix(t *testing.T) {
 		args       []string
 		wantCode   int
 		wantJSON   bool
+		wantErr    string
 		wantStdout string
+		stdoutJSON bool
+		badHome    bool
 	}{
-		{name: "unknown command json", args: []string{"--json", "nope"}, wantCode: 2, wantJSON: true},
-		{name: "bad flag json", args: []string{"--json", "--bad"}, wantCode: 2, wantJSON: true},
+		{name: "unknown command json", args: []string{"--json", "nope"}, wantCode: 2, wantJSON: true, wantErr: "USAGE"},
+		{name: "bad flag json", args: []string{"--json", "--bad"}, wantCode: 2, wantJSON: true, wantErr: "USAGE"},
 		{name: "help", args: []string{"--help"}, wantCode: 0, wantStdout: "Scribe manages local AI coding agent skills"},
 		{name: "version", args: []string{"--version"}, wantCode: 0, wantStdout: "scribe version"},
-		{name: "pre-run failure json", args: []string{"--json", "list"}, wantCode: 2, wantJSON: true},
+		{name: "operational pre-run failure json", args: []string{"--json", "list"}, wantCode: 1, wantJSON: true, wantErr: "GENERAL", badHome: true},
+		{name: "json unsupported config adoption", args: []string{"--json", "config", "adoption"}, wantCode: 2, wantJSON: true, wantErr: "JSON_NOT_SUPPORTED"},
+		{name: "json unsupported resolve", args: []string{"--json", "resolve", "recap"}, wantCode: 2, wantJSON: true, wantErr: "JSON_NOT_SUPPORTED"},
+		{name: "json supported schema list", args: []string{"--json", "schema", "list"}, wantCode: 0, stdoutJSON: true},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			stdout, stderr, code := runScribeHelper(t, tt.args, tt.name == "pre-run failure json")
+			stdout, stderr, code := runScribeHelper(t, tt.args, tt.badHome)
 			if code != tt.wantCode {
 				t.Fatalf("exit = %d, want %d\nstdout=%s\nstderr=%s", code, tt.wantCode, stdout, stderr)
 			}
@@ -37,6 +43,25 @@ func TestRootExitSubprocessMatrix(t *testing.T) {
 				}
 				if env["status"] != "error" || env["format_version"] != "1" {
 					t.Fatalf("unexpected envelope: %#v", env)
+				}
+				if tt.wantErr != "" {
+					errObj, ok := env["error"].(map[string]any)
+					if !ok {
+						t.Fatalf("envelope missing error object: %#v", env)
+					}
+					if got := errObj["code"]; got != tt.wantErr {
+						t.Fatalf("error code = %v, want %s\nenvelope=%#v", got, tt.wantErr, env)
+					}
+				}
+				return
+			}
+			if tt.stdoutJSON {
+				var env map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); err != nil {
+					t.Fatalf("stdout is not JSON: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+				}
+				if _, ok := env["input_schema"]; !ok {
+					t.Fatalf("schema JSON missing input_schema: %#v", env)
 				}
 				return
 			}
@@ -50,13 +75,14 @@ func TestRootExitSubprocessMatrix(t *testing.T) {
 func runScribeHelper(t *testing.T, args []string, badHome bool) (string, string, int) {
 	t.Helper()
 	cmd := exec.Command(os.Args[0], append([]string{"-test.run=TestScribeHelperProcess", "--"}, args...)...)
-	cmd.Env = append(os.Environ(), "GO_WANT_SCRIBE_HELPER_PROCESS=1")
+	home := t.TempDir()
+	cmd.Env = append(os.Environ(), "GO_WANT_SCRIBE_HELPER_PROCESS=1", "HOME="+home)
 	if badHome {
-		home := filepath.Join(t.TempDir(), "home-file")
-		if err := os.WriteFile(home, []byte("not a dir"), 0o644); err != nil {
+		homeFile := filepath.Join(t.TempDir(), "home-file")
+		if err := os.WriteFile(homeFile, []byte("not a dir"), 0o644); err != nil {
 			t.Fatalf("write home file: %v", err)
 		}
-		cmd.Env = append(cmd.Env, "HOME="+home)
+		cmd.Env = append(cmd.Env, "HOME="+homeFile)
 	}
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
@@ -80,6 +106,7 @@ func TestScribeHelperProcess(t *testing.T) {
 		if arg == "--" {
 			os.Args = append([]string{"scribe"}, os.Args[i+1:]...)
 			Execute()
+			os.Exit(0)
 			return
 		}
 	}

--- a/cmd/root_exit_test.go
+++ b/cmd/root_exit_test.go
@@ -60,8 +60,32 @@ func TestRootExitSubprocessMatrix(t *testing.T) {
 				if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); err != nil {
 					t.Fatalf("stdout is not JSON: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
 				}
-				if _, ok := env["input_schema"]; !ok {
-					t.Fatalf("schema JSON missing input_schema: %#v", env)
+				if env["status"] != "ok" || env["format_version"] != "1" {
+					t.Fatalf("unexpected success envelope: %#v", env)
+				}
+				data, ok := env["data"].(map[string]any)
+				if !ok {
+					t.Fatalf("envelope missing data object: %#v", env)
+				}
+				if _, ok := data["input_schema"]; !ok {
+					t.Fatalf("schema data missing input_schema: %#v", env)
+				}
+				if _, ok := data["output_schema"]; !ok {
+					t.Fatalf("schema data missing output_schema: %#v", env)
+				}
+				if _, ok := env["input_schema"]; ok {
+					t.Fatalf("schema leaked input_schema at top level: %#v", env)
+				}
+				meta, ok := env["meta"].(map[string]any)
+				if !ok {
+					t.Fatalf("envelope missing meta object: %#v", env)
+				}
+				if got := meta["command"]; got != "scribe schema list" {
+					t.Fatalf("meta.command = %v, want scribe schema list\nenvelope=%#v", got, env)
+				}
+				duration, ok := meta["duration_ms"].(float64)
+				if !ok || duration < 0 {
+					t.Fatalf("meta.duration_ms = %v, want number >= 0\nenvelope=%#v", meta["duration_ms"], env)
 				}
 				return
 			}

--- a/cmd/root_exit_test.go
+++ b/cmd/root_exit_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRootExitSubprocessMatrix(t *testing.T) {
+	cases := []struct {
+		name       string
+		args       []string
+		wantCode   int
+		wantJSON   bool
+		wantStdout string
+	}{
+		{name: "unknown command json", args: []string{"--json", "nope"}, wantCode: 2, wantJSON: true},
+		{name: "bad flag json", args: []string{"--json", "--bad"}, wantCode: 2, wantJSON: true},
+		{name: "help", args: []string{"--help"}, wantCode: 0, wantStdout: "Scribe manages local AI coding agent skills"},
+		{name: "version", args: []string{"--version"}, wantCode: 0, wantStdout: "scribe version"},
+		{name: "pre-run failure json", args: []string{"--json", "list"}, wantCode: 2, wantJSON: true},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr, code := runScribeHelper(t, tt.args, tt.name == "pre-run failure json")
+			if code != tt.wantCode {
+				t.Fatalf("exit = %d, want %d\nstdout=%s\nstderr=%s", code, tt.wantCode, stdout, stderr)
+			}
+			if tt.wantJSON {
+				var env map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(stderr)), &env); err != nil {
+					t.Fatalf("stderr is not JSON envelope: %v\nstderr=%s\nstdout=%s", err, stderr, stdout)
+				}
+				if env["status"] != "error" || env["format_version"] != "1" {
+					t.Fatalf("unexpected envelope: %#v", env)
+				}
+				return
+			}
+			if tt.wantStdout != "" && !strings.Contains(stdout, tt.wantStdout) {
+				t.Fatalf("stdout = %q, want contains %q", stdout, tt.wantStdout)
+			}
+		})
+	}
+}
+
+func runScribeHelper(t *testing.T, args []string, badHome bool) (string, string, int) {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], append([]string{"-test.run=TestScribeHelperProcess", "--"}, args...)...)
+	cmd.Env = append(os.Environ(), "GO_WANT_SCRIBE_HELPER_PROCESS=1")
+	if badHome {
+		home := filepath.Join(t.TempDir(), "home-file")
+		if err := os.WriteFile(home, []byte("not a dir"), 0o644); err != nil {
+			t.Fatalf("write home file: %v", err)
+		}
+		cmd.Env = append(cmd.Env, "HOME="+home)
+	}
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		return stdout.String(), stderr.String(), 0
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("helper run: %v", err)
+	}
+	return stdout.String(), stderr.String(), exitErr.ExitCode()
+}
+
+func TestScribeHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_SCRIBE_HELPER_PROCESS") != "1" {
+		return
+	}
+	for i, arg := range os.Args {
+		if arg == "--" {
+			os.Args = append([]string{"scribe"}, os.Args[i+1:]...)
+			Execute()
+			return
+		}
+	}
+	os.Exit(2)
+}

--- a/cmd/root_flags_test.go
+++ b/cmd/root_flags_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRootFlags(t *testing.T) {
+	root := newRootCmd()
+	walkCommands(t, root, func(cmd *cobra.Command) {
+		if cmd.Root().PersistentFlags().Lookup("json") == nil {
+			t.Fatalf("%s: root missing persistent --json", cmd.CommandPath())
+		}
+		if cmd.Flags().Lookup("fields") != nil {
+			t.Fatalf("%s: unexpected --fields; use output.AttachFieldsFlag for opt-in commands", cmd.CommandPath())
+		}
+	})
+}
+
+func walkCommands(t *testing.T, cmd *cobra.Command, visit func(*cobra.Command)) {
+	t.Helper()
+	visit(cmd)
+	for _, child := range cmd.Commands() {
+		walkCommands(t, child, visit)
+	}
+}

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	clischema "github.com/Naoray/scribe/internal/cli/schema"
+)
+
+type commandSchema struct {
+	InputSchema  json.RawMessage  `json:"input_schema"`
+	OutputSchema *json.RawMessage `json:"output_schema"`
+}
+
+func newSchemaCommand(root *cobra.Command) *cobra.Command {
+	var all bool
+	var markdown bool
+	cmd := &cobra.Command{
+		Use:   "schema [command]",
+		Short: "Print JSON Schema for command inputs and outputs",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if markdown {
+				_, err := fmt.Fprint(cmd.OutOrStdout(), clischema.RenderMarkdown(root, clischema.All()))
+				return err
+			}
+			if all {
+				return writeAllSchemas(cmd, root)
+			}
+			target := "schema"
+			if len(args) == 1 {
+				target = args[0]
+			}
+			found, err := findCommand(root, target)
+			if err != nil {
+				return err
+			}
+			return writeCommandSchema(cmd, found)
+		},
+	}
+	cmd.Flags().BoolVar(&all, "all", false, "Print schemas for all commands")
+	cmd.Flags().BoolVar(&markdown, "markdown", false, "Render command schema summary as Markdown")
+	return cmd
+}
+
+func writeAllSchemas(cmd *cobra.Command, root *cobra.Command) error {
+	out := map[string]commandSchema{}
+	walkCommandsForSchema(root, func(c *cobra.Command) {
+		if c.Hidden {
+			return
+		}
+		out[c.CommandPath()] = schemaForCommand(c)
+	})
+	return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+}
+
+func writeCommandSchema(cmd *cobra.Command, target *cobra.Command) error {
+	return json.NewEncoder(cmd.OutOrStdout()).Encode(schemaForCommand(target))
+}
+
+func schemaForCommand(cmd *cobra.Command) commandSchema {
+	input := json.RawMessage(clischema.InputSchema(cmd))
+	var output *json.RawMessage
+	if raw, ok := clischema.Get(cmd.CommandPath()); ok {
+		msg := json.RawMessage(raw)
+		output = &msg
+	}
+	return commandSchema{
+		InputSchema:  input,
+		OutputSchema: output,
+	}
+}
+
+func findCommand(root *cobra.Command, path string) (*cobra.Command, error) {
+	path = strings.TrimSpace(strings.TrimPrefix(path, root.CommandPath()+" "))
+	var found *cobra.Command
+	walkCommandsForSchema(root, func(cmd *cobra.Command) {
+		if found != nil || cmd.Hidden {
+			return
+		}
+		if cmd.CommandPath() == path || cmd.CommandPath() == root.CommandPath()+" "+path || cmd.Name() == path {
+			found = cmd
+		}
+	})
+	if found != nil {
+		return found, nil
+	}
+	return nil, &clierrors.Error{
+		Code:        "SCHEMA_COMMAND_NOT_FOUND",
+		Message:     "schema command not found: " + path,
+		Remediation: "registered commands: " + strings.Join(schemaCommandPaths(root), ", "),
+		Exit:        clierrors.ExitNotFound,
+	}
+}
+
+func schemaCommandPaths(root *cobra.Command) []string {
+	var paths []string
+	walkCommandsForSchema(root, func(cmd *cobra.Command) {
+		if !cmd.Hidden {
+			paths = append(paths, cmd.CommandPath())
+		}
+	})
+	sort.Strings(paths)
+	return paths
+}
+
+func walkCommandsForSchema(cmd *cobra.Command, visit func(*cobra.Command)) {
+	visit(cmd)
+	for _, child := range cmd.Commands() {
+		walkCommandsForSchema(child, visit)
+	}
+}

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -3,12 +3,16 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/Naoray/scribe/internal/cli/envelope"
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/Naoray/scribe/internal/cli/output"
 	clischema "github.com/Naoray/scribe/internal/cli/schema"
 )
 
@@ -40,7 +44,7 @@ func newSchemaCommand(root *cobra.Command) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return writeCommandSchema(cmd, found)
+			return writeCommandSchema(cmd, found, target)
 		},
 	}
 	cmd.Flags().BoolVar(&all, "all", false, "Print schemas for all commands")
@@ -56,11 +60,38 @@ func writeAllSchemas(cmd *cobra.Command, root *cobra.Command) error {
 		}
 		out[c.CommandPath()] = schemaForCommand(c)
 	})
-	return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+	return renderSchemaResult(cmd, cmd.CommandPath(), out)
 }
 
-func writeCommandSchema(cmd *cobra.Command, target *cobra.Command) error {
-	return json.NewEncoder(cmd.OutOrStdout()).Encode(schemaForCommand(target))
+func writeCommandSchema(cmd *cobra.Command, target *cobra.Command, requested string) error {
+	command := cmd.CommandPath()
+	if requested != "" && requested != cmd.Name() {
+		command += " " + requested
+	}
+	return renderSchemaResult(cmd, command, schemaForCommand(target))
+}
+
+func renderSchemaResult(cmd *cobra.Command, command string, data any) error {
+	if !jsonFlagPassed(cmd) {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(data)
+	}
+
+	renderer := output.New(envFromArgs(os.Args), os.Stdout, os.Stderr)
+	renderer.SetMeta("command", command)
+	if version, ok := cmd.Context().Value(envelope.ScribeVersionKey).(string); ok {
+		renderer.SetMeta("scribe_version", version)
+	}
+	if start, ok := cmd.Context().Value(envelope.RunEStartKey).(time.Time); ok {
+		duration := time.Since(start).Milliseconds()
+		if duration < 1 {
+			duration = 1
+		}
+		renderer.SetMeta("duration_ms", duration)
+	}
+	if err := renderer.Result(data); err != nil {
+		return err
+	}
+	return renderer.Flush()
 }
 
 func schemaForCommand(cmd *cobra.Command) commandSchema {

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -45,7 +45,7 @@ func newSchemaCommand(root *cobra.Command) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&all, "all", false, "Print schemas for all commands")
 	cmd.Flags().BoolVar(&markdown, "markdown", false, "Render command schema summary as Markdown")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func writeAllSchemas(cmd *cobra.Command, root *cobra.Command) error {

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	stderrors "errors"
+	"testing"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+)
+
+func TestSchemaCommandListInputsOnly(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := newRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{"schema", "list"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var got commandSchema
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out.String())
+	}
+	if got.OutputSchema != nil {
+		t.Fatalf("output_schema = %s, want null", string(*got.OutputSchema))
+	}
+	var input map[string]any
+	if err := json.Unmarshal(got.InputSchema, &input); err != nil {
+		t.Fatalf("input schema unmarshal: %v", err)
+	}
+	props := input["properties"].(map[string]any)
+	if _, ok := props["remote"]; !ok {
+		t.Fatalf("list input schema missing remote flag: %#v", props)
+	}
+}
+
+func TestSchemaCommandAll(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := newRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{"schema", "--all"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var got map[string]commandSchema
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out.String())
+	}
+	if _, ok := got["scribe list"]; !ok {
+		t.Fatalf("--all missing scribe list; keys=%v", got)
+	}
+}
+
+func TestSchemaCommandUnregistered(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := newRootCmd()
+	root.SetArgs([]string{"schema", "definitely-missing"})
+
+	err := root.Execute()
+	var ce *clierrors.Error
+	if !stderrors.As(err, &ce) {
+		t.Fatalf("error = %T, want *errors.Error", err)
+	}
+	if ce.Exit != clierrors.ExitNotFound {
+		t.Fatalf("Exit = %d, want %d", ce.Exit, clierrors.ExitNotFound)
+	}
+}

--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -51,7 +51,7 @@ Examples:
 	cmd.MarkFlagsMutuallyExclusive("inherit", "pin")
 	cmd.MarkFlagsMutuallyExclusive("inherit", "add")
 	cmd.MarkFlagsMutuallyExclusive("inherit", "remove")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 type skillEditResult struct {
@@ -81,7 +81,7 @@ func newSkillRepairCommand() *cobra.Command {
 	if err := cmd.MarkFlagRequired("tool"); err != nil {
 		panic(err)
 	}
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func runSkillEdit(cmd *cobra.Command, args []string) error {

--- a/cmd/skill_tools_cmd.go
+++ b/cmd/skill_tools_cmd.go
@@ -37,7 +37,7 @@ Examples:
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.MarkFlagsMutuallyExclusive("enable", "reset")
 	cmd.MarkFlagsMutuallyExclusive("disable", "reset")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func runSkillTools(cmd *cobra.Command, args []string) error {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -17,5 +17,5 @@ Examples:
 		RunE: runStatus,
 	}
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
-	return cmd
+	return markJSONSupported(cmd)
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -17,7 +17,7 @@ func newSyncCommand() *cobra.Command {
 	cmd.Flags().Bool("trust-all", false, "Approve all package install commands without prompting")
 	cmd.Flags().Bool("all", false, "Sync all registries (default behavior)")
 	cmd.Flags().MarkHidden("all")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func runSync(cmd *cobra.Command, args []string) error {

--- a/cmd/tools.go
+++ b/cmd/tools.go
@@ -37,7 +37,7 @@ Examples:
 	cmd.AddCommand(newToolsAddCommand())
 	cmd.AddCommand(newToolsEnableCommand())
 	cmd.AddCommand(newToolsDisableCommand())
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func newToolsAddCommand() *cobra.Command {

--- a/cmd/wrap_runE_test.go
+++ b/cmd/wrap_runE_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/cli/envelope"
+)
+
+func TestWrapRunEStampsTiming(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "noop",
+		RunE: wrapRunE(func(cmd *cobra.Command, args []string) error {
+			time.Sleep(time.Millisecond)
+			return nil
+		}),
+	}
+	cmd.SetContext(context.WithValue(context.Background(), envelope.BootstrapStartKey, time.Now()))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	duration, ok := cmd.Context().Value(envelope.DurationMSKey).(int64)
+	if !ok || duration <= 0 {
+		t.Fatalf("duration_ms = %v, want > 0", cmd.Context().Value(envelope.DurationMSKey))
+	}
+	bootstrap, ok := cmd.Context().Value(envelope.BootstrapMSKey).(int64)
+	if !ok || bootstrap < 0 {
+		t.Fatalf("bootstrap_ms = %v, want >= 0", cmd.Context().Value(envelope.BootstrapMSKey))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark v1.7.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/internal/cli/env/detect.go
+++ b/internal/cli/env/detect.go
@@ -1,0 +1,45 @@
+package env
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+type Format string
+
+const (
+	FormatJSON  Format = "json"
+	FormatText  Format = "text"
+	FormatQuiet Format = "quiet"
+)
+
+type Mode struct {
+	Format      Format
+	Color       bool
+	Interactive bool
+}
+
+func Detect(stdout, stdin *os.File, jsonFlag bool) Mode {
+	ci := os.Getenv("CI") == "true"
+	stdoutTTY := isTTY(stdout)
+	stdinTTY := isTTY(stdin)
+
+	format := FormatText
+	if jsonFlag || ci || !stdoutTTY {
+		format = FormatJSON
+	}
+
+	return Mode{
+		Format:      format,
+		Color:       stdoutTTY && !ci && os.Getenv("NO_COLOR") != "1",
+		Interactive: stdinTTY && !ci,
+	}
+}
+
+func isTTY(file *os.File) bool {
+	if file == nil {
+		return false
+	}
+	return isatty.IsTerminal(file.Fd())
+}

--- a/internal/cli/env/detect_test.go
+++ b/internal/cli/env/detect_test.go
@@ -1,0 +1,39 @@
+package env
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDetect(t *testing.T) {
+	t.Run("ci forces json", func(t *testing.T) {
+		t.Setenv("CI", "true")
+		mode := Detect(os.Stdout, os.Stdin, false)
+		if mode.Format != FormatJSON {
+			t.Fatalf("Format = %s, want json", mode.Format)
+		}
+	})
+
+	t.Run("no color keeps text format", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "1")
+		stdout, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer stdout.Close()
+		mode := Detect(stdout, os.Stdin, false)
+		if mode.Color {
+			t.Fatal("Color = true, want false")
+		}
+		if mode.Format != FormatJSON {
+			t.Fatalf("non-tty Format = %s, want json", mode.Format)
+		}
+	})
+
+	t.Run("json overrides tty", func(t *testing.T) {
+		mode := Detect(os.Stdout, os.Stdin, true)
+		if mode.Format != FormatJSON {
+			t.Fatalf("Format = %s, want json", mode.Format)
+		}
+	})
+}

--- a/internal/cli/envelope/envelope.go
+++ b/internal/cli/envelope/envelope.go
@@ -1,0 +1,51 @@
+package envelope
+
+import clierrors "github.com/Naoray/scribe/internal/cli/errors"
+
+const FormatVersion = "1"
+
+type Status string
+
+const (
+	StatusOK               Status = "ok"
+	StatusPartialSuccess   Status = "partial_success"
+	StatusAlreadyInstalled Status = "already_installed"
+	StatusNoChange         Status = "no_change"
+	StatusError            Status = "error"
+)
+
+func (s Status) IsValid() bool {
+	switch s {
+	case StatusOK, StatusPartialSuccess, StatusAlreadyInstalled, StatusNoChange, StatusError:
+		return true
+	default:
+		return false
+	}
+}
+
+type Meta struct {
+	DurationMS    int64  `json:"duration_ms,omitempty"`
+	BootstrapMS   int64  `json:"bootstrap_ms,omitempty"`
+	Command       string `json:"command,omitempty"`
+	ScribeVersion string `json:"scribe_version,omitempty"`
+}
+
+type Envelope struct {
+	Status        Status           `json:"status"`
+	FormatVersion string           `json:"format_version"`
+	Data          any              `json:"data,omitempty"`
+	Error         *clierrors.Error `json:"error,omitempty"`
+	Meta          Meta             `json:"meta"`
+}
+
+func New(status Status, data any, meta Meta) Envelope {
+	if !status.IsValid() {
+		status = StatusError
+	}
+	return Envelope{
+		Status:        status,
+		FormatVersion: FormatVersion,
+		Data:          data,
+		Meta:          meta,
+	}
+}

--- a/internal/cli/envelope/envelope_test.go
+++ b/internal/cli/envelope/envelope_test.go
@@ -1,0 +1,59 @@
+package envelope
+
+import (
+	"encoding/json"
+	"testing"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+)
+
+func TestEnvelopeGoldenShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		env  Envelope
+		want string
+	}{
+		{
+			name: "ok",
+			env:  New(StatusOK, map[string]any{"name": "recap"}, Meta{Command: "scribe list", ScribeVersion: "dev"}),
+			want: `{"status":"ok","format_version":"1","data":{"name":"recap"},"meta":{"command":"scribe list","scribe_version":"dev"}}`,
+		},
+		{
+			name: "error",
+			env: Envelope{
+				Status:        StatusError,
+				FormatVersion: FormatVersion,
+				Error:         &clierrors.Error{Code: "NOPE", Message: "not found", Retryable: false, Remediation: "retry", Resource: "recap"},
+				Meta:          Meta{},
+			},
+			want: `{"status":"error","format_version":"1","error":{"code":"NOPE","message":"not found","retryable":false,"remediation":"retry","resource":"recap"},"meta":{}}`,
+		},
+		{
+			name: "partial success",
+			env:  New(StatusPartialSuccess, []string{"a"}, Meta{}),
+			want: `{"status":"partial_success","format_version":"1","data":["a"],"meta":{}}`,
+		},
+		{
+			name: "already installed",
+			env:  New(StatusAlreadyInstalled, map[string]any{"name": "recap"}, Meta{}),
+			want: `{"status":"already_installed","format_version":"1","data":{"name":"recap"},"meta":{}}`,
+		},
+		{
+			name: "no change",
+			env:  New(StatusNoChange, nil, Meta{}),
+			want: `{"status":"no_change","format_version":"1","meta":{}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.env)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("json = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/envelope/keys.go
+++ b/internal/cli/envelope/keys.go
@@ -1,0 +1,12 @@
+package envelope
+
+type contextKey string
+
+const (
+	BootstrapStartKey contextKey = "bootstrap_start"
+	RunEStartKey      contextKey = "runE_start"
+	CommandPathKey    contextKey = "command_path"
+	ScribeVersionKey  contextKey = "scribe_version"
+	DurationMSKey     contextKey = "duration_ms"
+	BootstrapMSKey    contextKey = "bootstrap_ms"
+)

--- a/internal/cli/envelope/status_test.go
+++ b/internal/cli/envelope/status_test.go
@@ -1,0 +1,19 @@
+package envelope
+
+import "testing"
+
+func TestStatusIsValid(t *testing.T) {
+	valid := []Status{StatusOK, StatusPartialSuccess, StatusAlreadyInstalled, StatusNoChange, StatusError}
+	for _, status := range valid {
+		if !status.IsValid() {
+			t.Fatalf("%q should be valid", status)
+		}
+	}
+
+	invalid := []Status{"OK", "Success", ""}
+	for _, status := range invalid {
+		if status.IsValid() {
+			t.Fatalf("%q should be invalid", status)
+		}
+	}
+}

--- a/internal/cli/errors/error.go
+++ b/internal/cli/errors/error.go
@@ -1,0 +1,102 @@
+package errors
+
+import (
+	stderrors "errors"
+)
+
+const (
+	ExitOK = iota
+	ExitGeneral
+	ExitUsage
+	ExitNotFound
+	ExitPerm
+	ExitConflict
+	ExitNetwork
+	ExitUnavailable
+	ExitValid
+	ExitCanceled
+	ExitPartial
+)
+
+type Error struct {
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Retryable   bool   `json:"retryable"`
+	Remediation string `json:"remediation,omitempty"`
+	Resource    string `json:"resource,omitempty"`
+	Exit        int    `json:"-"`
+	err         error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.err != nil {
+		return e.err.Error()
+	}
+	return e.Code
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+type Option func(*Error)
+
+func WithMessage(message string) Option {
+	return func(e *Error) {
+		e.Message = message
+	}
+}
+
+func WithRetryable(retryable bool) Option {
+	return func(e *Error) {
+		e.Retryable = retryable
+	}
+}
+
+func WithRemediation(remediation string) Option {
+	return func(e *Error) {
+		e.Remediation = remediation
+	}
+}
+
+func WithResource(resource string) Option {
+	return func(e *Error) {
+		e.Resource = resource
+	}
+}
+
+func Wrap(err error, code string, exit int, opts ...Option) error {
+	if err == nil {
+		return nil
+	}
+	ce := &Error{
+		Code:    code,
+		Message: err.Error(),
+		Exit:    exit,
+		err:     err,
+	}
+	for _, opt := range opts {
+		opt(ce)
+	}
+	return ce
+}
+
+func ExitCode(err error) int {
+	if err == nil {
+		return ExitOK
+	}
+	var ce *Error
+	if stderrors.As(err, &ce) && ce.Exit != 0 {
+		return ce.Exit
+	}
+	return ExitGeneral
+}

--- a/internal/cli/errors/error_test.go
+++ b/internal/cli/errors/error_test.go
@@ -1,0 +1,42 @@
+package errors
+
+import (
+	stderrors "errors"
+	"testing"
+)
+
+func TestWrapPreservesErrorChainAndAs(t *testing.T) {
+	base := stderrors.New("boom")
+	err := Wrap(base, "NETWORK", ExitNetwork, WithRetryable(true), WithRemediation("retry"))
+
+	var ce *Error
+	if !stderrors.As(err, &ce) {
+		t.Fatal("errors.As did not find *Error")
+	}
+	if ce.Code != "NETWORK" || ce.Exit != ExitNetwork || !ce.Retryable || ce.Remediation != "retry" {
+		t.Fatalf("wrapped error = %+v", ce)
+	}
+	if !stderrors.Is(err, base) {
+		t.Fatal("wrapped error does not preserve source chain")
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "nil", err: nil, want: ExitOK},
+		{name: "cli error", err: &Error{Exit: ExitNotFound}, want: ExitNotFound},
+		{name: "plain error", err: stderrors.New("plain"), want: ExitGeneral},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExitCode(tt.err); got != tt.want {
+				t.Fatalf("ExitCode() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/fields/fieldset.go
+++ b/internal/cli/fields/fieldset.go
@@ -1,0 +1,37 @@
+package fields
+
+import (
+	"strings"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+)
+
+type FieldSet[T any] map[string]func(T) any
+
+func Project[T any](set FieldSet[T], selected []string, item T) (map[string]any, error) {
+	if len(selected) == 0 {
+		selected = make([]string, 0, len(set))
+		for name := range set {
+			selected = append(selected, name)
+		}
+	}
+
+	projected := make(map[string]any, len(selected))
+	for _, field := range selected {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		fn, ok := set[field]
+		if !ok {
+			return nil, &clierrors.Error{
+				Code:        "USAGE_UNKNOWN_FIELD",
+				Message:     "unknown field: " + field,
+				Remediation: "scribe schema <command> --fields",
+				Exit:        clierrors.ExitUsage,
+			}
+		}
+		projected[field] = fn(item)
+	}
+	return projected, nil
+}

--- a/internal/cli/fields/fieldset_test.go
+++ b/internal/cli/fields/fieldset_test.go
@@ -1,0 +1,42 @@
+package fields
+
+import (
+	stderrors "errors"
+	"testing"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+)
+
+type item struct {
+	Name    string
+	Version string
+}
+
+func TestProject(t *testing.T) {
+	set := FieldSet[item]{
+		"name":    func(i item) any { return i.Name },
+		"version": func(i item) any { return i.Version },
+	}
+
+	got, err := Project(set, []string{"name"}, item{Name: "recap", Version: "1.0.0"})
+	if err != nil {
+		t.Fatalf("Project: %v", err)
+	}
+	if got["name"] != "recap" {
+		t.Fatalf("name = %v", got["name"])
+	}
+	if _, ok := got["version"]; ok {
+		t.Fatal("unexpected version field")
+	}
+}
+
+func TestProjectUnknownField(t *testing.T) {
+	_, err := Project(FieldSet[item]{}, []string{"missing"}, item{})
+	var ce *clierrors.Error
+	if !stderrors.As(err, &ce) {
+		t.Fatalf("error = %T, want *errors.Error", err)
+	}
+	if ce.Exit != clierrors.ExitUsage {
+		t.Fatalf("Exit = %d, want %d", ce.Exit, clierrors.ExitUsage)
+	}
+}

--- a/internal/cli/output/attach.go
+++ b/internal/cli/output/attach.go
@@ -1,0 +1,13 @@
+package output
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/cli/fields"
+)
+
+const fieldsFlagName = "fields"
+
+func AttachFieldsFlag[T any](cmd *cobra.Command, _ fields.FieldSet[T]) {
+	cmd.Flags().String(fieldsFlagName, "", "Comma-separated fields to include in JSON output")
+}

--- a/internal/cli/output/attach_test.go
+++ b/internal/cli/output/attach_test.go
@@ -1,0 +1,22 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/cli/fields"
+)
+
+func TestAttachFieldsFlag(t *testing.T) {
+	attached := &cobra.Command{Use: "attached"}
+	AttachFieldsFlag(attached, fields.FieldSet[string]{"name": func(s string) any { return s }})
+	if attached.Flags().Lookup("fields") == nil {
+		t.Fatal("attached command missing --fields")
+	}
+
+	unattached := &cobra.Command{Use: "unattached"}
+	if unattached.Flags().Lookup("fields") != nil {
+		t.Fatal("unattached command has --fields")
+	}
+}

--- a/internal/cli/output/json.go
+++ b/internal/cli/output/json.go
@@ -1,0 +1,74 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/Naoray/scribe/internal/cli/envelope"
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+)
+
+type jsonRenderer struct {
+	baseRenderer
+	out     io.Writer
+	errOut  io.Writer
+	data    any
+	err     *clierrors.Error
+	hasData bool
+	flushed bool
+}
+
+func newJSONRenderer(out, errOut io.Writer) *jsonRenderer {
+	return &jsonRenderer{
+		baseRenderer: newBaseRenderer(),
+		out:          out,
+		errOut:       errOut,
+	}
+}
+
+func (r *jsonRenderer) Result(data any) error {
+	r.data = data
+	r.hasData = true
+	return nil
+}
+
+func (r *jsonRenderer) Error(err *clierrors.Error) error {
+	r.err = err
+	r.SetStatus(envelope.StatusError)
+	return r.flushTo(r.errOut)
+}
+
+func (r *jsonRenderer) Progress(msg string) {
+	if msg == "" {
+		return
+	}
+	fmt.Fprintln(r.errOut, msg)
+}
+
+func (r *jsonRenderer) Flush() error {
+	return r.flushTo(r.out)
+}
+
+func (r *jsonRenderer) flushTo(w io.Writer) error {
+	if r.flushed {
+		return nil
+	}
+	if !r.hasData && r.err == nil {
+		return nil
+	}
+	r.flushed = true
+
+	env := envelope.Envelope{
+		Status:        r.status,
+		FormatVersion: envelope.FormatVersion,
+		Data:          r.data,
+		Error:         r.err,
+		Meta:          r.envelopeMeta(),
+	}
+	if r.err != nil {
+		env.Status = envelope.StatusError
+	}
+	enc := json.NewEncoder(w)
+	return enc.Encode(env)
+}

--- a/internal/cli/output/json_test.go
+++ b/internal/cli/output/json_test.go
@@ -1,0 +1,67 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/cli/env"
+	"github.com/Naoray/scribe/internal/cli/envelope"
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+)
+
+func TestJSONRendererRoundTrip(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	r := New(env.Mode{Format: env.FormatJSON}, &stdout, &stderr)
+	r.Progress("loading")
+	r.SetMeta("command", "scribe list")
+	r.SetStatus(envelope.StatusOK)
+	if err := r.Result(map[string]any{"name": "recap"}); err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if err := r.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := r.Flush(); err != nil {
+		t.Fatalf("second Flush: %v", err)
+	}
+
+	if stderr.String() != "loading\n" {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	lines := bytes.Count(stdout.Bytes(), []byte("\n"))
+	if lines != 1 {
+		t.Fatalf("Flush emitted %d lines, want 1: %q", lines, stdout.String())
+	}
+
+	var got envelope.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Status != envelope.StatusOK || got.FormatVersion != envelope.FormatVersion {
+		t.Fatalf("envelope = %+v", got)
+	}
+	if got.Meta.Command != "scribe list" {
+		t.Fatalf("command meta = %q", got.Meta.Command)
+	}
+}
+
+func TestJSONRendererError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	r := New(env.Mode{Format: env.FormatJSON}, &stdout, &stderr)
+	err := &clierrors.Error{Code: "BAD", Message: "bad", Exit: clierrors.ExitUsage}
+	if writeErr := r.Error(err); writeErr != nil {
+		t.Fatalf("Error: %v", writeErr)
+	}
+
+	var got envelope.Envelope
+	if decodeErr := json.Unmarshal(stderr.Bytes(), &got); decodeErr != nil {
+		t.Fatalf("unmarshal: %v", decodeErr)
+	}
+	if got.Status != envelope.StatusError || got.Error.Code != "BAD" {
+		t.Fatalf("envelope = %+v", got)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}

--- a/internal/cli/output/quiet.go
+++ b/internal/cli/output/quiet.go
@@ -1,0 +1,42 @@
+package output
+
+import (
+	"fmt"
+	"io"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+)
+
+type quietRenderer struct {
+	baseRenderer
+	out    io.Writer
+	errOut io.Writer
+}
+
+func newQuietRenderer(out, errOut io.Writer) *quietRenderer {
+	return &quietRenderer{
+		baseRenderer: newBaseRenderer(),
+		out:          out,
+		errOut:       errOut,
+	}
+}
+
+func (r *quietRenderer) Result(data any) error {
+	if data == nil {
+		return nil
+	}
+	_, err := fmt.Fprintln(r.out, data)
+	return err
+}
+
+func (r *quietRenderer) Error(err *clierrors.Error) error {
+	if err == nil {
+		return nil
+	}
+	_, writeErr := fmt.Fprintln(r.errOut, err.Error())
+	return writeErr
+}
+
+func (r *quietRenderer) Progress(string) {}
+
+func (r *quietRenderer) Flush() error { return nil }

--- a/internal/cli/output/renderer.go
+++ b/internal/cli/output/renderer.go
@@ -1,0 +1,71 @@
+package output
+
+import (
+	"io"
+
+	"github.com/Naoray/scribe/internal/cli/env"
+	"github.com/Naoray/scribe/internal/cli/envelope"
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+)
+
+type Renderer interface {
+	Result(any) error
+	Error(*clierrors.Error) error
+	Progress(string)
+	SetMeta(string, any)
+	SetStatus(envelope.Status)
+	Flush() error
+}
+
+func New(mode env.Mode, out, errOut io.Writer) Renderer {
+	switch mode.Format {
+	case env.FormatJSON:
+		return newJSONRenderer(out, errOut)
+	case env.FormatQuiet:
+		return newQuietRenderer(out, errOut)
+	default:
+		return newTextRenderer(out, errOut, mode.Color)
+	}
+}
+
+type baseRenderer struct {
+	meta   map[string]any
+	status envelope.Status
+}
+
+func newBaseRenderer() baseRenderer {
+	return baseRenderer{
+		meta:   map[string]any{},
+		status: envelope.StatusOK,
+	}
+}
+
+func (r *baseRenderer) SetMeta(k string, v any) {
+	if k == "" {
+		return
+	}
+	r.meta[k] = v
+}
+
+func (r *baseRenderer) SetStatus(status envelope.Status) {
+	if status.IsValid() {
+		r.status = status
+	}
+}
+
+func (r *baseRenderer) envelopeMeta() envelope.Meta {
+	meta := envelope.Meta{}
+	if v, ok := r.meta["duration_ms"].(int64); ok {
+		meta.DurationMS = v
+	}
+	if v, ok := r.meta["bootstrap_ms"].(int64); ok {
+		meta.BootstrapMS = v
+	}
+	if v, ok := r.meta["command"].(string); ok {
+		meta.Command = v
+	}
+	if v, ok := r.meta["scribe_version"].(string); ok {
+		meta.ScribeVersion = v
+	}
+	return meta
+}

--- a/internal/cli/output/text.go
+++ b/internal/cli/output/text.go
@@ -1,0 +1,69 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+)
+
+type textRenderer struct {
+	baseRenderer
+	out     io.Writer
+	errOut  io.Writer
+	color   bool
+	flushed bool
+}
+
+func newTextRenderer(out, errOut io.Writer, color bool) *textRenderer {
+	return &textRenderer{
+		baseRenderer: newBaseRenderer(),
+		out:          out,
+		errOut:       errOut,
+		color:        color,
+	}
+}
+
+func (r *textRenderer) Result(data any) error {
+	switch v := data.(type) {
+	case nil:
+		return nil
+	case string:
+		_, err := fmt.Fprintln(r.out, v)
+		return err
+	default:
+		bytes, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(r.out, string(bytes))
+		return err
+	}
+}
+
+func (r *textRenderer) Error(err *clierrors.Error) error {
+	if err == nil {
+		return nil
+	}
+	if err.Code != "" {
+		_, _ = fmt.Fprintf(r.errOut, "error[%s]: %s\n", err.Code, err.Error())
+	} else {
+		_, _ = fmt.Fprintf(r.errOut, "error: %s\n", err.Error())
+	}
+	if err.Remediation != "" {
+		_, _ = fmt.Fprintf(r.errOut, "remediation: %s\n", err.Remediation)
+	}
+	return nil
+}
+
+func (r *textRenderer) Progress(msg string) {
+	if msg != "" {
+		fmt.Fprintln(r.errOut, msg)
+	}
+}
+
+func (r *textRenderer) Flush() error {
+	r.flushed = true
+	return nil
+}

--- a/internal/cli/output/text_test.go
+++ b/internal/cli/output/text_test.go
@@ -1,0 +1,28 @@
+package output
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/cli/env"
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+)
+
+func TestTextRendererShape(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	r := New(env.Mode{Format: env.FormatText}, &stdout, &stderr)
+	if err := r.Result("hello"); err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if err := r.Error(&clierrors.Error{Code: "BAD", Message: "bad", Remediation: "fix it"}); err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	if stdout.String() != "hello\n" {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	wantErr := "error[BAD]: bad\nremediation: fix it\n"
+	if stderr.String() != wantErr {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), wantErr)
+	}
+}

--- a/internal/cli/schema/inputs.go
+++ b/internal/cli/schema/inputs.go
@@ -1,0 +1,92 @@
+package schema
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type inputSchema struct {
+	Schema               string                `json:"$schema"`
+	Type                 string                `json:"type"`
+	Properties           map[string]flagSchema `json:"properties"`
+	Required             []string              `json:"required,omitempty"`
+	AdditionalProperties bool                  `json:"additionalProperties"`
+}
+
+type flagSchema struct {
+	Type        string `json:"type"`
+	Default     string `json:"default,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+func InputSchema(cmd *cobra.Command) string {
+	s := inputSchema{
+		Schema:               "https://json-schema.org/draft/2020-12/schema",
+		Type:                 "object",
+		Properties:           map[string]flagSchema{},
+		AdditionalProperties: false,
+	}
+
+	visitFlags(cmd, func(flag *pflag.Flag) {
+		if flag.Hidden {
+			return
+		}
+		s.Properties[flag.Name] = flagSchema{
+			Type:        schemaType(flag.Value.Type()),
+			Default:     flag.DefValue,
+			Description: flag.Usage,
+		}
+		if isRequired(flag) {
+			s.Required = append(s.Required, flag.Name)
+		}
+	})
+	sort.Strings(s.Required)
+
+	bytes, err := json.Marshal(s)
+	if err != nil {
+		return `{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","properties":{},"additionalProperties":false}`
+	}
+	return string(bytes)
+}
+
+func visitFlags(cmd *cobra.Command, visit func(*pflag.Flag)) {
+	seen := map[string]bool{}
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		seen[flag.Name] = true
+		visit(flag)
+	})
+	cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if seen[flag.Name] {
+			return
+		}
+		visit(flag)
+	})
+}
+
+func schemaType(flagType string) string {
+	switch flagType {
+	case "bool":
+		return "boolean"
+	case "int", "int64", "uint", "uint64":
+		return "integer"
+	case "float32", "float64":
+		return "number"
+	default:
+		return "string"
+	}
+}
+
+func isRequired(flag *pflag.Flag) bool {
+	for key := range flag.Annotations {
+		if key == cobra.BashCompOneRequiredFlag {
+			return true
+		}
+		if key == "cobra_annotation_required" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/schema/inputs_test.go
+++ b/internal/cli/schema/inputs_test.go
@@ -1,0 +1,28 @@
+package schema
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/spf13/cobra"
+)
+
+func TestInputSchemaIsValidJSONSchema202012(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool("json", false, "Output JSON")
+	cmd.Flags().String("name", "", "Name")
+
+	raw := InputSchema(cmd)
+	if _, err := jsonschema.CompileString("input.schema.json", raw); err != nil {
+		t.Fatalf("compile schema: %v\n%s", err, raw)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded["$schema"] != "https://json-schema.org/draft/2020-12/schema" {
+		t.Fatalf("$schema = %v", decoded["$schema"])
+	}
+}

--- a/internal/cli/schema/markdown.go
+++ b/internal/cli/schema/markdown.go
@@ -1,0 +1,46 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func RenderMarkdown(rootCmd *cobra.Command, registry map[string]string) string {
+	var rows []string
+	walk(rootCmd, func(cmd *cobra.Command) {
+		if cmd.Hidden {
+			return
+		}
+		output := "no"
+		if _, ok := registry[cmd.CommandPath()]; ok {
+			output = "yes"
+		}
+		var flags []string
+		visitFlags(cmd, func(flag *pflag.Flag) {
+			flags = append(flags, "--"+flag.Name)
+		})
+		sort.Strings(flags)
+		rows = append(rows, fmt.Sprintf("| `%s` | %s | %s |", cmd.CommandPath(), strings.Join(flags, ", "), output))
+	})
+	sort.Strings(rows)
+
+	var b strings.Builder
+	b.WriteString("| Command | Flags | Output schema |\n")
+	b.WriteString("|---|---|---|\n")
+	for _, row := range rows {
+		b.WriteString(row)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func walk(cmd *cobra.Command, visit func(*cobra.Command)) {
+	visit(cmd)
+	for _, child := range cmd.Commands() {
+		walk(child, visit)
+	}
+}

--- a/internal/cli/schema/registry.go
+++ b/internal/cli/schema/registry.go
@@ -1,0 +1,20 @@
+package schema
+
+var outputSchemas = map[string]string{}
+
+func Register(commandPath, jsonSchemaLiteral string) {
+	outputSchemas[commandPath] = jsonSchemaLiteral
+}
+
+func Get(path string) (string, bool) {
+	s, ok := outputSchemas[path]
+	return s, ok
+}
+
+func All() map[string]string {
+	out := make(map[string]string, len(outputSchemas))
+	for k, v := range outputSchemas {
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
First of 3 PRs implementing the agent-first foundation triplet (todos #399 #400 #404).

## What lands
- New packages under `internal/cli/{errors,envelope,env,output,fields,schema}` (Phase 1).
- `cmd/root.go` integration with `wrapRunE` for timing + `*cli.Error` exit-code unwrapping + fallback renderer for PreRunE-skip paths (Phase 2).
- `scribe schema [command] [--all] [--markdown]` with Cobra input introspection + empty output-schema registry (Phase 3 — registry filled by PR B).

## What does NOT land
- Migrating any existing command to use the renderer (PR B).
- Wrapping `workflow.jsonFormatter.Flush()` in envelope (PR C — the format_version=1 contract bump).
- Generating CLAUDE.md (PR C).

## Architecture sources
- Locked architecture: solo scratchpad 900
- r2 plan: solo scratchpad 906
- r2 addendum (B1 + B3 mechanism fixes): solo scratchpad 912
- Spec: docs/superpowers/specs/2026-04-13-agent-first-cli-design.md

## Test plan
- [x] go test ./... -count=1
- [x] go build ./...
- [x] subprocess matrix (cmd/root_exit_test.go): unknown cmd, bad flag, --help, --version, pre-run failure × JSON + non-TTY
- [x] wrap_runE_test.go: duration_ms > 0 and bootstrap_ms >= 0
- [x] root_flags_test.go: no duplicate --json panic; --fields absent unless AttachFieldsFlag called

## Spec deviations from PR #89 design doc
- spec §43, §118: field selection via overloaded `--json name,version` → we use `--fields name,version` (companion flag). Documented in CLAUDE.md (lands in PR C).