### PR TITLE
feat(cli): migrate read-only commands to envelope (PR B of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 Migration: `jq '.data.foo'` works; `jq '.foo'` requires update.
 
-Mutator commands (`sync`, `add`, `adopt`) keep their pre-envelope output for now; PR #<C> ships their migration.
+PR #118 / PR B introduces this format break for read-only commands. Mutator commands (`sync`, `add`, `adopt`, etc.) keep their pre-envelope output for now; their envelope migration is deferred to a follow-up PR.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+## Unreleased
+
+### BREAKING: --json output now uses versioned envelope (format_version=1)
+
+`scribe list --json`, `scribe status --json`, `scribe doctor --json`, `scribe explain --json`, `scribe guide --json` now wrap their previous payload as:
+
+```json
+{
+  "status": "ok",
+  "format_version": "1",
+  "data": { /* previously top-level keys are now here */ },
+  "meta": { "duration_ms": 12, "command": "scribe list", "scribe_version": "..." }
+}
+```
+
+Migration: `jq '.data.foo'` works; `jq '.foo'` requires update.
+
+Mutator commands (`sync`, `add`, `adopt`) keep their pre-envelope output for now; PR #<C> ships their migration.
+
+### Added
+
+- `--fields f1,f2` projection on read-only commands with tabular output (gh-style; opt-in per command via `output.AttachFieldsFlag`).
+- `scribe schema list`, `scribe schema status`, `scribe schema doctor`, `scribe schema explain`, `scribe schema guide` now return JSON Schema 2020-12 for both inputs and outputs.
+
+### Spec deviations
+
+- PR #89 spec §43, §118 propose field selection via overloaded `--json name,version`. We diverged: `--json` stays Bool; field selection uses companion `--fields name,version` flag to avoid breaking `--json=true` shell scripts. See `scribe schema <cmd>` for valid field names.

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -63,7 +63,7 @@ Examples:
 	cmd.Flags().Bool("yes", false, "Skip confirmation prompts")
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.Flags().String("registry", "", "Limit search to a specific registry (owner/repo)")
-	return markJSONSupported(cmd)
+	return cmd
 }
 
 func runAdd(cmd *cobra.Command, args []string) error {

--- a/cmd/adopt.go
+++ b/cmd/adopt.go
@@ -41,7 +41,7 @@ Examples:
 	cmd.Flags().Bool("dry-run", false, "Print plan without writing anything")
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.Flags().Bool("verbose", false, "Include paths and hashes in plan output")
-	return markJSONSupported(cmd)
+	return cmd
 }
 
 func runAdopt(cmd *cobra.Command, args []string) error {

--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -34,7 +34,7 @@ func newBrowseCommand() *cobra.Command {
 	cmd.Flags().String("install", "", "Install a skill by exact name or owner/repo:skill")
 	cmd.Flags().String("registry", "", "Limit browse/install to one connected registry")
 	cmd.Flags().Bool("yes", false, "Skip confirmation prompt")
-	return markJSONSupported(cmd)
+	return cmd
 }
 
 func runBrowse(cmd *cobra.Command, _ []string) error {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -38,7 +38,6 @@ Examples:
 	}
 	cmd.Flags().Bool("fix", false, "Normalize canonical skill metadata and repair affected projections")
 	cmd.Flags().String("skill", "", "Inspect a single managed skill")
-	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	return markJSONSupported(cmd)
 }
 
