### PR TITLE
feat(kit): kit YAML schema + resolution algorithm (todo #370)

### DIFF
--- a/internal/kit/kit.go
+++ b/internal/kit/kit.go
@@ -1,0 +1,96 @@
+package kit
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Kit is a named bundle of Scribe skills.
+type Kit struct {
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description,omitempty"`
+	Skills      []string `yaml:"skills"`
+	Source      *Source  `yaml:"source,omitempty"`
+}
+
+// Source records the registry source for a kit.
+type Source struct {
+	Registry string `yaml:"registry"`
+	Rev      string `yaml:"rev,omitempty"`
+}
+
+// Load reads a single kit YAML file from path.
+func Load(path string) (*Kit, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read kit: %w", err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return &Kit{}, nil
+	}
+
+	var kit Kit
+	if err := yaml.Unmarshal(data, &kit); err != nil {
+		return nil, fmt.Errorf("parse kit: %w", err)
+	}
+	if kit.Skills == nil {
+		kit.Skills = []string{}
+	}
+	return &kit, nil
+}
+
+// LoadAll reads all *.yaml kit files in dir, keyed by kit name.
+func LoadAll(dir string) (map[string]*Kit, error) {
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return map[string]*Kit{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read kits dir: %w", err)
+	}
+
+	kits := make(map[string]*Kit)
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+
+		kit, err := Load(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		kits[kit.Name] = kit
+	}
+	return kits, nil
+}
+
+// Save writes a kit YAML file to path atomically.
+func Save(path string, kit *Kit) error {
+	if kit == nil {
+		kit = &Kit{}
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create kit dir: %w", err)
+	}
+
+	data, err := yaml.Marshal(kit)
+	if err != nil {
+		return fmt.Errorf("encode kit: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write kit: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("save kit: %w", err)
+	}
+	return nil
+}

--- a/internal/kit/kit_test.go
+++ b/internal/kit/kit_test.go
@@ -1,0 +1,100 @@
+package kit
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoadParsesKitYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "frontend.yaml")
+	data := []byte(`
+name: frontend
+description: Frontend defaults
+skills:
+  - init-react
+  - init-tailwind
+  - init-*
+source:
+  registry: core
+  rev: abc123
+`)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	want := &Kit{
+		Name:        "frontend",
+		Description: "Frontend defaults",
+		Skills:      []string{"init-react", "init-tailwind", "init-*"},
+		Source: &Source{
+			Registry: "core",
+			Rev:      "abc123",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Load() = %#v, want %#v", got, want)
+	}
+}
+
+func TestLoadAllLoadsYAMLFilesKeyedByKitName(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"frontend.yaml": "name: frontend\nskills:\n  - init-react\n",
+		"backend.yaml":  "name: backend\nskills:\n  - init-go\n",
+		"ignored.txt":   "name: ignored\nskills:\n  - init-ruby\n",
+	}
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	got, err := LoadAll(dir)
+	if err != nil {
+		t.Fatalf("LoadAll() error = %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("LoadAll() loaded %d kits, want 2", len(got))
+	}
+	if got["frontend"].Skills[0] != "init-react" {
+		t.Fatalf("frontend skills = %#v", got["frontend"].Skills)
+	}
+	if got["backend"].Skills[0] != "init-go" {
+		t.Fatalf("backend skills = %#v", got["backend"].Skills)
+	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "frontend.yaml")
+	want := &Kit{
+		Name:        "frontend",
+		Description: "Frontend defaults",
+		Skills:      []string{"init-react", "init-tailwind"},
+		Source: &Source{
+			Registry: "core",
+			Rev:      "abc123",
+		},
+	}
+
+	if err := Save(path, want); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round trip = %#v, want %#v", got, want)
+	}
+}

--- a/internal/kit/resolver.go
+++ b/internal/kit/resolver.go
@@ -1,0 +1,82 @@
+package kit
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"github.com/Naoray/scribe/internal/projectfile"
+)
+
+// Resolve returns the final skill set for a project.
+// Algorithm:
+//   - union all skills declared by projectFile.Kits
+//   - apply projectFile.Add
+//   - apply projectFile.Remove
+//   - expand globs against installedSkills
+//   - return a deduplicated, sorted skill name slice
+func Resolve(pf *projectfile.ProjectFile, availableKits map[string]*Kit, installedSkills []string) ([]string, error) {
+	if pf == nil {
+		pf = &projectfile.ProjectFile{}
+	}
+
+	patterns := make([]string, 0, len(pf.Add))
+	for _, kitName := range pf.Kits {
+		kit, ok := availableKits[kitName]
+		if !ok {
+			return nil, fmt.Errorf("kit %q not found", kitName)
+		}
+		patterns = append(patterns, kit.Skills...)
+	}
+	patterns = append(patterns, pf.Add...)
+
+	result := make(map[string]struct{})
+	for _, pattern := range patterns {
+		matches, err := expandSkillPattern(pattern, installedSkills)
+		if err != nil {
+			return nil, err
+		}
+		for _, skill := range matches {
+			result[skill] = struct{}{}
+		}
+	}
+
+	for _, skill := range pf.Remove {
+		delete(result, skill)
+	}
+
+	skills := make([]string, 0, len(result))
+	for skill := range result {
+		skills = append(skills, skill)
+	}
+	sort.Strings(skills)
+	return skills, nil
+}
+
+func expandSkillPattern(pattern string, installedSkills []string) ([]string, error) {
+	if !hasGlobMeta(pattern) {
+		return []string{pattern}, nil
+	}
+
+	matches := make([]string, 0)
+	for _, skill := range installedSkills {
+		match, err := filepath.Match(pattern, skill)
+		if err != nil {
+			return nil, fmt.Errorf("match skill pattern %q: %w", pattern, err)
+		}
+		if match {
+			matches = append(matches, skill)
+		}
+	}
+	return matches, nil
+}
+
+func hasGlobMeta(pattern string) bool {
+	for _, r := range pattern {
+		switch r {
+		case '*', '?', '[':
+			return true
+		}
+	}
+	return false
+}

