### PR TITLE
docs(release): post-foundation documentation update (Waves 1-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,46 +1,40 @@
 ## Unreleased
 
-### BREAKING: --json output now uses versioned envelope (format_version=1)
-
-`scribe list --json`, `scribe status --json`, `scribe doctor --json`, `scribe explain --json`, `scribe guide --json` now wrap their previous payload as:
-
-```json
-{
-  "status": "ok",
-  "format_version": "1",
-  "data": { /* previously top-level keys are now here */ },
-  "meta": { "duration_ms": 12, "command": "scribe list", "scribe_version": "..." }
-}
-```
-
-Migration: `jq '.data.foo'` works; `jq '.foo'` requires update.
-
-PR #118 / PR B introduces this format break for read-only commands. Mutator commands (`sync`, `add`, `adopt`, etc.) keep their pre-envelope output for now; their envelope migration is deferred to a follow-up PR.
+The "agent-first foundation" wave. Scribe's `--json` output is now a versioned envelope, mutator commands have semantic exit codes, every migrated command exposes its JSON Schema, and the data layer for kits + snippets + project files is in place. Most of this is foundation — user-facing flows ride on top in follow-up releases.
 
 ### Added
 
-- `--fields f1,f2` projection on read-only commands with tabular output (gh-style; opt-in per command via `output.AttachFieldsFlag`).
-- `scribe schema list`, `scribe schema status`, `scribe schema doctor`, `scribe schema explain`, `scribe schema guide` now return JSON Schema 2020-12 for both inputs and outputs.
+- **JSON envelope contract** (`format_version: "1"`) — every migrated command wraps its output in `{status, format_version, data, meta}`. `meta.duration_ms` measures leaf execution; `meta.bootstrap_ms` covers first-run + store migration + builtins. ([#117](https://github.com/Naoray/scribe/pull/117), [#118](https://github.com/Naoray/scribe/pull/118), [#119](https://github.com/Naoray/scribe/pull/119))
+- **Semantic exit codes** at registry, network, validation, and conflict boundaries — `2` usage, `3` not-found, `4` permission, `5` conflict, `6` network, `7` dependency, `8` validation, `9` user-canceled, `10` partial success. ([#119](https://github.com/Naoray/scribe/pull/119))
+- **Schema introspection** — `scribe schema list|status|doctor|explain|guide|sync|add|adopt|connect --json` returns JSON Schema 2020-12 for inputs and outputs, so agents can compose calls without guessing. ([#118](https://github.com/Naoray/scribe/pull/118), [#119](https://github.com/Naoray/scribe/pull/119))
+- **Field projection** — opt-in `--fields name,version` flag on read-only commands with tabular output (gh-style). Wired per command via `output.AttachFieldsFlag`. ([#118](https://github.com/Naoray/scribe/pull/118))
+- **`CLAUDE.md` agent contract** — generated from `docs/agent/CLAUDE.md.tmpl` via `go generate`, committed at the repo root, embedded in the binary, and materialized beside `SKILL.md` when scribe-agent installs. Drift is a build-time gate. ([#119](https://github.com/Naoray/scribe/pull/119))
+- **`.scribe.yaml` project file** — schema + parser for declaring per-project kits, snippets, extra skills to add, and skills to remove. Empty or missing files are no-ops. ([#121](https://github.com/Naoray/scribe/pull/121))
+- **Kit schema + resolution algorithm** — kits express ordered skill bundles (e.g., "laravel-baseline"); the resolver merges declared kits, projectfile add/remove, and installed-skill state into a target set. ([#124](https://github.com/Naoray/scribe/pull/124))
+- **State schema v5** — projection indexes plus first-class storage for kits and snippets. Lays groundwork for fast lookup once the user-facing kit/snippet commands ship. ([#125](https://github.com/Naoray/scribe/pull/125))
+- **`scribe-hook.sh` script** — embedded shim that lets Claude Code (and similar) call into `scribe` from session lifecycle hooks. ([#122](https://github.com/Naoray/scribe/pull/122))
+- **Hook installer package** — internal `internal/hooks` package handles install/uninstall + status of `scribe-hook.sh` in Claude Code settings, with idempotent merge into existing user hooks. ([#123](https://github.com/Naoray/scribe/pull/123))
+- **Skill deny-list** — explicitly removed skills are remembered, so `sync` no longer re-installs them on the next reconcile. ([#116](https://github.com/Naoray/scribe/pull/116))
+- **Packages store** — multi-skill upstream packages now project as a single store entry instead of being splayed across tool skill dirs. ([#113](https://github.com/Naoray/scribe/pull/113))
 
-### Spec deviations
+### Changed
 
-- PR #89 spec §43, §118 propose field selection via overloaded `--json name,version`. We diverged: `--json` stays Bool; field selection uses companion `--fields name,version` flag to avoid breaking `--json=true` shell scripts. See `scribe schema <cmd>` for valid field names.
+- **BREAKING — `--json` payload shape** for `scribe list`, `status`, `doctor`, `explain`, `guide`. Previously top-level keys are now under `data`. Migrate parsers from `jq '.foo'` to `jq '.data.foo'`. ([#118](https://github.com/Naoray/scribe/pull/118))
+- **BREAKING — mutator `--json` payload shape** for `scribe sync`, `add`, `adopt`, `connect`. Same envelope rules. When `data.summary.failed > 0`, `status` becomes `"partial_success"` and exit code is `10`. ([#119](https://github.com/Naoray/scribe/pull/119))
+- **State schema bumped to v5** — projection indexes plus kits/snippets storage. Migration runs automatically at first invocation; no user action required. ([#125](https://github.com/Naoray/scribe/pull/125))
 
-### BREAKING (extended): mutator commands now emit envelope
+### Fixed
 
-PR #119 (this PR) extends the format_version=1 contract to mutator commands:
+- **`scribe --version`** now falls back to `debug.ReadBuildInfo` for `go install`-based builds, so installs without a release-time ldflag still report a meaningful version. ([#115](https://github.com/Naoray/scribe/pull/115))
 
-- `scribe sync --json`, `scribe add --json`, `scribe adopt --json`, `scribe connect --json` now wrap their previous payload in `{status, format_version, data, meta}`. Previously top-level keys are now under `data.<key>`.
-- `data.summary.failed > 0` triggers `status="partial_success"` and exit code 10.
-- Migration: same as PR B — `jq '.data.foo'` works; `jq '.foo'` requires update.
-- Legacy capture note: `sync.legacy.json` was captured through the pre-PR-C non-TTY JSON path because PR B's root `--json` gate rejected mutators until this PR marked them JSON-capable. `add` requires authenticated registry access for a representative success capture, so this PR covers add via schema/envelope tests and documents the capture gap.
+### Internal
 
-### Added (PR C)
+- **`cli/output` and `cli/workflow` foundation packages** — agent-first plumbing for the envelope, persistent `--json` flag, and `wrapRunE`. ([#117](https://github.com/Naoray/scribe/pull/117))
+- **Envelope unification** — `jsonFormatter.Flush` now routes through `cli/output.Renderer`, so every JSON path emits a single envelope instead of writing partial blobs. ([#120](https://github.com/Naoray/scribe/pull/120))
+- **Spec deviation: `--fields` is its own flag**, not overloaded `--json name,version`. Preserves boolean `--json=true` compatibility for existing shell scripts. See `scribe schema <cmd> --json` for valid field names per command.
 
-- `scribe schema sync`, `scribe schema add`, `scribe schema adopt`, `scribe schema connect` now return JSON Schema 2020-12 for inputs and outputs.
-- Semantic exit codes at registry/network/validation/conflict boundaries (codes 3, 4, 5, 6, 7, 8, 10). See `CLAUDE.md` for the full taxonomy.
-- `CLAUDE.md` shipped at repo root, regenerated by `go generate`, embedded in the binary, and materialized beside `SKILL.md` for the scribe-agent bootstrap skill.
+### Deferred
 
-### Deferred to wave-3 (solo todo #469)
+A handful of older mutator commands (`install`, `remove`, `resolve`, `restore`, `skill`, `tools`, `config`, `create`, `registry*`, `upgrade`, `migrate`, `browse`) still emit pre-envelope output and reject `--json` with `JSON_NOT_SUPPORTED` until they migrate. Track via `scribe schema --all --json`.
 
-- Other commands (`install`, `remove`, `resolve`, `restore`, `skill`, `tools`, `config`, `create`, `registry*`, `upgrade`, `migrate`, `browse`) still emit pre-envelope output. They reject `--json` with `JSON_NOT_SUPPORTED` until migrated.
+The CLI surfaces for kits, snippets, hooks, and `.scribe.yaml` activation are designed and in flight; only the foundation ships in this wave.

--- a/README.md
+++ b/README.md
@@ -141,9 +141,11 @@ ArtistfyHQ/team-skills/
 |---|---|
 | `scribe` | Open the local skill manager |
 | `scribe list` | Show all skills on this machine (managed + unmanaged) |
-| `scribe add [query]` | Find and install skills from registries |
+| `scribe browse` | Discover and install skills from connected registries |
+| `scribe add [query]` | Find and install skills from registries (legacy; prefer `browse`) |
+| `scribe install --all` | Install every catalog entry from a registry in one shot |
 | `scribe adopt [name]` | Import hand-rolled skills from `~/.claude/skills` etc. into the store |
-| `scribe remove <skill>` | Remove a skill from this machine |
+| `scribe remove <skill>` | Remove a skill from this machine (records a deny-list entry) |
 | `scribe sync` | Reconcile local skill state, tool installs, and connected registries |
 | `scribe doctor` | Inspect managed skills and projections for repairable issues |
 | `scribe doctor --fix` | Normalize canonical skill metadata and repair affected projections |
@@ -152,6 +154,7 @@ ArtistfyHQ/team-skills/
 | `scribe status` | Show connected registries, installed count, and last sync |
 | `scribe tools` | List detected AI tools, enable/disable |
 | `scribe explain <skill>` | AI-powered skill explanation (or `--raw` for rendered SKILL.md) |
+| `scribe upgrade-agent` | Refresh the embedded scribe-agent bootstrap skill |
 
 ### Registry management
 
@@ -169,6 +172,7 @@ ArtistfyHQ/team-skills/
 | Command | What it does |
 |---|---|
 | `scribe guide` | Interactive setup guide |
+| `scribe schema <command> --json` | Print the JSON Schema for a command's `--json` envelope |
 | `scribe --version` | Show version |
 
 ### What `scribe list` looks like
@@ -275,26 +279,68 @@ Auth fallback chain: `gh auth token` → `GITHUB_TOKEN` env → `~/.scribe/confi
 
 ## CI and agent use
 
-Scribe auto-detects non-TTY environments. Use `--json` for structured output in CI pipelines or agent scripts:
-
-```bash
-scribe list --json
-scribe status --json
-scribe add --json skillname --yes
-```
-
-Example output:
+Scribe auto-detects non-TTY environments. Use `--json` for structured output in CI pipelines or agent scripts. Migrated commands now wrap their payload in a versioned envelope:
 
 ```json
 {
-  "team_repos": ["ArtistfyHQ/team-skills"],
-  "skills": [
-    { "name": "gstack", "action": "skipped", "status": "current", "version": "v0.12.9.0" },
-    { "name": "laravel-init", "action": "updated", "version": "v1.1.0" }
-  ],
-  "summary": { "installed": 0, "updated": 1, "skipped": 1, "failed": 0 }
+  "status": "ok",
+  "format_version": "1",
+  "data": { /* command payload */ },
+  "meta": {
+    "duration_ms": 12,
+    "bootstrap_ms": 3,
+    "command": "scribe sync",
+    "scribe_version": "..."
+  }
 }
 ```
+
+Migration: previously top-level keys are now under `data`. Update parsers from `jq '.foo'` to `jq '.data.foo'`. When `data.summary.failed > 0`, `status` becomes `"partial_success"` and the process exits with code `10`.
+
+Use `scribe schema <command> --json` to fetch the JSON Schema (2020-12) for a migrated command's input flags and output envelope before composing calls. Use `--fields name,version` on read-only tabular commands to project specific columns.
+
+```bash
+scribe list --json
+scribe list --json --fields name,status
+scribe status --json
+scribe sync --json | jq '.data.summary'
+scribe schema sync --json
+scribe add --json owner/repo:skill --yes
+```
+
+### Exit codes
+
+| Code | Meaning |
+|---:|---|
+| 0 | success |
+| 1 | general operational failure |
+| 2 | usage or invalid flags |
+| 3 | not found (command, registry, skill, schema) |
+| 4 | permission or authentication failure |
+| 5 | conflict requiring user action |
+| 6 | network or remote service failure |
+| 7 | temporarily unavailable local dependency |
+| 8 | validation failure |
+| 9 | user canceled |
+| 10 | partial success — inspect `data.summary.failed` |
+
+## Project config
+
+A `.scribe.yaml` at a project root declares which kits, snippets, or extra skills that project wants. The parser and schema have shipped; CLI surfaces that act on them ride on top as they land.
+
+```yaml
+# .scribe.yaml — all keys optional, omit what you don't need
+kits:
+  - laravel-baseline
+snippets:
+  - commit-discipline
+add:
+  - owner/repo:extra-skill
+remove:
+  - skill-this-project-doesnt-want
+```
+
+Empty or missing files are treated as no project-level intent.
 
 ## Health checks
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -128,6 +128,27 @@ Use it for installs, updates, removal, adoption of unmanaged local skills, and s
 8. `scribe sync` reconciles registries; it does not install an arbitrary new skill by query.
 9. Some failures still return plain stderr plus non-zero exit, not a JSON error envelope.
 
+## JSON envelope (format_version=1)
+
+Migrated commands wrap their output in a versioned envelope. Read payload from `data`, never from the top level:
+
+```json
+{ "status": "ok", "format_version": "1", "data": { /* payload */ },
+  "meta": { "duration_ms": 12, "command": "scribe sync", "scribe_version": "..." } }
+```
+
+`status` is `"ok"` on success, `"partial_success"` when `data.summary.failed > 0` (exit code 10), or `"error"` (with non-zero exit). Use `jq '.data.foo'`, not `jq '.foo'`.
+
+Run `scribe schema <command> --json` before composing an unfamiliar call — returns JSON Schema 2020-12 for inputs and outputs.
+
+## Exit codes
+
+`0` ok · `2` usage · `3` not-found · `4` permission · `5` conflict · `6` network · `7` dependency · `8` validation · `9` user-canceled · `10` partial success.
+
+## Project file (`.scribe.yaml`)
+
+If a project root has `.scribe.yaml`, it declares per-project intent — `kits`, `snippets`, `add`, `remove`. The schema and parser ship; CLI surfaces that act on it land per release. Don't synthesize one without being asked.
+
 ## JSON shapes
 
 ### `scribe list --json`

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -128,6 +128,27 @@ Use it for installs, updates, removal, adoption of unmanaged local skills, and s
 9. `scribe list` is local-first. Use `scribe browse` for registry discovery.
 10. Some failures still return plain stderr plus non-zero exit, not a JSON error envelope.
 
+## JSON envelope (format_version=1)
+
+Migrated commands wrap their output in a versioned envelope. Read payload from `data`, never from the top level:
+
+```json
+{ "status": "ok", "format_version": "1", "data": { /* payload */ },
+  "meta": { "duration_ms": 12, "command": "scribe sync", "scribe_version": "..." } }
+```
+
+`status` is `"ok"` on success, `"partial_success"` when `data.summary.failed > 0` (exit code 10), or `"error"` (with non-zero exit). Use `jq '.data.foo'`, not `jq '.foo'`.
+
+Run `scribe schema <command> --json` before composing an unfamiliar call — returns JSON Schema 2020-12 for inputs and outputs.
+
+## Exit codes
+
+`0` ok · `2` usage · `3` not-found · `4` permission · `5` conflict · `6` network · `7` dependency · `8` validation · `9` user-canceled · `10` partial success.
+
+## Project file (`.scribe.yaml`)
+
+If a project root has `.scribe.yaml`, it declares per-project intent — `kits`, `snippets`, `add`, `remove`. The schema and parser ship; CLI surfaces that act on it land per release. Don't synthesize one without being asked.
+
 ## JSON shapes
 
 ### `scribe list --json`


### PR DESCRIPTION
## Summary

Docs-only update covering everything that has shipped since the v0.9.2-beta.1 tag (PRs #113 through #125 — the agent-first foundation waves). No source changes outside docs/, README, CHANGELOG, internal/agent skill, and CLAUDE.md regen.

This is meant to be merged directly by the orchestrator without reviewer.

## Files changed and why

### `README.md`
- Added `scribe browse`, `scribe install --all`, `scribe upgrade-agent` to the daily-use command table.
- Added `scribe schema <command> --json` to the "Other" command table.
- Replaced the old CI/JSON section with a description of the versioned envelope (`format_version: "1"`), `--fields` projection, `scribe schema` introspection, and the full semantic exit code table.
- Added a "Project config" section describing `.scribe.yaml` (parser + schema shipped, CLI surfaces deferred — example uses the actual shipped key set: `kits`, `snippets`, `add`, `remove`).
- Did NOT add a Hooks section: `internal/hooks` ships but isn't wired to a user-facing CLI command yet.

### `CHANGELOG.md`
Restructured the loose "Unreleased" section into Keep a Changelog format with explicit Added/Changed/Fixed/Internal/Deferred groupings, citing every shipped PR by number:
- **Wave 1**: #115 (version fix), #116 (deny-list), #113 (packages store)
- **Wave 2 foundation triplet**: #117 (cli/* foundation), #118 (read-only envelope), #119 (mutator envelope + exit codes + generated CLAUDE.md)
- **Wave 3**: #120 (envelope unification), #121 (.scribe.yaml parser), #122 (scribe-hook.sh + embed)
- **Wave 4**: #123 (hook installer package), #124 (kit YAML + resolution), #125 (state v5 projections + kits/snippets indexes)

Calls out the two BREAKING `--json` envelope changes (PR B for read-only commands, PR C for mutators) and lists the deferred wave-3 commands that still reject `--json`.

### `internal/agent/SKILL.md.tmpl` and `SKILL.md`
The embedded scribe-agent skill that ships in the binary and bootstraps every Claude Code session. Added three concise sections so agents know about the new contract surface without bloating the file:
- JSON envelope (format_version=1) with `data` / `meta` shape, `partial_success` semantics, and the `jq '.data.foo'` migration note
- Single-line exit-code taxonomy (`0` ok · `2` usage · `3` not-found · ... · `10` partial)
- `.scribe.yaml` project file (mentioned, with a clear "don't synthesize one without being asked" guardrail)

Both files updated to stay in sync — `SKILL.md.tmpl` is the //go:embed source, `SKILL.md` is the at-rest copy of the same content.

### `CLAUDE.md` — not modified
The generated agent contract (rendered from `docs/agent/CLAUDE.md.tmpl` via `go generate`). Verified `go generate ./... && git diff --exit-code CLAUDE.md` is clean — the existing committed version is already current for this wave's command surface.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/agent/` — pass (template still parses)
- `go generate ./... && git diff --exit-code CLAUDE.md` — clean

## Test plan

- [ ] Confirm CHANGELOG renders with proper headings on GitHub
- [ ] Confirm README command tables render cleanly
- [ ] Confirm SKILL.md (embedded) is shorter than 8KB so it stays cheap to inject per session