@@ -82,7 +81,7 @@ type pathSnapshot struct {
 func runDoctor(cmd *cobra.Command, _ []string) error {
 	fixFlag, _ := cmd.Flags().GetBool("fix")
 	skillFlag, _ := cmd.Flags().GetString("skill")
-	jsonFlag, _ := cmd.Flags().GetBool("json")
+	jsonFlag := jsonFlagPassed(cmd)
 
 	if fixFlag && jsonFlag {
 		return fmt.Errorf("doctor: --fix cannot be combined with --json")
@@ -120,7 +119,11 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 	}
 
 	if jsonFlag {
-		return writeDoctorJSON(cmd.OutOrStdout(), skillFlag, report)
+		r := jsonRendererForCommand(cmd, jsonFlag)
+		if err := r.Result(buildDoctorReportJSON(skillFlag, report)); err != nil {
+			return err
+		}
+		return r.Flush()
 	}
 	return writeDoctorText(cmd.OutOrStdout(), skillFlag, report)
 }
@@ -540,6 +543,14 @@ func copyPath(src, dst string) error {
 }
 
 func writeDoctorJSON(w io.Writer, skill string, report doctor.Report) error {
+	out := buildDoctorReportJSON(skill, report)
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+func buildDoctorReportJSON(skill string, report doctor.Report) doctorReportJSON {
 	out := doctorReportJSON{
 		Skill:  skill,
 		Fix:    false,
@@ -554,10 +565,7 @@ func writeDoctorJSON(w io.Writer, skill string, report doctor.Report) error {
 			Message: issue.Message,
 		})
 	}
-
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(out)
+	return out
 }
 
 func writeDoctorText(w io.Writer, skill string, report doctor.Report) error {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/doctor"
 	"github.com/Naoray/scribe/internal/skillmd"
@@ -84,30 +85,43 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 	jsonFlag := jsonFlagPassed(cmd)
 
 	if fixFlag && jsonFlag {
-		return fmt.Errorf("doctor: --fix cannot be combined with --json")
+		err := fmt.Errorf("doctor: --fix cannot be combined with --json")
+		return clierrors.Wrap(err, "USAGE_FLAG_CONFLICT", clierrors.ExitUsage,
+			clierrors.WithRemediation("Run `scribe doctor --fix` for repairs or `scribe doctor --json` for inspection."),
+		)
 	}
 
 	factory := newCommandFactory()
 
 	cfg, err := factory.Config()
 	if err != nil {
-		return fmt.Errorf("load config: %w", err)
+		return clierrors.Wrap(fmt.Errorf("load config: %w", err), "CONFIG_LOAD_FAILED", clierrors.ExitValid,
+			clierrors.WithRemediation("Check ~/.scribe/config.yaml for invalid YAML or schema drift."),
+		)
 	}
 
 	st, err := factory.State()
 	if err != nil {
-		return fmt.Errorf("load state: %w", err)
+		return clierrors.Wrap(fmt.Errorf("load state: %w", err), "STATE_LOAD_FAILED", clierrors.ExitValid,
+			clierrors.WithRemediation("Check ~/.scribe/state.yaml for invalid YAML or schema drift."),
+		)
 	}
 
 	if skillFlag != "" {
 		if _, ok := st.Installed[skillFlag]; !ok {
-			return fmt.Errorf("doctor: skill %q is not installed", skillFlag)
+			err := fmt.Errorf("doctor: skill %q is not installed", skillFlag)
+			return clierrors.Wrap(err, "SKILL_NOT_FOUND", clierrors.ExitNotFound,
+				clierrors.WithResource(skillFlag),
+				clierrors.WithRemediation("Run `scribe list` to see installed skills."),
+			)
 		}
 	}
 
 	report, err := doctor.InspectManagedSkills(cfg, st, skillFlag)
 	if err != nil {
-		return fmt.Errorf("inspect managed skills: %w", err)
+		return clierrors.Wrap(fmt.Errorf("inspect managed skills: %w", err), "DOCTOR_INSPECT_FAILED", clierrors.ExitValid,
+			clierrors.WithRemediation("Run `scribe doctor` without filters to inspect all managed skills."),
+		)
 	}
 
 	if fixFlag {

--- a/cmd/doctor_schema.go
+++ b/cmd/doctor_schema.go
@@ -1,0 +1,33 @@
+package cmd
+
+import clischema "github.com/Naoray/scribe/internal/cli/schema"
+
+var doctorOutputSchema = `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "skill": { "type": "string" },
+    "fix": { "type": "boolean" },
+    "issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "skill": { "type": "string" },
+          "tool": { "type": "string" },
+          "kind": { "type": "string" },
+          "status": { "type": "string" },
+          "message": { "type": "string" }
+        },
+        "required": ["skill", "kind", "status", "message"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["fix", "issues"],
+  "additionalProperties": false
+}`
+
+func init() {
+	clischema.Register("scribe doctor", doctorOutputSchema)
+}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -353,20 +353,22 @@ func TestDoctorJSONOutput(t *testing.T) {
 		t.Fatalf("unexpected error: %v (stderr=%s)", err, errBuf.String())
 	}
 
-	var report struct {
-		Issues []struct {
-			Skill   string `json:"skill"`
-			Tool    string `json:"tool"`
-			Kind    string `json:"kind"`
-			Status  string `json:"status"`
-			Message string `json:"message"`
-		} `json:"issues"`
+	var env struct {
+		Data struct {
+			Issues []struct {
+				Skill   string `json:"skill"`
+				Tool    string `json:"tool"`
+				Kind    string `json:"kind"`
+				Status  string `json:"status"`
+				Message string `json:"message"`
+			} `json:"issues"`
+		} `json:"data"`
 	}
-	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
 		t.Fatalf("invalid JSON: %v\noutput: %s", err, out.String())
 	}
-	if len(report.Issues) != 1 {
-		t.Fatalf("expected 1 issue, got %d: %+v", len(report.Issues), report.Issues)
+	if len(env.Data.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d: %+v", len(env.Data.Issues), env.Data.Issues)
 	}
 }
 

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
+	clienv "github.com/Naoray/scribe/internal/cli/env"
 	"github.com/Naoray/scribe/internal/discovery"
 )
 
@@ -47,13 +48,12 @@ Falls back to rendering the SKILL.md directly if no LLM is available.`,
 		Args: cobra.ExactArgs(1),
 		RunE: runExplain,
 	}
-	cmd.Flags().Bool("json", false, "Output structured JSON (for agents/scripts)")
 	cmd.Flags().Bool("raw", false, "Show rendered SKILL.md directly, skip AI explanation")
 	return markJSONSupported(cmd)
 }
 
 func runExplain(cmd *cobra.Command, args []string) error {
-	jsonFlag, _ := cmd.Flags().GetBool("json")
+	jsonFlag := jsonFlagPassed(cmd)
 	rawFlag, _ := cmd.Flags().GetBool("raw")
 	if jsonFlag && rawFlag {
 		return fmt.Errorf("if any flags in the group [json raw] are set none of the others can be; [json raw] were all set")
@@ -84,14 +84,18 @@ func runExplain(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	isTTY := isatty.IsTerminal(os.Stdout.Fd())
+	mode := clienv.Detect(os.Stdout, os.Stdin, jsonFlag)
 	w := cmd.OutOrStdout()
 
-	if jsonFlag {
-		return explainJSON(w, skill, content)
+	if mode.Format == clienv.FormatJSON {
+		r := jsonRendererForCommand(cmd, jsonFlag)
+		if err := r.Result(buildExplainOutput(skill, content)); err != nil {
+			return err
+		}
+		return r.Flush()
 	}
 
-	if !isTTY {
+	if mode.Format != clienv.FormatText {
 		return renderSkillBody(w, content)
 	}
 
@@ -180,14 +184,22 @@ func stripFrontmatter(s string) string {
 }
 
 func explainJSON(w io.Writer, skill discovery.Skill, content string) error {
-	out := struct {
-		Name        string   `json:"name"`
-		Description string   `json:"description,omitempty"`
-		Revision    int      `json:"revision,omitempty"`
-		Targets     []string `json:"targets,omitempty"`
-		Path        string   `json:"path,omitempty"`
-		Content     string   `json:"content"`
-	}{
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(buildExplainOutput(skill, content))
+}
+
+type explainOutput struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Revision    int      `json:"revision,omitempty"`
+	Targets     []string `json:"targets,omitempty"`
+	Path        string   `json:"path,omitempty"`
+	Content     string   `json:"content"`
+}
+
+func buildExplainOutput(skill discovery.Skill, content string) explainOutput {
+	return explainOutput{
 		Name:        skill.Name,
 		Description: skill.Description,
 		Revision:    skill.Revision,
@@ -195,9 +207,6 @@ func explainJSON(w io.Writer, skill discovery.Skill, content string) error {
 		Path:        skill.LocalPath,
 		Content:     content,
 	}
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(out)
 }
 
 func printSkillHeader(w io.Writer, skill discovery.Skill) {

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	clienv "github.com/Naoray/scribe/internal/cli/env"
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/discovery"
 )
 
@@ -56,7 +57,10 @@ func runExplain(cmd *cobra.Command, args []string) error {
 	jsonFlag := jsonFlagPassed(cmd)
 	rawFlag, _ := cmd.Flags().GetBool("raw")
 	if jsonFlag && rawFlag {
-		return fmt.Errorf("if any flags in the group [json raw] are set none of the others can be; [json raw] were all set")
+		err := fmt.Errorf("if any flags in the group [json raw] are set none of the others can be; [json raw] were all set")
+		return clierrors.Wrap(err, "USAGE_FLAG_CONFLICT", clierrors.ExitUsage,
+			clierrors.WithRemediation("Use either --json or --raw, not both."),
+		)
 	}
 	factory := newCommandFactory()
 
@@ -72,16 +76,24 @@ func runExplain(cmd *cobra.Command, args []string) error {
 
 	skill, ok := findSkill(skills, args[0])
 	if !ok {
-		return fmt.Errorf("skill %q not found — run `scribe list` to see installed skills", args[0])
+		err := fmt.Errorf("skill %q not found", args[0])
+		return clierrors.Wrap(err, "SKILL_NOT_FOUND", clierrors.ExitNotFound,
+			clierrors.WithResource(args[0]),
+			clierrors.WithRemediation("Run `scribe list` to see installed skills."),
+		)
 	}
 
 	if skill.LocalPath == "" {
-		return fmt.Errorf("skill %q is tracked but not on disk — try `scribe sync` first", args[0])
+		err := fmt.Errorf("skill %q is tracked but not on disk", args[0])
+		return clierrors.Wrap(err, "SKILL_NOT_ON_DISK", clierrors.ExitNotFound,
+			clierrors.WithResource(args[0]),
+			clierrors.WithRemediation("Run `scribe sync` before explaining this skill."),
+		)
 	}
 
 	content, err := readSkillContent(skill.LocalPath)
 	if err != nil {
-		return err
+		return wrapSkillReadError(err, args[0])
 	}
 
 	mode := clienv.Detect(os.Stdout, os.Stdin, jsonFlag)
@@ -160,6 +172,22 @@ func readSkillContent(skillDir string) (string, error) {
 		return "", fmt.Errorf("read SKILL.md: %w", err)
 	}
 	return string(data), nil
+}
+
+func wrapSkillReadError(err error, skillName string) error {
+	if os.IsNotExist(err) {
+		return clierrors.Wrap(err, "SKILL_NOT_FOUND", clierrors.ExitNotFound,
+			clierrors.WithResource(skillName),
+			clierrors.WithRemediation("Run `scribe sync` before explaining this skill."),
+		)
+	}
+	if os.IsPermission(err) {
+		return clierrors.Wrap(err, "SKILL_READ_PERMISSION_DENIED", clierrors.ExitPerm,
+			clierrors.WithResource(skillName),
+			clierrors.WithRemediation("Check file permissions for the skill directory."),
+		)
+	}
+	return err
 }
 
 // detectLLMCLI finds the first available LLM CLI on the machine.

--- a/cmd/explain_schema.go
+++ b/cmd/explain_schema.go
@@ -1,0 +1,22 @@
+package cmd
+
+import clischema "github.com/Naoray/scribe/internal/cli/schema"
+
+var explainOutputSchema = `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "revision": { "type": "integer" },
+    "targets": { "type": "array", "items": { "type": "string" } },
+    "path": { "type": "string" },
+    "content": { "type": "string" }
+  },
+  "required": ["name", "content"],
+  "additionalProperties": false
+}`
+
+func init() {
+	clischema.Register("scribe explain", explainOutputSchema)
+}

--- a/cmd/explain_test.go
+++ b/cmd/explain_test.go
@@ -21,7 +21,9 @@ func newTestRoot() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+	root.PersistentFlags().Bool("json", false, "Output machine-readable JSON")
 	root.AddCommand(newExplainCommand())
+	wrapRunECommands(root)
 	return root
 }
 

--- a/cmd/guide.go
+++ b/cmd/guide.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	clienv "github.com/Naoray/scribe/internal/cli/env"
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/prereq"
 	"github.com/Naoray/scribe/internal/workflow"
 )
@@ -55,7 +56,10 @@ func runGuide(cmd *cobra.Command, _ []string) error {
 	}
 
 	if !mode.Interactive {
-		return fmt.Errorf("scribe guide requires an interactive terminal — use --json for agent-friendly output")
+		err := fmt.Errorf("scribe guide requires an interactive terminal")
+		return clierrors.Wrap(err, "INTERACTIVE_TERMINAL_REQUIRED", clierrors.ExitUsage,
+			clierrors.WithRemediation("Use `scribe guide --json` for agent-friendly output."),
+		)
 	}
 
 	return runGuideInteractive(cmd)

--- a/cmd/guide.go
+++ b/cmd/guide.go
@@ -8,9 +8,9 @@ import (
 
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
+	clienv "github.com/Naoray/scribe/internal/cli/env"
 	"github.com/Naoray/scribe/internal/prereq"
 	"github.com/Naoray/scribe/internal/workflow"
 )
@@ -29,7 +29,6 @@ Examples:
 		Args: cobra.NoArgs,
 		RunE: runGuide,
 	}
-	cmd.Flags().Bool("json", false, "Output machine-readable JSON (for CI/agents)")
 	return markJSONSupported(cmd)
 }
 
@@ -45,13 +44,17 @@ var (
 )
 
 func runGuide(cmd *cobra.Command, _ []string) error {
-	jsonFlag, _ := cmd.Flags().GetBool("json")
-	useJSON := jsonFlag || !isatty.IsTerminal(os.Stdout.Fd())
-	if useJSON {
-		return runGuideJSON(os.Stdout)
+	jsonFlag := jsonFlagPassed(cmd)
+	mode := clienv.Detect(os.Stdout, os.Stdin, jsonFlag)
+	if mode.Format == clienv.FormatJSON {
+		r := jsonRendererForCommand(cmd, jsonFlag)
+		if err := r.Result(buildGuideOutput()); err != nil {
+			return err
+		}
+		return r.Flush()
 	}
 
-	if !isatty.IsTerminal(os.Stdin.Fd()) {
+	if !mode.Interactive {
 		return fmt.Errorf("scribe guide requires an interactive terminal — use --json for agent-friendly output")
 	}
 
@@ -66,6 +69,18 @@ type guideStep struct {
 
 // runGuideJSON writes the guide steps as JSON to w.
 func runGuideJSON(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(buildGuideOutput())
+}
+
+type guideOutput struct {
+	Status        string        `json:"status"`
+	Prerequisites prereq.Result `json:"prerequisites"`
+	Steps         []guideStep   `json:"steps"`
+}
+
+func buildGuideOutput() guideOutput {
 	result := prereq.Check()
 
 	status := "not_connected"
@@ -104,13 +119,11 @@ func runGuideJSON(w io.Writer) error {
 		Description: "Import hand-rolled skills from ~/.claude/skills into the store",
 	})
 
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(map[string]any{
-		"status":        status,
-		"prerequisites": result,
-		"steps":         steps,
-	})
+	return guideOutput{
+		Status:        status,
+		Prerequisites: result,
+		Steps:         steps,
+	}
 }
 
 // displayPrereqs shows prereq status with styled icons.

--- a/cmd/guide_schema.go
+++ b/cmd/guide_schema.go
@@ -1,0 +1,39 @@
+package cmd
+
+import clischema "github.com/Naoray/scribe/internal/cli/schema"
+
+var guideOutputSchema = `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "status": { "type": "string" },
+    "prerequisites": {
+      "type": "object",
+      "properties": {
+        "github_auth": { "type": "object" },
+        "scribe_dir": { "type": "object" },
+        "connections": { "type": "object" }
+      },
+      "required": ["github_auth", "scribe_dir", "connections"],
+      "additionalProperties": true
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "command": { "type": "string" },
+          "description": { "type": "string" }
+        },
+        "required": ["command", "description"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["status", "prerequisites", "steps"],
+  "additionalProperties": false
+}`
+
+func init() {
+	clischema.Register("scribe guide", guideOutputSchema)
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,9 +6,9 @@ import (
 	"os"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
+	clienv "github.com/Naoray/scribe/internal/cli/env"
 	"github.com/Naoray/scribe/internal/workflow"
 )
 
@@ -28,14 +28,13 @@ Examples:
   scribe list --json         # machine-readable output`,
 		RunE: runList,
 	}
