### PR TITLE
feat(projectfile): .scribe.yaml schema + parser (todo #367)

### DIFF
--- a/internal/projectfile/projectfile.go
+++ b/internal/projectfile/projectfile.go
@@ -43,6 +43,31 @@ func Load(path string) (*ProjectFile, error) {
 	return &pf, nil
 }
 
+// Save writes a ProjectFile to path atomically.
+func Save(path string, pf *ProjectFile) error {
+	if pf == nil {
+		pf = &ProjectFile{}
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create project file dir: %w", err)
+	}
+
+	data, err := yaml.Marshal(pf)
+	if err != nil {
+		return fmt.Errorf("encode project file: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write project file: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("save project file: %w", err)
+	}
+	return nil
+}
+
 // Find walks upward from startDir looking for .scribe.yaml.
 // It returns an empty string when no project file exists.
 func Find(startDir string) (string, error) {

--- a/internal/projectfile/projectfile.go
+++ b/internal/projectfile/projectfile.go
@@ -1,0 +1,76 @@
+package projectfile
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Filename is the conventional name for a Scribe project file.
+const Filename = ".scribe.yaml"
+
+// ProjectFile declares which Scribe assets a project wants projected locally.
+type ProjectFile struct {
+	Kits     []string `yaml:"kits,omitempty"`
+	Snippets []string `yaml:"snippets,omitempty"`
+	Add      []string `yaml:"add,omitempty"`
+	Remove   []string `yaml:"remove,omitempty"`
+}
+
+// Load reads a .scribe.yaml file from path.
+// Missing or empty files are treated as no Scribe activity for the project.
+func Load(path string) (*ProjectFile, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return &ProjectFile{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read project file: %w", err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return &ProjectFile{}, nil
+	}
+
+	var pf ProjectFile
+	if err := yaml.Unmarshal(data, &pf); err != nil {
+		return nil, fmt.Errorf("parse project file: %w", err)
+	}
+	return &pf, nil
+}
+
+// Find walks upward from startDir looking for .scribe.yaml.
+// It returns an empty string when no project file exists.
+func Find(startDir string) (string, error) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve start dir: %w", err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		return "", fmt.Errorf("stat start dir: %w", err)
+	}
+	if !info.IsDir() {
+		dir = filepath.Dir(dir)
+	}
+
+	for {
+		candidate := filepath.Join(dir, Filename)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("stat project file: %w", err)
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", nil
+		}
+		dir = parent
+	}
+}

--- a/internal/projectfile/projectfile_test.go
+++ b/internal/projectfile/projectfile_test.go
@@ -1,0 +1,151 @@
+package projectfile
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    *ProjectFile
+		wantErr bool
+	}{
+		{
+			name:    "empty file",
+			content: "",
+			want:    &ProjectFile{},
+		},
+		{
+			name:    "minimal kits only",
+			content: "kits:\n  - core\n",
+			want: &ProjectFile{
+				Kits: []string{"core"},
+			},
+		},
+		{
+			name: "all fields present",
+			content: `kits:
+  - core
+snippets:
+  - editor
+add:
+  - local/agent
+remove:
+  - old/skill
+`,
+			want: &ProjectFile{
+				Kits:     []string{"core"},
+				Snippets: []string{"editor"},
+				Add:      []string{"local/agent"},
+				Remove:   []string{"old/skill"},
+			},
+		},
+		{
+			name:    "malformed yaml",
+			content: "kits: [",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), Filename)
+			if err := os.WriteFile(path, []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("write project file: %v", err)
+			}
+
+			got, err := Load(path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Load() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Load() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadNonexistentPath(t *testing.T) {
+	t.Parallel()
+
+	got, err := Load(filepath.Join(t.TempDir(), Filename))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, &ProjectFile{}) {
+		t.Fatalf("Load() = %#v, want empty project file", got)
+	}
+}
+
+func TestFindWalksUp(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	projectPath := filepath.Join(root, Filename)
+	if err := os.WriteFile(projectPath, []byte("kits:\n  - core\n"), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+
+	nested := filepath.Join(root, "one", "two")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("create nested dir: %v", err)
+	}
+
+	got, err := Find(nested)
+	if err != nil {
+		t.Fatalf("Find() error = %v", err)
+	}
+	if got != projectPath {
+		t.Fatalf("Find() = %q, want %q", got, projectPath)
+	}
+}
+
+func TestFindNotFound(t *testing.T) {
+	t.Parallel()
+
+	got, err := Find(t.TempDir())
+	if err != nil {
+		t.Fatalf("Find() error = %v", err)
+	}
+	if got != "" {
+		t.Fatalf("Find() = %q, want empty string", got)
+	}
+}
+
+func TestSaveRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "project", Filename)
+	want := &ProjectFile{
+		Kits:     []string{"core", "review"},
+		Snippets: []string{"editor"},
+		Add:      []string{"local/agent"},
+		Remove:   []string{"old/skill"},
+	}
+
+	if err := Save(path, want); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Load() after Save() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/projectfile` for the project-root `.scribe.yaml` file, distinct from registry `scribe.yaml` manifests.
- Defines the bounded `ProjectFile` schema with `kits`, `snippets`, `add`, and `remove`.
- Implements `Load`, upward `Find`, and atomic `Save` using a temp file plus rename.

## Scope
Only Solo todo #367: pure project-file data layer. No state migration, projection changes, kit/snippet schemas, CLI commands, or command integration.

## Spec
Requested spec path: `docs/superpowers/specs/2026-04-29-kits-and-snippets-design.md` (Key Decision 4). That file was not present in this checkout at HEAD `85dc439`; implementation follows the explicit bounded schema and behavior in todo #367.

## Test Plan
- `go build ./...`
- `go test ./internal/projectfile/ -count=1`
- `go vet ./...`.