### PR TITLE
feat(hooks): installer for scribe-hook.sh in Claude Code settings (todo #393)

### DIFF
--- a/internal/hooks/install.go
+++ b/internal/hooks/install.go
@@ -1,0 +1,364 @@
+package hooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const (
+	hookFileName = "scribe-hook.sh"
+	hookEvent    = "PostToolUseFailure"
+	hookMatcher  = "*"
+)
+
+// Status describes the result of a hook installer operation.
+type Status int
+
+const (
+	StatusInstalled Status = iota
+	StatusAlreadyInstalled
+	StatusNotApplicable
+)
+
+// Installer installs the embedded Scribe hook into Claude Code.
+type Installer struct {
+	// HomeDir is dependency-injected for tests. If empty, os.UserHomeDir is used.
+	HomeDir string
+}
+
+// Install reads ~/.claude/settings.json, adds the Scribe hook entry, and writes
+// the embedded script to ~/.claude/hooks/scribe-hook.sh with 0755 permissions.
+func (i *Installer) Install() (Status, error) {
+	claudeDir, ok, err := i.claudeDir()
+	if err != nil {
+		return StatusNotApplicable, err
+	}
+	if !ok {
+		return StatusNotApplicable, nil
+	}
+
+	scriptPath := managedScriptPath(claudeDir)
+	settings, settingsMode, err := readSettings(claudeDir)
+	if err != nil {
+		return StatusNotApplicable, err
+	}
+
+	alreadyInstalled := scriptIsCurrent(scriptPath) && settingsHasManagedHook(settings, scriptPath)
+	if alreadyInstalled {
+		return StatusAlreadyInstalled, nil
+	}
+
+	settings, _ = addManagedHook(settings, scriptPath)
+	if err := writeScript(scriptPath); err != nil {
+		return StatusNotApplicable, err
+	}
+	if err := writeSettings(claudeDir, settings, settingsMode); err != nil {
+		return StatusNotApplicable, err
+	}
+
+	return StatusInstalled, nil
+}
+
+// Uninstall removes the Scribe hook entry from settings.json and deletes the
+// managed hook script. It is idempotent.
+func (i *Installer) Uninstall() error {
+	claudeDir, ok, err := i.claudeDir()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	scriptPath := managedScriptPath(claudeDir)
+	if err := os.Remove(scriptPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove hook script: %w", err)
+	}
+
+	settings, settingsMode, err := readSettings(claudeDir)
+	if err != nil {
+		return err
+	}
+	settings, changed := removeManagedHook(settings, scriptPath)
+	if !changed {
+		return nil
+	}
+	if err := writeSettings(claudeDir, settings, settingsMode); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CurrentStatus reports whether the hook is currently installed. Because the
+// Status enum intentionally has no NotInstalled value, StatusInstalled means
+// Claude Code is present but the managed hook is not fully installed.
+func (i *Installer) CurrentStatus() (Status, error) {
+	claudeDir, ok, err := i.claudeDir()
+	if err != nil {
+		return StatusNotApplicable, err
+	}
+	if !ok {
+		return StatusNotApplicable, nil
+	}
+
+	settings, _, err := readSettings(claudeDir)
+	if err != nil {
+		return StatusNotApplicable, err
+	}
+	scriptPath := managedScriptPath(claudeDir)
+	if scriptIsCurrent(scriptPath) && settingsHasManagedHook(settings, scriptPath) {
+		return StatusAlreadyInstalled, nil
+	}
+	return StatusInstalled, nil
+}
+
+func (i *Installer) claudeDir() (string, bool, error) {
+	home := i.HomeDir
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return "", false, fmt.Errorf("home dir: %w", err)
+		}
+	}
+
+	claudeDir := filepath.Join(home, ".claude")
+	info, err := os.Stat(claudeDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return claudeDir, false, nil
+		}
+		return "", false, fmt.Errorf("stat Claude Code dir: %w", err)
+	}
+	if !info.IsDir() {
+		return "", false, fmt.Errorf("%s is not a directory", claudeDir)
+	}
+	return claudeDir, true, nil
+}
+
+func managedScriptPath(claudeDir string) string {
+	return filepath.Join(claudeDir, "hooks", hookFileName)
+}
+
+func scriptIsCurrent(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() || info.Mode().Perm() != 0o755 {
+		return false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(data, Script())
+}
+
+func writeScript(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create hooks dir: %w", err)
+	}
+	if err := os.WriteFile(path, Script(), 0o755); err != nil {
+		return fmt.Errorf("write hook script: %w", err)
+	}
+	if err := os.Chmod(path, 0o755); err != nil {
+		return fmt.Errorf("chmod hook script: %w", err)
+	}
+	return nil
+}
+
+func readSettings(claudeDir string) (map[string]any, fs.FileMode, error) {
+	path := filepath.Join(claudeDir, "settings.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return map[string]any{}, 0o644, nil
+		}
+		return nil, 0, fmt.Errorf("read settings.json: %w", err)
+	}
+
+	settings := map[string]any{}
+	if len(bytes.TrimSpace(data)) > 0 {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return nil, 0, fmt.Errorf("parse settings.json: %w", err)
+		}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("stat settings.json: %w", err)
+	}
+	return settings, info.Mode().Perm(), nil
+}
+
+func writeSettings(claudeDir string, settings map[string]any, mode fs.FileMode) error {
+	path := filepath.Join(claudeDir, "settings.json")
+	if mode == 0 {
+		mode = 0o644
+	}
+
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode settings.json: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(claudeDir, ".settings.json.*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp settings.json: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp settings.json: %w", err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp settings.json: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp settings.json: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("save settings.json: %w", err)
+	}
+	return nil
+}
+
+func settingsHasManagedHook(settings map[string]any, scriptPath string) bool {
+	for _, hook := range postFailureHookCommands(settings) {
+		if hook == scriptPath {
+			return true
+		}
+	}
+	return false
+}
+
+func addManagedHook(settings map[string]any, scriptPath string) (map[string]any, bool) {
+	if settingsHasManagedHook(settings, scriptPath) {
+		return settings, false
+	}
+
+	hooksMap, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		hooksMap = map[string]any{}
+		settings["hooks"] = hooksMap
+	}
+
+	entries, _ := hooksMap[hookEvent].([]any)
+	entries = append(entries, map[string]any{
+		"matcher": hookMatcher,
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": scriptPath,
+			},
+		},
+	})
+	hooksMap[hookEvent] = entries
+
+	return settings, true
+}
+
+func removeManagedHook(settings map[string]any, scriptPath string) (map[string]any, bool) {
+	hooksMap, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		return settings, false
+	}
+
+	entries, ok := hooksMap[hookEvent].([]any)
+	if !ok {
+		return settings, false
+	}
+
+	changed := false
+	filteredEntries := make([]any, 0, len(entries))
+	for _, entryValue := range entries {
+		entry, ok := entryValue.(map[string]any)
+		if !ok {
+			filteredEntries = append(filteredEntries, entryValue)
+			continue
+		}
+
+		hooksList, ok := entry["hooks"].([]any)
+		if !ok {
+			filteredEntries = append(filteredEntries, entryValue)
+			continue
+		}
+
+		filteredHooks := make([]any, 0, len(hooksList))
+		for _, hookValue := range hooksList {
+			hook, ok := hookValue.(map[string]any)
+			if !ok {
+				filteredHooks = append(filteredHooks, hookValue)
+				continue
+			}
+			command, _ := hook["command"].(string)
+			if command == scriptPath {
+				changed = true
+				continue
+			}
+			filteredHooks = append(filteredHooks, hookValue)
+		}
+
+		if len(filteredHooks) == 0 {
+			changed = true
+			continue
+		}
+		entry["hooks"] = filteredHooks
+		filteredEntries = append(filteredEntries, entry)
+	}
+
+	if !changed {
+		return settings, false
+	}
+	if len(filteredEntries) == 0 {
+		delete(hooksMap, hookEvent)
+	} else {
+		hooksMap[hookEvent] = filteredEntries
+	}
+	if len(hooksMap) == 0 {
+		delete(settings, "hooks")
+	}
+
+	return settings, true
+}
+
+func postFailureHookCommands(settings map[string]any) []string {
+	hooksMap, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	entries, ok := hooksMap[hookEvent].([]any)
+	if !ok {
+		return nil
+	}
+
+	var commands []string
+	for _, entryValue := range entries {
+		entry, ok := entryValue.(map[string]any)
+		if !ok {
+			continue
+		}
+		hooksList, ok := entry["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, hookValue := range hooksList {
+			hook, ok := hookValue.(map[string]any)
+			if !ok {
+				continue
+			}
+			command, _ := hook["command"].(string)
+			if command != "" {
+				commands = append(commands, command)
+			}
+		}
+	}
+	return commands
+}