-	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.Flags().Bool("remote", false, "Show available skills from registries (not installed)")
 	cmd.Flags().String("registry", "", "Show only this registry (owner/repo or repo name)")
+	attachListFields(cmd)
 	return markJSONSupported(cmd)
 }
 
 func runList(cmd *cobra.Command, args []string) error {
-	jsonFlag, _ := cmd.Flags().GetBool("json")
 	remoteFlag, _ := cmd.Flags().GetBool("remote")
 	repoFlag, _ := cmd.Flags().GetString("registry")
 
@@ -44,7 +43,9 @@ func runList(cmd *cobra.Command, args []string) error {
 		remoteFlag = true
 	}
 
-	useJSON := jsonFlag || !isatty.IsTerminal(os.Stdout.Fd())
+	jsonFlag := jsonFlagPassed(cmd)
+	mode := clienv.Detect(os.Stdout, os.Stdin, jsonFlag)
+	useJSON := mode.Format == clienv.FormatJSON
 
 	bag := &workflow.Bag{
 		Args:             args,
@@ -57,7 +58,25 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	if useJSON {
-		if err := workflow.Run(cmd.Context(), workflow.ListJSONSteps(), bag); err != nil {
+		if err := workflow.Run(cmd.Context(), workflow.ListJSONSteps()[:2], bag); err != nil {
+			return err
+		}
+		out, stateDirty, err := workflow.BuildListJSONData(cmd.Context(), bag)
+		if stateDirty {
+			bag.MarkStateDirty()
+		}
+		if err != nil {
+			return err
+		}
+		projected, err := projectListOutput(cmd, out)
+		if err != nil {
+			return err
+		}
+		r := jsonRendererForCommand(cmd, jsonFlag)
+		if err := r.Result(projected); err != nil {
+			return err
+		}
+		if err := r.Flush(); err != nil {
 			return err
 		}
 		return saveWorkflowState(bag)

--- a/cmd/list_fields.go
+++ b/cmd/list_fields.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/cli/fields"
+	"github.com/Naoray/scribe/internal/cli/output"
+	"github.com/Naoray/scribe/internal/workflow"
+)
+
+var listFieldSet = fields.FieldSet[workflow.ListOutput]{
+	"skills": func(out workflow.ListOutput) any {
+		return out["skills"]
+	},
+	"packages": func(out workflow.ListOutput) any {
+		return out["packages"]
+	},
+	"registries": func(out workflow.ListOutput) any {
+		return out["registries"]
+	},
+	"warnings": func(out workflow.ListOutput) any {
+		return out["warnings"]
+	},
+}
+
+func attachListFields(cmd *cobra.Command) {
+	output.AttachFieldsFlag(cmd, listFieldSet)
+}
+
+func projectListOutput(cmd *cobra.Command, out workflow.ListOutput) (any, error) {
+	fieldsFlag, _ := cmd.Flags().GetString("fields")
+	if strings.TrimSpace(fieldsFlag) == "" {
+		return out, nil
+	}
+	return fields.Project(listFieldSet, strings.Split(fieldsFlag, ","), out)
+}

--- a/cmd/list_schema.go
+++ b/cmd/list_schema.go
@@ -1,0 +1,91 @@
+package cmd
+
+import clischema "github.com/Naoray/scribe/internal/cli/schema"
+
+var listOutputSchema = `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "skills": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "description": { "type": "string" },
+              "package": { "type": "string" },
+              "revision": { "type": "integer" },
+              "content_hash": { "type": "string" },
+              "targets": { "type": "array", "items": { "type": "string" } },
+              "managed": { "type": "boolean" },
+              "origin": { "type": "string" },
+              "path": { "type": "string" }
+            },
+            "required": ["name", "targets", "managed"],
+            "additionalProperties": false
+          }
+        },
+        "packages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "description": { "type": "string" },
+              "revision": { "type": "integer" },
+              "path": { "type": "string" },
+              "install_cmd": { "type": "string" },
+              "sources": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["skills", "packages"],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "registries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "registry": { "type": "string" },
+              "skills": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": { "type": "string" },
+                    "status": { "type": "string" },
+                    "version": { "type": "string" },
+                    "loadout_ref": { "type": "string" },
+                    "maintainer": { "type": "string" },
+                    "agents": { "type": "array", "items": { "type": "string" } }
+                  },
+                  "required": ["name", "status"],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": ["registry", "skills"],
+            "additionalProperties": false
+          }
+        },
+        "warnings": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["registries"],
+      "additionalProperties": false
+    }
+  ]
+}`
+
+func init() {
+	clischema.Register("scribe list", listOutputSchema)
+}

--- a/cmd/read_only_envelope_test.go
+++ b/cmd/read_only_envelope_test.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	clischema "github.com/Naoray/scribe/internal/cli/schema"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+func TestReadOnlyCommandsEmitEnvelopeAndValidateOutputSchema(t *testing.T) {
+	cases := []struct {
+		name  string
+		args  []string
+		setup func(t *testing.T, home string)
+	}{
+		{name: "list", args: []string{"list", "--json"}},
+		{name: "status", args: []string{"status", "--json"}},
+		{name: "doctor", args: []string{"doctor", "--json"}},
+		{name: "guide", args: []string{"guide", "--json"}, setup: func(t *testing.T, home string) {
+			t.Setenv("PATH", home)
+		}},
+		{name: "explain", args: []string{"explain", "--json", "test-skill"}, setup: func(t *testing.T, home string) {
+			writeEnvelopeTestSkill(t, home)
+		}},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			if tt.setup != nil {
+				tt.setup(t, home)
+			}
+
+			env := executeEnvelopeCommand(t, tt.args)
+			if env.Status != "ok" {
+				t.Fatalf("status = %q, want ok\nenvelope=%#v", env.Status, env)
+			}
+			if env.FormatVersion != "1" {
+				t.Fatalf("format_version = %q, want 1", env.FormatVersion)
+			}
+			if env.Data == nil {
+				t.Fatalf("data is nil")
+			}
+
+			rawSchema, ok := clischema.Get("scribe " + tt.name)
+			if !ok {
+				t.Fatalf("missing output schema for %s", tt.name)
+			}
+			schema, err := jsonschema.CompileString(tt.name+".schema.json", rawSchema)
+			if err != nil {
+				t.Fatalf("compile schema: %v\n%s", err, rawSchema)
+			}
+			var data any
+			if err := json.Unmarshal(env.Data, &data); err != nil {
+				t.Fatalf("unmarshal data: %v", err)
+			}
+			if err := schema.Validate(data); err != nil {
+				t.Fatalf("schema validation: %v\ndata=%s\nschema=%s", err, string(env.Data), rawSchema)
+			}
+		})
+	}
+}
+
+func TestListEnvelopeDataMatchesLegacyGolden(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	env := executeEnvelopeCommand(t, []string{"list", "--json"})
+	got := normalizeListLegacyData(t, env.Data, home)
+
+	golden, err := os.ReadFile(filepath.Join("..", "testdata", "golden", "list.legacy.json"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	var want any
+	if err := json.Unmarshal(golden, &want); err != nil {
+		t.Fatalf("unmarshal golden: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		gotJSON, _ := json.MarshalIndent(got, "", "  ")
+		wantJSON, _ := json.MarshalIndent(want, "", "  ")
+		t.Fatalf("list data changed\nwant=%s\ngot=%s", wantJSON, gotJSON)
+	}
+}
+
+func TestListFieldsProjection(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	env := executeEnvelopeCommand(t, []string{"list", "--json", "--fields", "skills"})
+	var data map[string]any
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if _, ok := data["skills"]; !ok {
+		t.Fatalf("projected data missing skills: %#v", data)
+	}
+	if _, ok := data["packages"]; ok {
+		t.Fatalf("projected data kept packages: %#v", data)
+	}
+
+	_, stderr, code := runScribeHelper(t, []string{"list", "--json", "--fields", "nonexistent"}, false)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2\nstderr=%s", code, stderr)
+	}
+	var errEnv struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	jsonStart := strings.LastIndex(stderr, "{\"status\"")
+	if jsonStart < 0 {
+		t.Fatalf("stderr missing JSON envelope: %s", stderr)
+	}
+	if err := json.Unmarshal([]byte(stderr[jsonStart:]), &errEnv); err != nil {
+		t.Fatalf("stderr is not JSON: %v\n%s", err, stderr)
+	}
+	if errEnv.Error.Code != "USAGE_UNKNOWN_FIELD" {
+		t.Fatalf("error code = %q, want USAGE_UNKNOWN_FIELD", errEnv.Error.Code)
+	}
+}
+
+type testEnvelope struct {
+	Status        string          `json:"status"`
+	FormatVersion string          `json:"format_version"`
+	Data          json.RawMessage `json:"data"`
+}
+
+func executeEnvelopeCommand(t *testing.T, args []string) testEnvelope {
+	t.Helper()
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs(args)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute(%v): %v\nstdout=%s\nstderr=%s", args, err, stdout.String(), stderr.String())
+	}
+	var env testEnvelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	return env
+}
+
+func writeEnvelopeTestSkill(t *testing.T, home string) {
+	t.Helper()
+	dir := filepath.Join(home, ".scribe", "skills", "test-skill")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	content := "---\nname: test-skill\ndescription: A test skill\n---\n\n# Test Skill\n\nBody.\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+}
+
+func normalizeListLegacyData(t *testing.T, raw json.RawMessage, home string) any {
+	t.Helper()
+	var data map[string]any
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("unmarshal list data: %v", err)
+	}
+	skills, _ := data["skills"].([]any)
+	for _, item := range skills {
+		skill, _ := item.(map[string]any)
+		if path, _ := skill["path"].(string); path == filepath.Join(home, ".scribe", "skills", "scribe-agent") {
+			skill["path"] = "$HOME/.scribe/skills/scribe-agent"
+		}
+	}
+	return data
+}

--- a/cmd/read_only_envelope_test.go
+++ b/cmd/read_only_envelope_test.go
@@ -104,21 +104,21 @@ func TestListFieldsProjection(t *testing.T) {
 		t.Fatalf("projected data kept packages: %#v", data)
 	}
 
-	_, stderr, code := runScribeHelper(t, []string{"list", "--json", "--fields", "nonexistent"}, false)
+	stdout, stderr, code := runScribeHelper(t, []string{"list", "--json", "--fields", "nonexistent"}, false)
 	if code != 2 {
-		t.Fatalf("exit = %d, want 2\nstderr=%s", code, stderr)
+		t.Fatalf("exit = %d, want 2\nstdout=%s\nstderr=%s", code, stdout, stderr)
 	}
 	var errEnv struct {
 		Error struct {
 			Code string `json:"code"`
 		} `json:"error"`
 	}
-	jsonStart := strings.LastIndex(stderr, "{\"status\"")
+	jsonStart := strings.LastIndex(stdout, "{\"status\"")
 	if jsonStart < 0 {
-		t.Fatalf("stderr missing JSON envelope: %s", stderr)
+		t.Fatalf("stdout missing JSON envelope: %s", stdout)
 	}
-	if err := json.Unmarshal([]byte(stderr[jsonStart:]), &errEnv); err != nil {
-		t.Fatalf("stderr is not JSON: %v\n%s", err, stderr)
+	if err := json.Unmarshal([]byte(stdout[jsonStart:]), &errEnv); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout)
 	}
 	if errEnv.Error.Code != "USAGE_UNKNOWN_FIELD" {
 		t.Fatalf("error code = %q, want USAGE_UNKNOWN_FIELD", errEnv.Error.Code)
@@ -129,6 +129,37 @@ type testEnvelope struct {
 	Status        string          `json:"status"`
 	FormatVersion string          `json:"format_version"`
 	Data          json.RawMessage `json:"data"`
+	Meta          struct {
+		DurationMS  int64 `json:"duration_ms"`
+		BootstrapMS int64 `json:"bootstrap_ms"`
+	} `json:"meta"`
+}
+
+func TestReadOnlyTypedErrorsRoundTripThroughEnvelope(t *testing.T) {
+	stdout, stderr, code := runScribeHelper(t, []string{"explain", "nope", "--json"}, false)
+	if code != 3 {
+		t.Fatalf("exit = %d, want 3\nstdout=%s\nstderr=%s", code, stdout, stderr)
+	}
+
+	var env struct {
+		Status string `json:"status"`
+		Error  struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	jsonStart := strings.LastIndex(stdout, "{\"status\"")
+	if jsonStart < 0 {
+		t.Fatalf("stdout missing JSON envelope: %s", stdout)
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout[jsonStart:])), &env); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if env.Status != "error" {
+		t.Fatalf("status = %q, want error\nenvelope=%#v", env.Status, env)
+	}
+	if env.Error.Code != "SKILL_NOT_FOUND" {
+		t.Fatalf("error code = %q, want SKILL_NOT_FOUND\nenvelope=%#v", env.Error.Code, env)
+	}
 }
 
 func executeEnvelopeCommand(t *testing.T, args []string) testEnvelope {

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -24,7 +24,7 @@ func newRegistryCommand() *cobra.Command {
 	cmd.AddCommand(newRegistryAddCommand())
 	cmd.AddCommand(newRegistryCreateCommand())
 	cmd.AddCommand(newRegistryMigrateCommand())
-	return markJSONSupported(cmd)
+	return cmd
 }
 
 // newRegistryMigrateCommand wires `scribe registry migrate` to the existing

--- a/cmd/registry_add.go
+++ b/cmd/registry_add.go
@@ -47,7 +47,7 @@ Examples:
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.Flags().String("registry", "", "Target registry (owner/repo)")
 	cmd.Flags().StringArray("install", nil, "Per-tool install command for package refs (tool=command, repeatable)")
-	return markJSONSupported(cmd)
+	return cmd
 }
 
 func runRegistryAdd(cmd *cobra.Command, args []string) error {

--- a/cmd/registry_list.go
+++ b/cmd/registry_list.go
@@ -16,7 +16,7 @@ func newRegistryListCommand() *cobra.Command {
 		RunE:  runRegistryList,
 	}
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
-	return markJSONSupported(cmd)
+	return cmd
 }
 
 func runRegistryList(cmd *cobra.Command, args []string) error {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -36,7 +36,7 @@ intent so future syncs keep it removed until you install it again.`,
 	}
 	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
-	return markJSONSupported(cmd)
+	return cmd
 }
 
 // removeResult is the JSON output for `scribe remove`.

--- a/cmd/render_json.go
+++ b/cmd/render_json.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"os"
+	"time"
+
+	clienv "github.com/Naoray/scribe/internal/cli/env"
+	"github.com/Naoray/scribe/internal/cli/envelope"
+	"github.com/Naoray/scribe/internal/cli/output"
+
+	"github.com/spf13/cobra"
+)
+
+func jsonRendererForCommand(cmd *cobra.Command, jsonFlag bool) output.Renderer {
+	mode := clienv.Detect(os.Stdout, os.Stdin, jsonFlag)
+	r := output.New(mode, cmd.OutOrStdout(), cmd.ErrOrStderr())
+	r.SetMeta("command", cmd.CommandPath())
+	if version, ok := cmd.Context().Value(envelope.ScribeVersionKey).(string); ok {
+		r.SetMeta("scribe_version", version)
+	}
+	if start, ok := cmd.Context().Value(envelope.RunEStartKey).(time.Time); ok {
+		duration := time.Since(start).Milliseconds()
+		if duration < 1 {
+			duration = 1
+		}
+		r.SetMeta("duration_ms", duration)
+	}
+	if bootstrapStart, ok := cmd.Context().Value(envelope.BootstrapStartKey).(time.Time); ok {
+		if runStart, ok := cmd.Context().Value(envelope.RunEStartKey).(time.Time); ok {
+			bootstrap := runStart.Sub(bootstrapStart).Milliseconds()
+			if bootstrap < 0 {
+				bootstrap = 0
+			}
+			r.SetMeta("bootstrap_ms", bootstrap)
+		}
+	}
+	return r
+}

--- a/cmd/render_json.go
+++ b/cmd/render_json.go
@@ -18,21 +18,36 @@ func jsonRendererForCommand(cmd *cobra.Command, jsonFlag bool) output.Renderer {
 	if version, ok := cmd.Context().Value(envelope.ScribeVersionKey).(string); ok {
 		r.SetMeta("scribe_version", version)
 	}
-	if start, ok := cmd.Context().Value(envelope.RunEStartKey).(time.Time); ok {
-		duration := time.Since(start).Milliseconds()
-		if duration < 1 {
-			duration = 1
-		}
-		r.SetMeta("duration_ms", duration)
+	return &timingRenderer{Renderer: r, cmd: cmd}
+}
+
+type timingRenderer struct {
+	output.Renderer
+	cmd *cobra.Command
+}
+
+func (r *timingRenderer) Flush() error {
+	ctx := r.cmd.Context()
+	if duration, ok := ctx.Value(envelope.DurationMSKey).(int64); ok {
+		r.SetMeta("duration_ms", positiveDuration(duration))
+	} else if start, ok := ctx.Value(envelope.RunEStartKey).(time.Time); ok {
+		r.SetMeta("duration_ms", positiveDuration(time.Since(start).Milliseconds()))
 	}
-	if bootstrapStart, ok := cmd.Context().Value(envelope.BootstrapStartKey).(time.Time); ok {
-		if runStart, ok := cmd.Context().Value(envelope.RunEStartKey).(time.Time); ok {
-			bootstrap := runStart.Sub(bootstrapStart).Milliseconds()
-			if bootstrap < 0 {
-				bootstrap = 0
-			}
-			r.SetMeta("bootstrap_ms", bootstrap)
+
+	if bootstrap, ok := ctx.Value(envelope.BootstrapMSKey).(int64); ok {
+		r.SetMeta("bootstrap_ms", positiveDuration(bootstrap))
+	} else if bootstrapStart, ok := ctx.Value(envelope.BootstrapStartKey).(time.Time); ok {
+		if runStart, ok := ctx.Value(envelope.RunEStartKey).(time.Time); ok {
+			r.SetMeta("bootstrap_ms", positiveDuration(runStart.Sub(bootstrapStart).Milliseconds()))
 		}
 	}
-	return r
+
+	return r.Renderer.Flush()
+}
+
+func positiveDuration(ms int64) int64 {
+	if ms < 1 {
+		return 1
+	}
+	return ms
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -185,7 +185,6 @@ func newRootCmd() *cobra.Command {
 	}
 
 	cmd.RunE = runDefault
-	markJSONSupported(cmd)
 	cmd.PersistentFlags().Bool("json", false, "Output machine-readable JSON")
 	cmd.CompletionOptions = cobra.CompletionOptions{HiddenDefaultCmd: true}
 

--- a/cmd/root_exit_test.go
+++ b/cmd/root_exit_test.go
@@ -38,8 +38,8 @@ func TestRootExitSubprocessMatrix(t *testing.T) {
 			}
 			if tt.wantJSON {
 				var env map[string]any
-				if err := json.Unmarshal([]byte(strings.TrimSpace(stderr)), &env); err != nil {
-					t.Fatalf("stderr is not JSON envelope: %v\nstderr=%s\nstdout=%s", err, stderr, stdout)
+				if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); err != nil {
+					t.Fatalf("stdout is not JSON envelope: %v\nstderr=%s\nstdout=%s", err, stderr, stdout)
 				}
 				if env["status"] != "error" || env["format_version"] != "1" {
 					t.Fatalf("unexpected envelope: %#v", env)

--- a/cmd/root_flags_test.go
+++ b/cmd/root_flags_test.go
@@ -12,6 +12,12 @@ func TestRootFlags(t *testing.T) {
 		if cmd.Root().PersistentFlags().Lookup("json") == nil {
 			t.Fatalf("%s: root missing persistent --json", cmd.CommandPath())
 		}
+		if cmd.CommandPath() == "scribe list" {
+			if cmd.Flags().Lookup("fields") == nil {
+				t.Fatalf("%s: missing --fields opt-in", cmd.CommandPath())
+			}
+			return
+		}
 		if cmd.Flags().Lookup("fields") != nil {
 			t.Fatalf("%s: unexpected --fields; use output.AttachFieldsFlag for opt-in commands", cmd.CommandPath())
 		}

--- a/cmd/root_hub.go
+++ b/cmd/root_hub.go
@@ -25,7 +25,7 @@ func runDefault(cmd *cobra.Command, args []string) error {
 }
 
 func runStatus(cmd *cobra.Command, args []string) error {
-	jsonFlag, _ := cmd.Flags().GetBool("json")
+	jsonFlag := jsonFlagPassed(cmd)
 	factory := newCommandFactory()
 
 	cfg, err := factory.Config()
@@ -38,7 +38,11 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	if jsonFlag || !isatty.IsTerminal(os.Stdout.Fd()) || os.Getenv("CI") != "" {
-		return writeStatusJSON(os.Stdout, Version, cfg, st)
+		r := jsonRendererForCommand(cmd, jsonFlag)
+		if err := r.Result(buildStatusOutput(Version, cfg, st)); err != nil {
+			return err
+		}
+		return r.Flush()
 	}
 
 	if os.Getenv("TERM") == "dumb" {
@@ -57,31 +61,33 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func writeStatusJSON(w io.Writer, version string, cfg *config.Config, st *state.State) error {
-	repos := cfg.TeamRepos()
+type statusOutput struct {
+	Version        string   `json:"version"`
+	Registries     []string `json:"registries"`
+	InstalledCount int      `json:"installed_count"`
+	LastSync       string   `json:"last_sync,omitempty"`
+}
 
-	status := struct {
-		Version        string   `json:"version"`
-		Registries     []string `json:"registries"`
-		InstalledCount int      `json:"installed_count"`
-		LastSync       string   `json:"last_sync,omitempty"`
-	}{
+func buildStatusOutput(version string, cfg *config.Config, st *state.State) statusOutput {
+	repos := cfg.TeamRepos()
+	out := statusOutput{
 		Version:        version,
 		Registries:     repos,
 		InstalledCount: len(st.Installed),
 	}
-
 	if repos == nil {
-		status.Registries = []string{}
+		out.Registries = []string{}
 	}
-
 	if !st.LastSync.IsZero() {
-		status.LastSync = st.LastSync.UTC().Format(time.RFC3339)
+		out.LastSync = st.LastSync.UTC().Format(time.RFC3339)
 	}
+	return out
+}
 
+func writeStatusJSON(w io.Writer, version string, cfg *config.Config, st *state.State) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	return enc.Encode(status)
+	return enc.Encode(buildStatusOutput(version, cfg, st))
 }
 
 // syncTime returns a human-readable last-sync string. Uses "never" for the

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -24,8 +24,8 @@ func TestSchemaCommandListInputsOnly(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal: %v\n%s", err, out.String())
 	}
-	if got.OutputSchema != nil {
-		t.Fatalf("output_schema = %s, want null", string(*got.OutputSchema))
+	if got.OutputSchema == nil {
+		t.Fatalf("output_schema = nil, want list schema")
 	}
 	var input map[string]any
 	if err := json.Unmarshal(got.InputSchema, &input); err != nil {

--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -51,7 +51,7 @@ Examples:
 	cmd.MarkFlagsMutuallyExclusive("inherit", "pin")
 	cmd.MarkFlagsMutuallyExclusive("inherit", "add")
 	cmd.MarkFlagsMutuallyExclusive("inherit", "remove")
-	return markJSONSupported(cmd)
+	return cmd
 }
 
 type skillEditResult struct {
@@ -81,7 +81,7 @@ func newSkillRepairCommand() *cobra.Command {
 	if err := cmd.MarkFlagRequired("tool"); err != nil {
 		panic(err)
 	}
-	return markJSONSupported(cmd)
+	return cmd
 }
 
 func runSkillEdit(cmd *cobra.Command, args []string) error {

--- a/cmd/skill_tools_cmd.go
+++ b/cmd/skill_tools_cmd.go
@@ -37,7 +37,7 @@ Examples:
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.MarkFlagsMutuallyExclusive("enable", "reset")
 	cmd.MarkFlagsMutuallyExclusive("disable", "reset")
-	return markJSONSupported(cmd)
+	return cmd
 }
 
 func runSkillTools(cmd *cobra.Command, args []string) error {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -16,6 +16,5 @@ Examples:
 		Args: cobra.NoArgs,
 		RunE: runStatus,
 	}
-	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	return markJSONSupported(cmd)
 }

--- a/cmd/status_schema.go
+++ b/cmd/status_schema.go
@@ -1,0 +1,20 @@
+package cmd
+
+import clischema "github.com/Naoray/scribe/internal/cli/schema"
+
+var statusOutputSchema = `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "version": { "type": "string" },
+    "registries": { "type": "array", "items": { "type": "string" } },
+    "installed_count": { "type": "integer" },
+    "last_sync": { "type": "string" }
+  },
+  "required": ["version", "registries", "installed_count"],
+  "additionalProperties": false
+}`
+
+func init() {
+	clischema.Register("scribe status", statusOutputSchema)
+}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -17,7 +17,7 @@ func newSyncCommand() *cobra.Command {
 	cmd.Flags().Bool("trust-all", false, "Approve all package install commands without prompting")
 	cmd.Flags().Bool("all", false, "Sync all registries (default behavior)")
 	cmd.Flags().MarkHidden("all")
-	return markJSONSupported(cmd)
+	return cmd
 }
 
 func runSync(cmd *cobra.Command, args []string) error {

--- a/cmd/tools.go
+++ b/cmd/tools.go
@@ -37,7 +37,7 @@ Examples:
 	cmd.AddCommand(newToolsAddCommand())
 	cmd.AddCommand(newToolsEnableCommand())
 	cmd.AddCommand(newToolsDisableCommand())
-	return markJSONSupported(cmd)
+	return cmd
 }
 
 func newToolsAddCommand() *cobra.Command {

--- a/cmd/wrap_runE_test.go
+++ b/cmd/wrap_runE_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,5 +33,28 @@ func TestWrapRunEStampsTiming(t *testing.T) {
 	bootstrap, ok := cmd.Context().Value(envelope.BootstrapMSKey).(int64)
 	if !ok || bootstrap < 0 {
 		t.Fatalf("bootstrap_ms = %v, want >= 0", cmd.Context().Value(envelope.BootstrapMSKey))
+	}
+}
+
+func TestWrapRunERendererEmitsTiming(t *testing.T) {
+	stdout, stderr, code := runScribeHelper(t, []string{"list", "--json"}, false)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0\nstdout=%s\nstderr=%s", code, stdout, stderr)
+	}
+
+	var env struct {
+		Meta struct {
+			DurationMS  int64 `json:"duration_ms"`
+			BootstrapMS int64 `json:"bootstrap_ms"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if env.Meta.DurationMS <= 0 {
+		t.Fatalf("duration_ms = %d, want > 0\nenvelope=%s", env.Meta.DurationMS, stdout)
+	}
+	if env.Meta.BootstrapMS <= 0 {
+		t.Fatalf("bootstrap_ms = %d, want > 0\nenvelope=%s", env.Meta.BootstrapMS, stdout)
 	}
 }

