### PR TITLE
feat(hooks): scribe-hook.sh script + embed (todo #392)

### DIFF
--- a/internal/hooks/embed.go
+++ b/internal/hooks/embed.go
@@ -1,0 +1,13 @@
+package hooks
+
+import _ "embed"
+
+//go:embed scripts/scribe-hook.sh
+var script []byte
+
+// Script returns the embedded Claude Code hook script.
+func Script() []byte {
+	out := make([]byte, len(script))
+	copy(out, script)
+	return out
+}

--- a/internal/hooks/embed_test.go
+++ b/internal/hooks/embed_test.go
@@ -1,0 +1,33 @@
+package hooks
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestScriptEmbedsHook(t *testing.T) {
+	t.Parallel()
+
+	got := Script()
+	if len(got) < 100 {
+		t.Fatalf("Script() length = %d, want nontrivial embedded script", len(got))
+	}
+	if !bytes.HasPrefix(got, []byte("#!/usr/bin/env bash\n")) {
+		t.Fatalf("Script() does not start with bash shebang: %q", got[:min(len(got), 32)])
+	}
+	if !bytes.Contains(got, []byte("hookSpecificOutput")) {
+		t.Fatal("Script() does not contain Claude Code hook output key")
+	}
+}
+
+func TestScriptReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	first := Script()
+	first[0] = 'x'
+
+	second := Script()
+	if second[0] != '#' {
+		t.Fatal("Script() returned mutable embedded backing storage")
+	}
+}