--- a/internal/kit/resolver_test.go
+++ b/internal/kit/resolver_test.go
@@ -1,0 +1,116 @@
+package kit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/projectfile"
+)
+
+func TestResolve(t *testing.T) {
+	tests := []struct {
+		name            string
+		projectFile     *projectfile.ProjectFile
+		availableKits   map[string]*Kit
+		installedSkills []string
+		want            []string
+		wantErr         string
+	}{
+		{
+			name:        "empty project file",
+			projectFile: &projectfile.ProjectFile{},
+			want:        []string{},
+		},
+		{
+			name: "single kit returns its skills",
+			projectFile: &projectfile.ProjectFile{
+				Kits: []string{"frontend"},
+			},
+			availableKits: map[string]*Kit{
+				"frontend": {Name: "frontend", Skills: []string{"init-react", "init-tailwind"}},
+			},
+			want: []string{"init-react", "init-tailwind"},
+		},
+		{
+			name: "multiple kits union without duplicates",
+			projectFile: &projectfile.ProjectFile{
+				Kits: []string{"frontend", "backend"},
+			},
+			availableKits: map[string]*Kit{
+				"frontend": {Name: "frontend", Skills: []string{"init-react", "shared"}},
+				"backend":  {Name: "backend", Skills: []string{"init-go", "shared"}},
+			},
+			want: []string{"init-go", "init-react", "shared"},
+		},
+		{
+			name: "glob expands against installed skills",
+			projectFile: &projectfile.ProjectFile{
+				Kits: []string{"all-init"},
+			},
+			availableKits: map[string]*Kit{
+				"all-init": {Name: "all-init", Skills: []string{"init-*"}},
+			},
+			installedSkills: []string{"init-react", "init-go", "audit-tests"},
+			want:            []string{"init-go", "init-react"},
+		},
+		{
+			name: "add applies after kits",
+			projectFile: &projectfile.ProjectFile{
+				Kits: []string{"frontend"},
+				Add:  []string{"audit-tests"},
+			},
+			availableKits: map[string]*Kit{
+				"frontend": {Name: "frontend", Skills: []string{"init-react"}},
+			},
+			want: []string{"audit-tests", "init-react"},
+		},
+		{
+			name: "remove applies after add and kits",
+			projectFile: &projectfile.ProjectFile{
+				Kits:   []string{"frontend"},
+				Add:    []string{"audit-tests"},
+				Remove: []string{"init-react", "audit-tests"},
+			},
+			availableKits: map[string]*Kit{
+				"frontend": {Name: "frontend", Skills: []string{"init-react", "init-tailwind"}},
+			},
+			want: []string{"init-tailwind"},
+		},
+		{
+			name: "missing kit returns error with name",
+			projectFile: &projectfile.ProjectFile{
+				Kits: []string{"missing"},
+			},
+			wantErr: "missing",
+		},
+		{
+			name: "glob matching nothing contributes nothing without error",
+			projectFile: &projectfile.ProjectFile{
+				Kits: []string{"none"},
+			},
+			availableKits: map[string]*Kit{
+				"none": {Name: "none", Skills: []string{"init-*"}},
+			},
+			installedSkills: []string{"audit-tests"},
+			want:            []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Resolve(tt.projectFile, tt.availableKits, tt.installedSkills)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Resolve() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Resolve() error = %v", err)
+			}
+			if strings.Join(got, "\x00") != strings.Join(tt.want, "\x00") {
+				t.Fatalf("Resolve() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/kit` schema types for `~/.scribe/kits/<name>.yaml` with yaml.v3 Load/LoadAll/Save support.
- Adds deterministic kit resolution from `.scribe.yaml` project files: kit union, project add, project remove, glob expansion against installed skills, sorted output.
- Covers schema parsing, LoadAll filtering, Save/Load round trip, missing kit errors, glob expansion, add, remove, and duplicate elimination.

## Scope
Only Solo todo #370: pure data layer and resolution algorithm. No snippet schema, Cobra commands, sync integration, state schema, projection writer, or budget guardrail changes.

## Spec
Intended to follow `docs/superpowers/specs/2026-04-29-kits-and-snippets-design.md` Key Decision 2 / Data Model / Resolution algorithm. Note: that path is absent from local `main` and `origin/main` at `af38aec` after fetch, so this PR follows the explicit todo schema and algorithm text.

## Test plan
- `go build ./...`
- `go test ./internal/kit/ -count=1`
- `go vet ./...`
- `go test ./...`