--- a/internal/cli/errors/error.go
+++ b/internal/cli/errors/error.go
@@ -24,7 +24,7 @@ type Error struct {
 	Retryable   bool   `json:"retryable"`
 	Remediation string `json:"remediation,omitempty"`
 	Resource    string `json:"resource,omitempty"`
-	Exit        int    `json:"-"`
+	Exit        int    `json:"exit_code,omitempty"`
 	err         error
 }
 

--- a/internal/cli/output/json.go
+++ b/internal/cli/output/json.go
@@ -36,7 +36,7 @@ func (r *jsonRenderer) Result(data any) error {
 func (r *jsonRenderer) Error(err *clierrors.Error) error {
 	r.err = err
 	r.SetStatus(envelope.StatusError)
-	return r.flushTo(r.errOut)
+	return r.flushTo(r.out)
 }
 
 func (r *jsonRenderer) Progress(msg string) {

--- a/internal/cli/output/json_test.go
+++ b/internal/cli/output/json_test.go
@@ -55,13 +55,13 @@ func TestJSONRendererError(t *testing.T) {
 	}
 
 	var got envelope.Envelope
-	if decodeErr := json.Unmarshal(stderr.Bytes(), &got); decodeErr != nil {
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &got); decodeErr != nil {
 		t.Fatalf("unmarshal: %v", decodeErr)
 	}
 	if got.Status != envelope.StatusError || got.Error.Code != "BAD" {
 		t.Fatalf("envelope = %+v", got)
 	}
-	if stdout.Len() != 0 {
-		t.Fatalf("stdout = %q, want empty", stdout.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
 }

--- a/internal/workflow/list.go
+++ b/internal/workflow/list.go
@@ -50,19 +50,68 @@ func ListJSONSteps() []Step {
 // the loader logic the TUI runs (in cmd/) but writes structured output to
 // stdout instead of rendering a TUI.
 func StepWriteListJSON(ctx context.Context, b *Bag) error {
-	w := os.Stdout
+	out, stateDirty, err := BuildListJSONData(ctx, b)
+	if stateDirty {
+		b.MarkStateDirty()
+	}
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
 
+// ListOutput is the legacy payload shape for `scribe list --json`.
+type ListOutput map[string]any
+
+type ListLocalSkillJSON struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Package     string   `json:"package,omitempty"`
+	Revision    int      `json:"revision,omitempty"`
+	ContentHash string   `json:"content_hash,omitempty"`
+	Targets     []string `json:"targets"`
+	Managed     bool     `json:"managed"`
+	Origin      string   `json:"origin,omitempty"`
+	Path        string   `json:"path,omitempty"`
+}
+
+type ListLocalPackageJSON struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Revision    int      `json:"revision,omitempty"`
+	Path        string   `json:"path,omitempty"`
+	InstallCmd  string   `json:"install_cmd,omitempty"`
+	Sources     []string `json:"sources,omitempty"`
+}
+
+type ListRemoteSkillJSON struct {
+	Name       string   `json:"name"`
+	Status     string   `json:"status"`
+	Version    string   `json:"version,omitempty"`
+	LoadoutRef string   `json:"loadout_ref,omitempty"`
+	Maintainer string   `json:"maintainer,omitempty"`
+	Agents     []string `json:"agents,omitempty"`
+}
+
+type ListRegistryJSON struct {
+	Registry string                `json:"registry"`
+	Skills   []ListRemoteSkillJSON `json:"skills"`
+}
+
+func BuildListJSONData(ctx context.Context, b *Bag) (ListOutput, bool, error) {
 	// Local view is the default; --remote switches to registry diff.
 	if !b.RemoteFlag {
 		skills, err := discovery.OnDisk(b.State)
 		if err != nil {
-			return err
+			return ListOutput{}, false, err
 		}
-		return printLocalJSON(w, skills, b.State)
+		return buildLocalListJSON(skills, b.State), false, nil
 	}
 
 	if err := StepFilterRegistries(ctx, b); err != nil {
-		return err
+		return ListOutput{}, false, err
 	}
 
 	syncer := &sync.Syncer{
@@ -71,35 +120,17 @@ func StepWriteListJSON(ctx context.Context, b *Bag) error {
 		Tools:    []tools.Tool{},
 	}
 
-	stateDirty, err := printMultiListJSON(ctx, w, b.Repos, syncer, b.State)
-	if stateDirty {
-		b.MarkStateDirty()
-	}
-	return err
+	return buildMultiListJSON(ctx, b.Repos, syncer, b.State)
 }
 
 func printLocalJSON(w io.Writer, skills []discovery.Skill, st *state.State) error {
-	type localSkillJSON struct {
-		Name        string   `json:"name"`
-		Description string   `json:"description,omitempty"`
-		Package     string   `json:"package,omitempty"`
-		Revision    int      `json:"revision,omitempty"`
-		ContentHash string   `json:"content_hash,omitempty"`
-		Targets     []string `json:"targets"`
-		Managed     bool     `json:"managed"`
-		Origin      string   `json:"origin,omitempty"`
-		Path        string   `json:"path,omitempty"`
-	}
-	type localPackageJSON struct {
-		Name        string   `json:"name"`
-		Description string   `json:"description,omitempty"`
-		Revision    int      `json:"revision,omitempty"`
-		Path        string   `json:"path,omitempty"`
-		InstallCmd  string   `json:"install_cmd,omitempty"`
-		Sources     []string `json:"sources,omitempty"`
-	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(buildLocalListJSON(skills, st))
+}
 
-	skillsOut := make([]localSkillJSON, 0, len(skills))
+func buildLocalListJSON(skills []discovery.Skill, st *state.State) ListOutput {
+	skillsOut := make([]ListLocalSkillJSON, 0, len(skills))
 	// Emit one entry per discovered skill that is NOT tracked as a package.
 	// Package entries come from the state map because discovery walks
 	// ~/.scribe/skills/ and tool dirs, neither of which now hold packages.
@@ -124,7 +155,7 @@ func printLocalJSON(w io.Writer, skills []discovery.Skill, st *state.State) erro
 			origin = "local"
 		}
 
-		skillsOut = append(skillsOut, localSkillJSON{
+		skillsOut = append(skillsOut, ListLocalSkillJSON{
 			Name:        sk.Name,
 			Description: sk.Description,
 			Package:     sk.Package,
@@ -137,7 +168,7 @@ func printLocalJSON(w io.Writer, skills []discovery.Skill, st *state.State) erro
 		})
 	}
 
-	packagesOut := make([]localPackageJSON, 0)
+	packagesOut := make([]ListLocalPackageJSON, 0)
 	for name, inst := range st.Installed {
 		if !inst.IsPackage() {
 			continue
@@ -149,7 +180,7 @@ func printLocalJSON(w io.Writer, skills []discovery.Skill, st *state.State) erro
 				srcRegistries = append(srcRegistries, s.Registry)
 			}
 		}
-		packagesOut = append(packagesOut, localPackageJSON{
+		packagesOut = append(packagesOut, ListLocalPackageJSON{
 			Name:       name,
 			Revision:   inst.Revision,
 			Path:       pkgsDir,
@@ -158,12 +189,10 @@ func printLocalJSON(w io.Writer, skills []discovery.Skill, st *state.State) erro
 		})
 	}
 
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(map[string]any{
+	return ListOutput{
 		"skills":   skillsOut,
 		"packages": packagesOut,
-	})
+	}
 }
 
 // stateInstalledPackageDir resolves the canonical package directory for a
@@ -178,21 +207,15 @@ func stateInstalledPackageDir(name string) (string, error) {
 }
 
 func printMultiListJSON(ctx context.Context, w io.Writer, repos []string, syncer *sync.Syncer, st *state.State) (bool, error) {
-	type skillJSON struct {
-		Name       string   `json:"name"`
-		Status     string   `json:"status"`
-		Version    string   `json:"version,omitempty"`
-		LoadoutRef string   `json:"loadout_ref,omitempty"`
-		Maintainer string   `json:"maintainer,omitempty"`
-		Agents     []string `json:"agents,omitempty"`
+	out, stateDirty, err := buildMultiListJSON(ctx, repos, syncer, st)
+	if err != nil {
+		return stateDirty, err
 	}
+	return stateDirty, json.NewEncoder(w).Encode(out)
+}
 
-	type registryJSON struct {
-		Registry string      `json:"registry"`
-		Skills   []skillJSON `json:"skills"`
-	}
-
-	var registries []registryJSON
+func buildMultiListJSON(ctx context.Context, repos []string, syncer *sync.Syncer, st *state.State) (ListOutput, bool, error) {
+	var registries []ListRegistryJSON
 	var warnings []string
 	stateDirty := false
 
@@ -211,7 +234,7 @@ func printMultiListJSON(ctx context.Context, w io.Writer, repos []string, syncer
 		}
 		stateDirty = stateDirty || st.ClearRegistryFailure(teamRepo)
 
-		skills := make([]skillJSON, 0, len(statuses))
+		skills := make([]ListRemoteSkillJSON, 0, len(statuses))
 		for _, sk := range statuses {
 			ver := ""
 			var agents []string
@@ -219,7 +242,7 @@ func printMultiListJSON(ctx context.Context, w io.Writer, repos []string, syncer
 				ver = sk.Installed.DisplayVersion()
 				agents = sk.Installed.Tools
 			}
-			skills = append(skills, skillJSON{
+			skills = append(skills, ListRemoteSkillJSON{
 				Name:       sk.Name,
 				Status:     sk.Status.String(),
 				Version:    ver,
@@ -229,17 +252,17 @@ func printMultiListJSON(ctx context.Context, w io.Writer, repos []string, syncer
 			})
 		}
 
-		registries = append(registries, registryJSON{
+		registries = append(registries, ListRegistryJSON{
 			Registry: teamRepo,
 			Skills:   skills,
 		})
 	}
 
-	out := map[string]any{"registries": registries}
+	out := ListOutput{"registries": registries}
 	if len(warnings) > 0 {
 		out["warnings"] = warnings
 	}
-	return stateDirty, json.NewEncoder(w).Encode(out)
+	return out, stateDirty, nil
 }
 
 func CountStatuses(statuses []sync.SkillStatus) map[sync.Status]int {

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -1,0 +1,14 @@
+{
+  "packages": [],
+  "skills": [
+    {
+      "content_hash": "ea75654e",
+      "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
+      "managed": true,
+      "name": "scribe-agent",
+      "path": "$HOME/.scribe/skills/scribe-agent",
+      "revision": 1,
+      "targets": []
+    }
+  ]
+}


### PR DESCRIPTION
Second of 3 PRs implementing the agent-first foundation triplet (todos #399 #400 #404).

## What lands
- Migrates `list`, `status`, `doctor`, `explain`, `guide` to use `internal/cli/output.Renderer` and emit the standard envelope (`status`, `format_version=1`, `data`, `meta`) on `--json`.
- Each migrated command:
  - Marked with `markJSONSupported` (root `--json` gate passes).
  - Registered output schema visible via `scribe schema <cmd>`.
  - `--fields f1,f2` projection where data is tabular.
  - Wrapped registry/network/validation errors with `*cli.Error` for semantic exit codes.
- CHANGELOG entry documents the format_version=1 break for these read-only commands.

## What does NOT land
- Mutator commands (`sync`, `add`, `adopt`, `install`, `remove`, etc.) — those ship in PR C alongside `workflow.jsonFormatter` envelope wrap.
- `CLAUDE.md` generation + embedding — PR C.

## BREAKING change
`scribe list --json | jq '.foo'` now requires `.data.foo`. CHANGELOG.md updated.

## Architecture sources
- Locked architecture: solo scratchpad 900
- r2 plan: solo scratchpad 906
- r2 addendum: solo scratchpad 912
- PR A foundation: PR #117 (sha 57c0d1c)

## Test plan
- [x] go test ./... -count=1
- [x] go build ./...
- [x] Subprocess proof: each migrated cmd emits envelope with format_version="1" and status="ok"
- [x] Schema registry proof: each migrated cmd's `scribe schema <name>` returns non-null output_schema
- [x] Legacy diff for `list`: `data.<keys>` byte-identical to pre-migration capture
- [x] Schema validation: golden envelopes validate against registered schemas (jsonschema/v5 in tests)