--- a/internal/hooks/script_test.go
+++ b/internal/hooks/script_test.go
@@ -1,0 +1,117 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestScribeHookScriptOutputsAdditionalContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires bash")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("requires bash")
+	}
+
+	binDir := t.TempDir()
+	fakeScribe := filepath.Join(binDir, "scribe")
+	if err := os.WriteFile(fakeScribe, []byte(`#!/usr/bin/env bash
+set -eu
+case "$1 $2" in
+  "list --json")
+    printf '{"skills":[{"name":"alpha"},{"name":"beta"}]}\n'
+    ;;
+  "status --json")
+    printf '{"installed_count":2,"registries":["owner/repo"],"last_sync":"2026-04-30T10:10:47Z"}\n'
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout := runHookScript(t, binDir+string(os.PathListSeparator)+os.Getenv("PATH"), []byte(`{"hook_event_name":"PostToolUseFailure"}`))
+
+	var envelope struct {
+		HookSpecificOutput struct {
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout, &envelope); err != nil {
+		t.Fatalf("hook stdout is not valid JSON: %v\n%s", err, stdout)
+	}
+
+	context := envelope.HookSpecificOutput.AdditionalContext
+	if context == "" {
+		t.Fatal("additionalContext is empty")
+	}
+	for _, want := range []string{
+		"Scribe is available on PATH",
+		"Installed skills: 2",
+		"Examples: alpha, beta",
+		"Registry status: 2 installed, 1 registries",
+		"scribe explain <name>",
+		"scribe doctor",
+	} {
+		if !strings.Contains(context, want) {
+			t.Fatalf("additionalContext missing %q:\n%s", want, context)
+		}
+	}
+}
+
+func TestScribeHookScriptHandlesMissingScribe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires bash")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("requires bash")
+	}
+
+	stdout := runHookScript(t, t.TempDir(), nil)
+
+	var envelope struct {
+		HookSpecificOutput struct {
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout, &envelope); err != nil {
+		t.Fatalf("hook stdout is not valid JSON without scribe: %v\n%s", err, stdout)
+	}
+	if !strings.Contains(envelope.HookSpecificOutput.AdditionalContext, "scribe not available") {
+		t.Fatalf("additionalContext = %q, want missing-scribe message", envelope.HookSpecificOutput.AdditionalContext)
+	}
+}
+
+func runHookScript(t *testing.T, pathEnv string, stdin []byte) []byte {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", filepath.Join("scripts", "scribe-hook.sh"))
+	cmd.Dir = "."
+	cmd.Env = append(os.Environ(), "PATH="+pathEnv)
+	cmd.Stdin = bytes.NewReader(stdin)
+
+	stdout, err := cmd.Output()
+	if ctx.Err() != nil {
+		t.Fatalf("hook script timed out: %v", ctx.Err())
+	}
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("hook script failed: %v\nstderr:\n%s", err, exitErr.Stderr)
+		}
+		t.Fatalf("hook script failed: %v", err)
+	}
+	return stdout
+}

--- a/internal/hooks/scripts/scribe-hook.sh
+++ b/internal/hooks/scripts/scribe-hook.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# scribe-hook.sh - Claude Code PostToolUseFailure hook.
+#
+# Stdin: Claude Code's PostToolUseFailure JSON payload.
+# Stdout: JSON shaped as:
+#   {"hookSpecificOutput":{"additionalContext":"..."}}
+#
+# The hook is fail-soft: it always emits valid JSON, even when scribe, jq, or
+# individual scribe commands are unavailable.
+
+set -u
+
+MAX_CONTEXT_CHARS=1800
+
+escape_json_string() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -Rn --arg value "$1" '$value'
+    return
+  fi
+
+  local value=${1//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\t'/\\t}
+  printf '"%s"' "$value"
+}
+
+emit_context() {
+  local context=$1
+
+  if [ "${#context}" -gt "$MAX_CONTEXT_CHARS" ]; then
+    context="${context:0:$MAX_CONTEXT_CHARS}..."
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    jq -n --arg context "$context" '{
+      hookSpecificOutput: {
+        additionalContext: $context
+      }
+    }'
+    return
+  fi
+
+  printf '{"hookSpecificOutput":{"additionalContext":%s}}\n' "$(escape_json_string "$context")"
+}
+
+json_length() {
+  local payload=$1
+
+  if ! command -v jq >/dev/null 2>&1; then
+    printf ''
+    return
+  fi
+
+  printf '%s' "$payload" | jq -r '
+    if type == "array" then length
+    elif type == "object" and (.skills | type) == "array" then .skills | length
+    elif type == "object" and (.installed | type) == "array" then .installed | length
+    elif type == "object" and (.items | type) == "array" then .items | length
+    else empty
+    end
+  ' 2>/dev/null
+}
+
+status_summary() {
+  local payload=$1
+
+  if ! command -v jq >/dev/null 2>&1; then
+    printf ''
+    return
+  fi
+
+  printf '%s' "$payload" | jq -r '
+    if type != "object" then empty
+    else
+      [
+        (if (.installed_count | type) == "number" then "\(.installed_count) installed" else empty end),
+        (if (.registries | type) == "array" then "\(.registries | length) registries" else empty end),
+        (if (.last_sync | type) == "string" and .last_sync != "" then "last sync \(.last_sync)" else empty end)
+      ] | join(", ")
+    end
+  ' 2>/dev/null
+}
+
+skill_names() {
+  local payload=$1
+
+  if ! command -v jq >/dev/null 2>&1; then
+    printf ''
+    return
+  fi
+
+  printf '%s' "$payload" | jq -r '
+    def names:
+      if type == "array" then .
+      elif type == "object" and (.skills | type) == "array" then .skills
+      elif type == "object" and (.installed | type) == "array" then .installed
+      elif type == "object" and (.items | type) == "array" then .items
+      else []
+      end
+      | map(if type == "object" then .name // empty else empty end)
+      | map(select(. != ""));
+    names | .[:8] | join(", ")
+  ' 2>/dev/null
+}
+
+# Drain stdin so Claude Code can pipe payloads without affecting hook output.
+cat >/dev/null 2>&1 || true
+
+if ! command -v scribe >/dev/null 2>&1; then
+  emit_context "scribe not available. Suggested next steps: install scribe or run scribe doctor once scribe is on PATH."
+  exit 0
+fi
+
+context="Scribe is available on PATH."
+
+list_json=$(scribe list --json 2>/dev/null) || list_json=''
+if [ -n "$list_json" ]; then
+  installed_count=$(json_length "$list_json")
+  names=$(skill_names "$list_json")
+  if [ -n "$installed_count" ]; then
+    context="$context Installed skills: $installed_count."
+  else
+    context="$context Installed skills: available via 'scribe list --json'."
+  fi
+  if [ -n "$names" ]; then
+    context="$context Examples: $names."
+  fi
+else
+  context="$context Installed skills: unavailable right now."
+fi
+
+status_json=$(scribe status --json 2>/dev/null) || status_json=''
+if [ -n "$status_json" ]; then
+  summary=$(status_summary "$status_json")
+  if [ -n "$summary" ]; then
+    context="$context Registry status: $summary."
+  else
+    context="$context Registry status: available via 'scribe status --json'."
+  fi
+else
+  context="$context Registry status: unavailable right now."
+fi
+
+context="$context Suggested commands: scribe list, scribe status, scribe explain <name>, scribe install <name>, scribe doctor."
+
+emit_context "$context"


### PR DESCRIPTION
## Summary
- Adds `internal/hooks/scripts/scribe-hook.sh` as a Claude Code `PostToolUseFailure` hook bridge.
- Embeds the script into the Go binary through `internal/hooks.Script()`.
- Covers embedded bytes and hook stdin/stdout JSON behavior with tests.

## Plan Doc
- `docs/superpowers/plans/2026-04-14-nono-inspired-patterns.md` Task 1

## Files
- `internal/hooks/scripts/scribe-hook.sh`
- `internal/hooks/embed.go`
- `internal/hooks/embed_test.go`
- `internal/hooks/script_test.go`

## Scope
Only Solo todo #392 is included. This PR does not add installer logic (#393), Cobra command surface (#394), sync auto-install integration (#395), or end-to-end integration tests (#398).

## Test Plan
- `go build ./...`
- `go test ./internal/hooks/ -count=1`
- `go vet ./...`
- `bash internal/hooks/scripts/scribe-hook.sh < /dev/null`.