--- a/internal/hooks/install_test.go
+++ b/internal/hooks/install_test.go
@@ -1,0 +1,334 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallerInstallEmptyClaudeDir(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	claudeDir := makeClaudeDir(t, home)
+
+	status, err := (&Installer{HomeDir: home}).Install()
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if status != StatusInstalled {
+		t.Fatalf("Install() status = %v, want %v", status, StatusInstalled)
+	}
+
+	scriptPath := filepath.Join(claudeDir, "hooks", "scribe-hook.sh")
+	assertInstalledScript(t, scriptPath)
+	assertScribeHookCount(t, filepath.Join(claudeDir, "settings.json"), scriptPath, 1)
+}
+
+func TestInstallerInstallWithoutClaudeDir(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+
+	status, err := (&Installer{HomeDir: home}).Install()
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if status != StatusNotApplicable {
+		t.Fatalf("Install() status = %v, want %v", status, StatusNotApplicable)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude")); !os.IsNotExist(err) {
+		t.Fatalf("Install() created .claude or returned unexpected stat error: %v", err)
+	}
+}
+
+func TestInstallerInstallAlreadyPresent(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	claudeDir := makeClaudeDir(t, home)
+	installer := &Installer{HomeDir: home}
+
+	status, err := installer.Install()
+	if err != nil {
+		t.Fatalf("first Install() error = %v", err)
+	}
+	if status != StatusInstalled {
+		t.Fatalf("first Install() status = %v, want %v", status, StatusInstalled)
+	}
+
+	status, err = installer.Install()
+	if err != nil {
+		t.Fatalf("second Install() error = %v", err)
+	}
+	if status != StatusAlreadyInstalled {
+		t.Fatalf("second Install() status = %v, want %v", status, StatusAlreadyInstalled)
+	}
+
+	scriptPath := filepath.Join(claudeDir, "hooks", "scribe-hook.sh")
+	assertScribeHookCount(t, filepath.Join(claudeDir, "settings.json"), scriptPath, 1)
+}
+
+func TestInstallerInstallPreservesOtherSettingsAndHooks(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	claudeDir := makeClaudeDir(t, home)
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	writeJSON(t, settingsPath, map[string]any{
+		"theme": "dark",
+		"mcpServers": map[string]any{
+			"local": map[string]any{"command": "mcp-local"},
+		},
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": "Bash",
+					"hooks": []any{
+						map[string]any{"type": "command", "command": "/usr/local/bin/pre-tool"},
+					},
+				},
+			},
+			"PostToolUseFailure": []any{
+				map[string]any{
+					"matcher": "Write",
+					"hooks": []any{
+						map[string]any{"type": "command", "command": "/tmp/user-scribe-hook.sh"},
+					},
+				},
+			},
+		},
+	})
+
+	status, err := (&Installer{HomeDir: home}).Install()
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if status != StatusInstalled {
+		t.Fatalf("Install() status = %v, want %v", status, StatusInstalled)
+	}
+
+	var settings map[string]any
+	readJSON(t, settingsPath, &settings)
+	if settings["theme"] != "dark" {
+		t.Fatalf("theme = %v, want dark", settings["theme"])
+	}
+	if _, ok := settings["mcpServers"].(map[string]any)["local"]; !ok {
+		t.Fatal("mcpServers.local was not preserved")
+	}
+
+	hooksMap := settings["hooks"].(map[string]any)
+	if len(hooksMap["PreToolUse"].([]any)) != 1 {
+		t.Fatal("PreToolUse hooks were not preserved")
+	}
+	postFailure := hooksMap["PostToolUseFailure"].([]any)
+	if len(postFailure) != 2 {
+		t.Fatalf("PostToolUseFailure entries = %d, want 2", len(postFailure))
+	}
+
+	scriptPath := filepath.Join(claudeDir, "hooks", "scribe-hook.sh")
+	assertScribeHookCount(t, settingsPath, scriptPath, 1)
+	assertHookCommandPresent(t, settingsPath, "/tmp/user-scribe-hook.sh")
+}
+
+func TestInstallerUninstallRemovesHookAndScript(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	claudeDir := makeClaudeDir(t, home)
+	installer := &Installer{HomeDir: home}
+	if _, err := installer.Install(); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	if err := installer.Uninstall(); err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if err := installer.Uninstall(); err != nil {
+		t.Fatalf("second Uninstall() error = %v", err)
+	}
+
+	scriptPath := filepath.Join(claudeDir, "hooks", "scribe-hook.sh")
+	if _, err := os.Stat(scriptPath); !os.IsNotExist(err) {
+		t.Fatalf("script stat after Uninstall() error = %v, want not exist", err)
+	}
+	assertScribeHookCount(t, filepath.Join(claudeDir, "settings.json"), scriptPath, 0)
+}
+
+func TestInstallerCurrentStatus(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	installer := &Installer{HomeDir: home}
+
+	status, err := installer.CurrentStatus()
+	if err != nil {
+		t.Fatalf("CurrentStatus() without .claude error = %v", err)
+	}
+	if status != StatusNotApplicable {
+		t.Fatalf("CurrentStatus() without .claude = %v, want %v", status, StatusNotApplicable)
+	}
+
+	makeClaudeDir(t, home)
+	status, err = installer.CurrentStatus()
+	if err != nil {
+		t.Fatalf("CurrentStatus() before install error = %v", err)
+	}
+	if status != StatusInstalled {
+		t.Fatalf("CurrentStatus() before install = %v, want %v", status, StatusInstalled)
+	}
+
+	if _, err := installer.Install(); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	status, err = installer.CurrentStatus()
+	if err != nil {
+		t.Fatalf("CurrentStatus() after install error = %v", err)
+	}
+	if status != StatusAlreadyInstalled {
+		t.Fatalf("CurrentStatus() after install = %v, want %v", status, StatusAlreadyInstalled)
+	}
+}
+
+func TestInstallerInstallInvalidSettingsJSONErrors(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	claudeDir := makeClaudeDir(t, home)
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"hooks":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := (&Installer{HomeDir: home}).Install()
+	if err == nil {
+		t.Fatal("Install() error = nil, want parse error")
+	}
+
+	data, readErr := os.ReadFile(settingsPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(data) != `{"hooks":` {
+		t.Fatalf("settings.json was overwritten on parse error: %q", data)
+	}
+}
+
+func makeClaudeDir(t *testing.T, home string) string {
+	t.Helper()
+
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return claudeDir
+}
+
+func assertInstalledScript(t *testing.T, path string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read installed script: %v", err)
+	}
+	if string(data) != string(Script()) {
+		t.Fatal("installed script content does not match embedded script")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat installed script: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("script mode = %v, want 0755", info.Mode().Perm())
+	}
+}
+
+func assertScribeHookCount(t *testing.T, settingsPath, scriptPath string, want int) {
+	t.Helper()
+
+	var settings map[string]any
+	readJSON(t, settingsPath, &settings)
+
+	count := 0
+	for _, hook := range hookCommands(t, settings) {
+		if hook == scriptPath {
+			count++
+		}
+	}
+	if count != want {
+		t.Fatalf("managed scribe hook count = %d, want %d", count, want)
+	}
+}
+
+func assertHookCommandPresent(t *testing.T, settingsPath, command string) {
+	t.Helper()
+
+	var settings map[string]any
+	readJSON(t, settingsPath, &settings)
+	for _, hook := range hookCommands(t, settings) {
+		if hook == command {
+			return
+		}
+	}
+	t.Fatalf("hook command %q not found", command)
+}
+
+func hookCommands(t *testing.T, settings map[string]any) []string {
+	t.Helper()
+
+	hooksValue, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	entries, ok := hooksValue["PostToolUseFailure"].([]any)
+	if !ok {
+		return nil
+	}
+
+	var commands []string
+	for _, entryValue := range entries {
+		entry, ok := entryValue.(map[string]any)
+		if !ok {
+			continue
+		}
+		hooks, ok := entry["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, hookValue := range hooks {
+			hook, ok := hookValue.(map[string]any)
+			if !ok {
+				continue
+			}
+			command, _ := hook["command"].(string)
+			commands = append(commands, command)
+		}
+	}
+	return commands
+}
+
+func writeJSON(t *testing.T, path string, value any) {
+	t.Helper()
+
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readJSON(t *testing.T, path string, value any) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read JSON %s: %v", path, err)
+	}
+	if err := json.Unmarshal(data, value); err != nil {
+		t.Fatalf("parse JSON %s: %v\n%s", path, err, data)
+	}
+}


### PR DESCRIPTION
## Summary
- Add internal/hooks Installer API for installing the embedded Claude Code scribe-hook.sh into ~/.claude/hooks.
- Register and remove only the managed Scribe PostToolUseFailure hook entry in ~/.claude/settings.json using atomic temp-file writes.
- Report missing ~/.claude as StatusNotApplicable and keep Install, Uninstall, and CurrentStatus idempotent.

## Scope
Only Solo todo #393: hook installer package.

Not included: cmd hooks command (#394), sync auto-install integration (#395), or end-to-end integration test (#398).

Plan: docs/superpowers/plans/2026-04-14-nono-inspired-patterns.md Task 2.

## Test Plan
- go build ./...
- go test ./internal/hooks/ -count=1
- go vet ./...