### PR TITLE
feat(state): schema v5 projections + kits/snippets indexes (todos #368 #461)

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -17,15 +17,38 @@ import (
 
 // State is the contents of ~/.scribe/state.json.
 type State struct {
-	SchemaVersion int                       `json:"schema_version"`
-	LastSync      time.Time                 `json:"last_sync,omitempty"`
-	Installed     map[string]InstalledSkill `json:"installed"`
+	SchemaVersion int                         `json:"schema_version"`
+	LastSync      time.Time                   `json:"last_sync,omitempty"`
+	Installed     map[string]InstalledSkill   `json:"installed"`
+	Kits          map[string]InstalledKit     `json:"kits"`
+	Snippets      map[string]InstalledSnippet `json:"snippets"`
 	// Schema v5 is shared with the kits/snippets pivot; its projection, kit,
 	// and snippet indexes are additive siblings of this deny-list.
 	RemovedByUser      []RemovedSkill               `json:"removed_by_user"`
 	Migrations         map[string]bool              `json:"migrations,omitempty"`
 	RegistryFailures   map[string]RegistryFailure   `json:"registry_failures,omitempty"`
 	BinaryUpdateChecks map[string]BinaryUpdateCheck `json:"binary_update_checks,omitempty"`
+}
+
+// ProjectionEntry records the set of tool projections currently linked for a
+// project. An empty Project is the legacy global projection.
+type ProjectionEntry struct {
+	Project string   `json:"project"`
+	Tools   []string `json:"tools"`
+}
+
+// InstalledKit indexes an installed kit definition in the local state file.
+type InstalledKit struct {
+	Source  string   `json:"source,omitempty"`
+	Version string   `json:"version,omitempty"`
+	Skills  []string `json:"skills,omitempty"`
+}
+
+// InstalledSnippet indexes an installed snippet definition in the local state file.
+type InstalledSnippet struct {
+	Source  string   `json:"source,omitempty"`
+	Version string   `json:"version,omitempty"`
+	Targets []string `json:"targets,omitempty"`
 }
 
 // RemovedSkill records a user's intent not to reinstall a registry skill.
@@ -90,16 +113,21 @@ const (
 
 // InstalledSkill records everything needed to detect updates and uninstall.
 type InstalledSkill struct {
-	Revision      int                  `json:"revision"`
-	InstalledHash string               `json:"installed_hash"`
-	Sources       []SkillSource        `json:"sources,omitempty"`
-	InstalledAt   time.Time            `json:"installed_at"`
-	Tools         []string             `json:"tools"`
-	ToolsMode     ToolsMode            `json:"tools_mode,omitempty"`
-	Paths         []string             `json:"paths"`
-	ManagedPaths  []string             `json:"managed_paths,omitempty"`
-	Conflicts     []ProjectionConflict `json:"projection_conflicts,omitempty"`
-	Origin        Origin               `json:"origin,omitempty"`
+	Revision      int           `json:"revision"`
+	InstalledHash string        `json:"installed_hash"`
+	Sources       []SkillSource `json:"sources,omitempty"`
+	InstalledAt   time.Time     `json:"installed_at"`
+	// Deprecated in schema v5: projections replace the single global tools set.
+	// Kept through v5 for parsing and compatibility with existing commands.
+	Tools     []string  `json:"tools"`
+	ToolsMode ToolsMode `json:"tools_mode,omitempty"`
+	// Deprecated in schema v5: managed paths are superseded by projections.
+	// Kept through v5 for parsing and compatibility with existing commands.
+	Paths        []string             `json:"paths"`
+	Projections  []ProjectionEntry    `json:"projections,omitempty"`
+	ManagedPaths []string             `json:"managed_paths,omitempty"`
+	Conflicts    []ProjectionConflict `json:"projection_conflicts,omitempty"`
+	Origin       Origin               `json:"origin,omitempty"`
 
 	// Kind distinguishes auto-detected tree packages (files under
 	// ~/.scribe/packages/<name>/) from regular skills. Missing value on
@@ -146,6 +174,8 @@ type legacyState struct {
 	Team               *legacyTeamState             `json:"team,omitempty"`
 	LastSync           *time.Time                   `json:"last_sync,omitempty"`
 	Installed          map[string]json.RawMessage   `json:"installed"`
+	Kits               map[string]InstalledKit      `json:"kits,omitempty"`
+	Snippets           map[string]InstalledSnippet  `json:"snippets,omitempty"`
 	RemovedByUser      []RemovedSkill               `json:"removed_by_user,omitempty"`
 	BinaryUpdateChecks map[string]BinaryUpdateCheck `json:"binary_update_checks,omitempty"`
 }
@@ -171,12 +201,13 @@ type legacyInstalledSkill struct {
 	ApprovedAt  time.Time `json:"approved_at,omitempty"`
 
 	// New v2 fields that may already exist in state (if re-loaded after partial migration)
-	Revision      int           `json:"revision,omitempty"`
-	InstalledHash string        `json:"installed_hash,omitempty"`
-	Sources       []SkillSource `json:"sources,omitempty"`
-	Origin        Origin        `json:"origin,omitempty"`
-	ToolsMode     ToolsMode     `json:"tools_mode,omitempty"`
-	Kind          Kind          `json:"kind,omitempty"`
+	Revision      int               `json:"revision,omitempty"`
+	InstalledHash string            `json:"installed_hash,omitempty"`
+	Sources       []SkillSource     `json:"sources,omitempty"`
+	Origin        Origin            `json:"origin,omitempty"`
+	ToolsMode     ToolsMode         `json:"tools_mode,omitempty"`
+	Kind          Kind              `json:"kind,omitempty"`
+	Projections   []ProjectionEntry `json:"projections,omitempty"`
 }
 
 // DisplayVersion returns the version string shown in `scribe list`.
@@ -223,15 +254,28 @@ func Load() (*State, error) {
 
 	data, err := os.ReadFile(path)
 	if errors.Is(err, fs.ErrNotExist) {
-		return &State{SchemaVersion: 5, Installed: make(map[string]InstalledSkill), RemovedByUser: []RemovedSkill{}, Migrations: map[string]bool{}, RegistryFailures: map[string]RegistryFailure{}, BinaryUpdateChecks: map[string]BinaryUpdateCheck{}}, nil
+		return emptyState(), nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("read state: %w", err)
 	}
 	if len(bytes.TrimSpace(data)) == 0 {
-		return &State{SchemaVersion: 5, Installed: make(map[string]InstalledSkill), RemovedByUser: []RemovedSkill{}, Migrations: map[string]bool{}, RegistryFailures: map[string]RegistryFailure{}, BinaryUpdateChecks: map[string]BinaryUpdateCheck{}}, nil
+		return emptyState(), nil
 	}
 	return parseAndMigrate(data)
+}
+
+func emptyState() *State {
+	return &State{
+		SchemaVersion:      5,
+		Installed:          make(map[string]InstalledSkill),
+		Kits:               map[string]InstalledKit{},
+		Snippets:           map[string]InstalledSnippet{},
+		RemovedByUser:      []RemovedSkill{},
+		Migrations:         map[string]bool{},
+		RegistryFailures:   map[string]RegistryFailure{},
+		BinaryUpdateChecks: map[string]BinaryUpdateCheck{},
+	}
 }
 
 // parseAndMigrate handles migrations:
@@ -252,10 +296,18 @@ func parseAndMigrate(data []byte) (*State, error) {
 	s := &State{
 		SchemaVersion:      legacy.SchemaVersion,
 		Installed:          make(map[string]InstalledSkill, len(legacy.Installed)),
+		Kits:               map[string]InstalledKit{},
+		Snippets:           map[string]InstalledSnippet{},
 		RemovedByUser:      append([]RemovedSkill(nil), legacy.RemovedByUser...),
 		Migrations:         map[string]bool{},
 		RegistryFailures:   map[string]RegistryFailure{},
 		BinaryUpdateChecks: map[string]BinaryUpdateCheck{},
+	}
+	if len(legacy.Kits) > 0 {
+		s.Kits = legacy.Kits
+	}
+	if len(legacy.Snippets) > 0 {
+		s.Snippets = legacy.Snippets
 	}
 	if len(legacy.BinaryUpdateChecks) > 0 {
 		s.BinaryUpdateChecks = legacy.BinaryUpdateChecks
@@ -626,6 +678,7 @@ func legacyToSkill(ls legacyInstalledSkill) InstalledSkill {
 		Tools:         ls.Tools,
 		ToolsMode:     ls.ToolsMode,
 		Paths:         ls.Paths,
+		Projections:   append([]ProjectionEntry(nil), ls.Projections...),
 		ManagedPaths:  append([]string(nil), ls.Paths...),
 		Origin:        ls.Origin,
 		Kind:          kind,

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -287,6 +287,7 @@ func emptyState() *State {
 //  6. Schema v4: normalize branch-backed LastSHA values to the locally cached
 //     SKILL.md blob SHA so blob-SHA diffs do not force needless reinstalls.
 //  7. Schema v5: initialize the user removal deny-list.
+//  8. Schema v5: seed legacy global tools/paths into Projections.
 func parseAndMigrate(data []byte) (*State, error) {
 	var legacy legacyState
 	if err := json.Unmarshal(data, &legacy); err != nil {
@@ -427,6 +428,7 @@ func parseAndMigrate(data []byte) (*State, error) {
 		}
 		s.SchemaVersion = 5
 	}
+	seedLegacyProjections(s)
 	seedManagedPaths(s)
 
 	return s, nil
@@ -750,6 +752,22 @@ func seedManagedPaths(s *State) {
 			skill.ManagedPaths = append([]string(nil), skill.Paths...)
 			s.Installed[name] = skill
 		}
+	}
+}
+
+func seedLegacyProjections(s *State) {
+	for name, skill := range s.Installed {
+		if len(skill.Projections) > 0 {
+			continue
+		}
+		if len(skill.Tools) == 0 && len(skill.Paths) == 0 {
+			continue
+		}
+		skill.Projections = []ProjectionEntry{{
+			Project: "",
+			Tools:   append([]string{}, skill.Tools...),
+		}}
+		s.Installed[name] = skill
 	}
 }
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -33,6 +33,18 @@ func TestLoadMissing(t *testing.T) {
 	if len(s.BinaryUpdateChecks) != 0 {
 		t.Fatalf("expected empty BinaryUpdateChecks, got %d entries", len(s.BinaryUpdateChecks))
 	}
+	if s.Kits == nil {
+		t.Fatal("expected Kits to be initialized")
+	}
+	if len(s.Kits) != 0 {
+		t.Fatalf("expected empty Kits, got %d entries", len(s.Kits))
+	}
+	if s.Snippets == nil {
+		t.Fatal("expected Snippets to be initialized")
+	}
+	if len(s.Snippets) != 0 {
+		t.Fatalf("expected empty Snippets, got %d entries", len(s.Snippets))
+	}
 }
 
 func TestSaveAndLoad(t *testing.T) {
@@ -461,6 +473,140 @@ func TestStateMigrateV4ToV5InitializesRemovedByUser(t *testing.T) {
 	}
 	if len(st.RemovedByUser) != 0 {
 		t.Fatalf("RemovedByUser len = %d, want 0", len(st.RemovedByUser))
+	}
+}
+
+func TestLoadEmptyFileReturnsEmptyV5State(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".scribe")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(" \n\t"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if st.SchemaVersion != 5 {
+		t.Fatalf("SchemaVersion = %d, want 5", st.SchemaVersion)
+	}
+	if len(st.Installed) != 0 {
+		t.Fatalf("Installed len = %d, want 0", len(st.Installed))
+	}
+	if st.Kits == nil || len(st.Kits) != 0 {
+		t.Fatalf("Kits = %#v, want empty non-nil map", st.Kits)
+	}
+	if st.Snippets == nil || len(st.Snippets) != 0 {
+		t.Fatalf("Snippets = %#v, want empty non-nil map", st.Snippets)
+	}
+}
+
+func TestStateMigrateLegacyToolsPathsToProjectionsRoundTrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".scribe")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(`{
+		"schema_version": 4,
+		"installed": {
+			"recap": {
+				"revision": 2,
+				"installed_hash": "abc",
+				"sources": [{"registry": "acme/skills", "ref": "main"}],
+				"installed_at": "2026-01-01T00:00:00Z",
+				"tools": ["claude", "codex"],
+				"paths": ["/Users/test/.claude/skills/recap", "/Users/test/.codex/skills/recap"]
+			}
+		}
+	}`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load legacy: %v", err)
+	}
+	assertGlobalProjection(t, st.Installed["recap"], []string{"claude", "codex"})
+	if st.Kits == nil || st.Snippets == nil {
+		t.Fatalf("Kits/Snippets should be initialized: kits=%#v snippets=%#v", st.Kits, st.Snippets)
+	}
+
+	if err := st.Save(); err != nil {
+		t.Fatalf("Save migrated: %v", err)
+	}
+	reloaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("Reload migrated: %v", err)
+	}
+	if reloaded.SchemaVersion != 5 {
+		t.Fatalf("SchemaVersion = %d, want 5", reloaded.SchemaVersion)
+	}
+	assertGlobalProjection(t, reloaded.Installed["recap"], []string{"claude", "codex"})
+}
+
+func TestStateMigrateV5DenyListPreservedWhileAddingProjections(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".scribe")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(`{
+		"schema_version": 5,
+		"installed": {
+			"recap": {
+				"revision": 2,
+				"installed_hash": "abc",
+				"sources": [{"registry": "acme/skills", "ref": "main"}],
+				"installed_at": "2026-01-01T00:00:00Z",
+				"tools": ["claude"],
+				"paths": ["/Users/test/.claude/skills/recap"]
+			}
+		},
+		"removed_by_user": [
+			{"name": "deploy", "registry": "acme/skills", "removed_at": "2026-04-29T12:00:00Z"}
+		]
+	}`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load v5 deny-list fixture: %v", err)
+	}
+	if st.SchemaVersion != 5 {
+		t.Fatalf("SchemaVersion = %d, want 5", st.SchemaVersion)
+	}
+	assertGlobalProjection(t, st.Installed["recap"], []string{"claude"})
+	if len(st.RemovedByUser) != 1 {
+		t.Fatalf("RemovedByUser len = %d, want 1", len(st.RemovedByUser))
+	}
+	if !st.IsRemovedByUser("acme/skills", "deploy") {
+		t.Fatal("expected deny-list entry to be preserved")
+	}
+	if st.Kits == nil || st.Snippets == nil {
+		t.Fatalf("Kits/Snippets should be initialized: kits=%#v snippets=%#v", st.Kits, st.Snippets)
+	}
+
+	if err := st.Save(); err != nil {
+		t.Fatalf("Save migrated v5: %v", err)
+	}
+	reloaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("Reload migrated v5: %v", err)
+	}
+	assertGlobalProjection(t, reloaded.Installed["recap"], []string{"claude"})
+	if !reloaded.IsRemovedByUser("acme/skills", "deploy") {
+		t.Fatal("expected deny-list entry to survive save/reload")
 	}
 }
 
@@ -1011,6 +1157,25 @@ func installedKeys(s *state.State) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+func assertGlobalProjection(t *testing.T, skill state.InstalledSkill, wantTools []string) {
+	t.Helper()
+	if len(skill.Projections) != 1 {
+		t.Fatalf("Projections len = %d, want 1: %#v", len(skill.Projections), skill.Projections)
+	}
+	projection := skill.Projections[0]
+	if projection.Project != "" {
+		t.Fatalf("Projection project = %q, want legacy global project", projection.Project)
+	}
+	if len(projection.Tools) != len(wantTools) {
+		t.Fatalf("Projection tools = %v, want %v", projection.Tools, wantTools)
+	}
+	for i, want := range wantTools {
+		if projection.Tools[i] != want {
+			t.Fatalf("Projection tools = %v, want %v", projection.Tools, wantTools)
+		}
+	}
 }
 
 // TestMigrationSchemaV4NormalizesBranchBlobSHA verifies that loading an older


### PR DESCRIPTION
## Summary
- Implements state schema v5 additions from docs/superpowers/specs/2026-04-29-kits-and-snippets-design.md Key Decision 6.
- Adds per-skill projections as additive v5 state alongside deprecated tools/paths compatibility fields.
- Adds top-level kits and snippets indexes with source/version metadata fields.
- Migrates legacy global tools/paths into one projection entry with project="" on Load.

## #368 + #461 reconciliation
- Keeps schema_version at v5; no v6 bump.
- Preserves removed_by_user and RemovedSkill shape from PR #116 / sha 72efded.
- Adds a v5 deny-list fixture with no projections to prove Load adds projections without touching the deny-list.

## New fields
- installed.<skill>.projections[]: { project, tools }
- kits: map[string]InstalledKit { source, version, skills }
- snippets: map[string]InstalledSnippet { source, version, targets }

## Test plan
- go build ./...
- go test ./internal/state/ -count=1
- go test ./... -count=1
- go vet ./...