### PR TITLE
feat(tools): per-project projection writer (todos #369 #380)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -19,6 +20,7 @@ import (
 	"github.com/Naoray/scribe/internal/config"
 	gh "github.com/Naoray/scribe/internal/github"
 	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
@@ -387,11 +389,24 @@ func installSelected(
 // newInstallSyncer constructs a Syncer ready to install skills.
 func newInstallSyncer(client *gh.Client, targets []tools.Tool) *sync.Syncer {
 	return &sync.Syncer{
-		Client:   sync.WrapGitHubClient(client),
-		Provider: provider.NewGitHubProvider(provider.WrapGitHubClient(client)),
-		Tools:    targets,
-		Executor: &sync.ShellExecutor{},
+		Client:      sync.WrapGitHubClient(client),
+		Provider:    provider.NewGitHubProvider(provider.WrapGitHubClient(client)),
+		Tools:       targets,
+		Executor:    &sync.ShellExecutor{},
+		ProjectRoot: resolveCurrentProjectRoot(),
 	}
+}
+
+func resolveCurrentProjectRoot() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	projectFile, err := projectfile.Find(wd)
+	if err != nil || projectFile == "" {
+		return ""
+	}
+	return filepath.Dir(projectFile)
 }
 
 // wireInstallSyncer attaches an Emit callback that prints progress (or

--- a/cmd/add_shared.go
+++ b/cmd/add_shared.go
@@ -261,8 +261,9 @@ func finishAdd(ctx context.Context, results []addResult, targetRepo string, st *
 // autoSync runs a sync for the target registry after adding skills.
 func autoSync(ctx context.Context, targetRepo string, st *state.State, client *gh.Client, targets []tools.Tool, useJSON bool) bool {
 	syncer := &sync.Syncer{
-		Client: sync.WrapGitHubClient(client),
-		Tools:  targets,
+		Client:      sync.WrapGitHubClient(client),
+		Tools:       targets,
+		ProjectRoot: resolveCurrentProjectRoot(),
 		Emit: func(msg any) {
 			if useJSON {
 				return

--- a/cmd/list_tui_actions.go
+++ b/cmd/list_tui_actions.go
@@ -165,6 +165,7 @@ func (m listModel) runUpdate(choice updateChoice) tea.Cmd {
 			Tools:            bag.Tools,
 			Executor:         &sync.ShellExecutor{},
 			TrustAll:         bag.TrustAllFlag,
+			ProjectRoot:      bag.ProjectRoot,
 			ModifiedStrategy: sync.ModifiedStrategyMerge,
 		}
 		if choice == updateChoicePreferTheirs {

--- a/cmd/skill_projection_repair.go
+++ b/cmd/skill_projection_repair.go
@@ -51,7 +51,7 @@ func repairSkillProjections(cfg *config.Config, st *state.State, name string) (s
 				return skillProjectionRepairResult{}, fmt.Errorf("clear %s/%s: %w", toolName, name, err)
 			}
 		}
-		links, err := tool.Install(name, canonicalDir)
+		links, err := tool.Install(name, canonicalDir, "")
 		if err != nil {
 			return skillProjectionRepairResult{}, fmt.Errorf("repair %s/%s: %w", toolName, name, err)
 		}

--- a/cmd/skill_repair.go
+++ b/cmd/skill_repair.go
@@ -49,7 +49,7 @@ func applySkillRepair(cfg *config.Config, st *state.State, name, toolName, sourc
 	if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
 		return skillRepairResult{}, err
 	}
-	links, err := tool.Install(name, canonicalDir)
+	links, err := tool.Install(name, canonicalDir, "")
 	if err != nil {
 		return skillRepairResult{}, err
 	}

--- a/cmd/skill_test.go
+++ b/cmd/skill_test.go
@@ -46,12 +46,12 @@ func seedSkillEnv(t *testing.T) {
 	claude := tools.ClaudeTool{}
 	cursor := tools.CursorTool{}
 	paths := []string{}
-	p1, err := claude.Install("commit", canonical)
+	p1, err := claude.Install("commit", canonical, "")
 	if err != nil {
 		t.Fatalf("claude install: %v", err)
 	}
 	paths = append(paths, p1...)
-	p2, err := cursor.Install("commit", canonical)
+	p2, err := cursor.Install("commit", canonical, "")
 	if err != nil {
 		t.Fatalf("cursor install: %v", err)
 	}

--- a/cmd/skill_tools.go
+++ b/cmd/skill_tools.go
@@ -123,7 +123,7 @@ func applySkillToolSelection(cfg *config.Config, st *state.State, name string, m
 
 	for _, toolName := range added {
 		tool := availableByName[toolName]
-		paths, err := tool.Install(name, canonicalDir)
+		paths, err := tool.Install(name, canonicalDir, "")
 		if err != nil {
 			return skillEditResult{}, fmt.Errorf("install into %s: %w", toolName, err)
 		}

--- a/internal/adopt/adopt_test.go
+++ b/internal/adopt/adopt_test.go
@@ -69,7 +69,7 @@ type mockTool struct {
 
 func (m *mockTool) Name() string { return m.name }
 func (m *mockTool) Detect() bool { return true }
-func (m *mockTool) Install(skillName, canonicalDir string) ([]string, error) {
+func (m *mockTool) Install(skillName, canonicalDir, projectRoot string) ([]string, error) {
 	if m.installErr != nil {
 		return nil, m.installErr
 	}

--- a/internal/adopt/apply.go
+++ b/internal/adopt/apply.go
@@ -88,7 +88,7 @@ func (a *Adopter) applyOne(cand Candidate, result *Result) error {
 	var allPaths []string
 
 	for _, tool := range targetTools {
-		paths, err := tool.Install(cand.Name, canonicalDir)
+		paths, err := tool.Install(cand.Name, canonicalDir, "")
 		if err != nil {
 			return fmt.Errorf("install into %s: %w", tool.Name(), err)
 		}

--- a/internal/firstrun/adoption_test.go
+++ b/internal/firstrun/adoption_test.go
@@ -22,12 +22,12 @@ type adoptMockTool struct {
 	name string
 }
 
-func (m *adoptMockTool) Name() string                            { return m.name }
-func (m *adoptMockTool) Detect() bool                            { return true }
-func (m *adoptMockTool) Install(_, _ string) ([]string, error)   { return nil, nil }
-func (m *adoptMockTool) Uninstall(_ string) error                { return nil }
-func (m *adoptMockTool) SkillPath(_ string) (string, error)      { return "", nil }
-func (m *adoptMockTool) CanonicalTarget(_ string) (string, bool) { return "", false }
+func (m *adoptMockTool) Name() string                             { return m.name }
+func (m *adoptMockTool) Detect() bool                             { return true }
+func (m *adoptMockTool) Install(_, _, _ string) ([]string, error) { return nil, nil }
+func (m *adoptMockTool) Uninstall(_ string) error                 { return nil }
+func (m *adoptMockTool) SkillPath(_ string) (string, error)       { return "", nil }
+func (m *adoptMockTool) CanonicalTarget(_ string) (string, bool)  { return "", false }
 
 var _ tools.Tool = (*adoptMockTool)(nil)
 

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -128,7 +128,7 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 
 			if _, err := os.Lstat(path); err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
-					links, installErr := tool.Install(name, canonicalDir)
+					links, installErr := tool.Install(name, canonicalDir, "")
 					if installErr != nil {
 						return summary, actions, fmt.Errorf("install %s/%s: %w", toolName, name, installErr)
 					}
@@ -155,7 +155,7 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 					if err := os.RemoveAll(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
 						return summary, actions, err
 					}
-					links, installErr := tool.Install(name, canonicalDir)
+					links, installErr := tool.Install(name, canonicalDir, "")
 					if installErr != nil {
 						return summary, actions, fmt.Errorf("relink %s/%s: %w", toolName, name, installErr)
 					}

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -438,7 +438,7 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 			var toolNames []string
 			toolFailed := false
 			for _, t := range effectiveTools {
-				links, err := t.Install(sk.Name, canonicalDir)
+				links, err := t.Install(sk.Name, canonicalDir, "")
 				if err != nil {
 					if errors.Is(err, tools.ErrRealDirectoryExists) {
 						existing, pathErr := t.SkillPath(sk.Name)

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -37,6 +37,9 @@ type Syncer struct {
 	Tools    []tools.Tool
 	Emit     func(any) // receives events defined in events.go
 	Executor CommandExecutor
+	// ProjectRoot scopes tool projections to a project-local agent directory.
+	// Empty preserves legacy global projections.
+	ProjectRoot string
 
 	// ModifiedStrategy controls what to do when an outdated skill also has
 	// unsynced local edits on disk.
@@ -438,7 +441,7 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 			var toolNames []string
 			toolFailed := false
 			for _, t := range effectiveTools {
-				links, err := t.Install(sk.Name, canonicalDir, "")
+				links, err := t.Install(sk.Name, canonicalDir, s.ProjectRoot)
 				if err != nil {
 					if errors.Is(err, tools.ErrRealDirectoryExists) {
 						existing, pathErr := t.SkillPath(sk.Name)
@@ -498,14 +501,16 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 				toolsMode = installed.ToolsMode
 			}
 
+			managedPaths := mergeManagedPaths(installed, paths)
 			st.RecordInstall(sk.Name, state.InstalledSkill{
 				Revision:      nextRevision(installed),
 				InstalledHash: installedHash,
 				Sources:       sources,
 				Tools:         toolNames,
 				ToolsMode:     toolsMode,
-				Paths:         paths,
-				ManagedPaths:  append([]string(nil), paths...),
+				Paths:         append([]string(nil), managedPaths...),
+				Projections:   mergeProjection(installed, s.ProjectRoot, toolNames),
+				ManagedPaths:  managedPaths,
 			})
 			// Save after each successful install — partial sync is safe.
 			if err := st.Save(); err != nil {
@@ -599,6 +604,47 @@ func selectEffectiveTools(global []tools.Tool, installed *state.InstalledSkill) 
 		}
 	}
 	return out
+}
+
+func mergeProjection(installed *state.InstalledSkill, projectRoot string, toolNames []string) []state.ProjectionEntry {
+	projections := []state.ProjectionEntry{}
+	if installed != nil {
+		projections = append(projections, installed.Projections...)
+	}
+	next := state.ProjectionEntry{
+		Project: projectRoot,
+		Tools:   append([]string(nil), toolNames...),
+	}
+	for i, projection := range projections {
+		if projection.Project == projectRoot {
+			projections[i] = next
+			return projections
+		}
+	}
+	return append(projections, next)
+}
+
+func mergeManagedPaths(installed *state.InstalledSkill, paths []string) []string {
+	pathSet := make(map[string]bool)
+	if installed != nil {
+		existing := installed.ManagedPaths
+		if len(existing) == 0 {
+			existing = installed.Paths
+		}
+		for _, path := range existing {
+			pathSet[path] = true
+		}
+	}
+	for _, path := range paths {
+		pathSet[path] = true
+	}
+
+	merged := make([]string, 0, len(pathSet))
+	for path := range pathSet {
+		merged = append(merged, path)
+	}
+	sort.Strings(merged)
+	return merged
 }
 
 // formatCmds formats tool commands for display in approval prompts.

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -173,6 +173,120 @@ func TestRunWithDiff_RemovedByUserIsRegistryScoped(t *testing.T) {
 	}
 }
 
+func TestRunWithDiff_RecordsProjectProjection(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	projectRoot := t.TempDir()
+
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{
+			files: []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}},
+		},
+		Tools:       []tools.Tool{tools.ClaudeTool{}},
+		ProjectRoot: projectRoot,
+	}
+	st := &state.State{Installed: make(map[string]state.InstalledSkill)}
+	statuses := []sync.SkillStatus{{
+		Name:   "recap",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "recap", Source: "github:acme/skills@main"},
+	}}
+
+	if err := syncer.RunWithDiff(context.Background(), "acme/skills", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+
+	installed := st.Installed["recap"]
+	if len(installed.Projections) != 1 {
+		t.Fatalf("Projections = %#v, want one entry", installed.Projections)
+	}
+	if installed.Projections[0].Project != projectRoot {
+		t.Fatalf("Projection project = %q, want %q", installed.Projections[0].Project, projectRoot)
+	}
+	if got := installed.Projections[0].Tools; len(got) != 1 || got[0] != "claude" {
+		t.Fatalf("Projection tools = %v, want [claude]", got)
+	}
+
+	wantPath := filepath.Join(projectRoot, ".claude", "skills", "recap")
+	if len(installed.ManagedPaths) != 1 || installed.ManagedPaths[0] != wantPath {
+		t.Fatalf("ManagedPaths = %v, want [%s]", installed.ManagedPaths, wantPath)
+	}
+}
+
+func TestRunWithDiff_RecordsGlobalProjectionWhenProjectRootEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{
+			files: []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}},
+		},
+		Tools: []tools.Tool{tools.ClaudeTool{}},
+	}
+	st := &state.State{Installed: make(map[string]state.InstalledSkill)}
+	statuses := []sync.SkillStatus{{
+		Name:   "recap",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "recap", Source: "github:acme/skills@main"},
+	}}
+
+	if err := syncer.RunWithDiff(context.Background(), "acme/skills", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+
+	installed := st.Installed["recap"]
+	if len(installed.Projections) != 1 || installed.Projections[0].Project != "" {
+		t.Fatalf("Projections = %#v, want one global entry", installed.Projections)
+	}
+	wantPath := filepath.Join(home, ".claude", "skills", "recap")
+	if len(installed.ManagedPaths) != 1 || installed.ManagedPaths[0] != wantPath {
+		t.Fatalf("ManagedPaths = %v, want [%s]", installed.ManagedPaths, wantPath)
+	}
+}
+
+func TestRunWithDiff_MultiProjectProjectionPathsAreIsolated(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	projectOne := t.TempDir()
+	projectTwo := t.TempDir()
+	files := []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}}
+	statuses := []sync.SkillStatus{{
+		Name:   "recap",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "recap", Source: "github:acme/skills@main"},
+	}}
+	st := &state.State{Installed: make(map[string]state.InstalledSkill)}
+
+	for _, projectRoot := range []string{projectOne, projectTwo} {
+		syncer := &sync.Syncer{
+			Client:      &syncTestFetcher{files: files},
+			Tools:       []tools.Tool{tools.ClaudeTool{}},
+			ProjectRoot: projectRoot,
+		}
+		if err := syncer.RunWithDiff(context.Background(), "acme/skills", statuses, st); err != nil {
+			t.Fatalf("RunWithDiff %s: %v", projectRoot, err)
+		}
+	}
+
+	installed := st.Installed["recap"]
+	if len(installed.Projections) != 2 {
+		t.Fatalf("Projections = %#v, want two project entries", installed.Projections)
+	}
+	pathOne := filepath.Join(projectOne, ".claude", "skills", "recap")
+	pathTwo := filepath.Join(projectTwo, ".claude", "skills", "recap")
+	if _, err := os.Lstat(pathOne); err != nil {
+		t.Fatalf("project one projection missing: %v", err)
+	}
+	if _, err := os.Lstat(pathTwo); err != nil {
+		t.Fatalf("project two projection missing: %v", err)
+	}
+
+	if err := os.Remove(pathOne); err != nil {
+		t.Fatalf("remove project one projection: %v", err)
+	}
+	if _, err := os.Lstat(pathTwo); err != nil {
+		t.Fatalf("project two projection affected by project one removal: %v", err)
+	}
+}
+
 func TestApply_PackageMissing_Approved(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/tools/claude.go
+++ b/internal/tools/claude.go
@@ -27,8 +27,8 @@ func (t ClaudeTool) Detect() bool {
 	return err == nil
 }
 
-func (t ClaudeTool) Install(skillName, canonicalDir string) ([]string, error) {
-	skillsDir, err := claudeSkillsDir()
+func (t ClaudeTool) Install(skillName, canonicalDir, projectRoot string) ([]string, error) {
+	skillsDir, err := claudeSkillsDir(projectRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (t ClaudeTool) Install(skillName, canonicalDir string) ([]string, error) {
 }
 
 func (t ClaudeTool) Uninstall(skillName string) error {
-	skillsDir, err := claudeSkillsDir()
+	skillsDir, err := claudeSkillsDir("")
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (t ClaudeTool) Uninstall(skillName string) error {
 }
 
 func (t ClaudeTool) SkillPath(skillName string) (string, error) {
-	skillsDir, err := claudeSkillsDir()
+	skillsDir, err := claudeSkillsDir("")
 	if err != nil {
 		return "", err
 	}
@@ -72,7 +72,10 @@ func (t ClaudeTool) CanonicalTarget(canonicalDir string) (string, bool) {
 	return canonicalDir, true
 }
 
-func claudeSkillsDir() (string, error) {
+func claudeSkillsDir(projectRoot string) (string, error) {
+	if projectRoot != "" {
+		return filepath.Join(projectRoot, ".claude", "skills"), nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("home dir: %w", err)

--- a/internal/tools/claude.go
+++ b/internal/tools/claude.go
@@ -28,6 +28,7 @@ func (t ClaudeTool) Detect() bool {
 }
 
 func (t ClaudeTool) Install(skillName, canonicalDir, projectRoot string) ([]string, error) {
+	projectRoot = projectionProjectRoot(skillName, projectRoot)
 	skillsDir, err := claudeSkillsDir(projectRoot)
 	if err != nil {
 		return nil, err

--- a/internal/tools/claude_test.go
+++ b/internal/tools/claude_test.go
@@ -39,7 +39,7 @@ func TestClaudeInstall_ReplacesExistingSymlink(t *testing.T) {
 	}
 
 	tool := ClaudeTool{}
-	if _, err := tool.Install("qa", oldCanonical); err != nil {
+	if _, err := tool.Install("qa", oldCanonical, ""); err != nil {
 		t.Fatalf("first Install: %v", err)
 	}
 
@@ -48,7 +48,7 @@ func TestClaudeInstall_ReplacesExistingSymlink(t *testing.T) {
 	if err := os.MkdirAll(newCanonical, 0o755); err != nil {
 		t.Fatalf("mkdir new canonical: %v", err)
 	}
-	if _, err := tool.Install("qa", newCanonical); err != nil {
+	if _, err := tool.Install("qa", newCanonical, ""); err != nil {
 		t.Fatalf("second Install: %v", err)
 	}
 
@@ -88,7 +88,7 @@ func TestClaudeInstall_FailsOnRealDirectory(t *testing.T) {
 	}
 
 	tool := ClaudeTool{}
-	_, err := tool.Install("qa", canonical)
+	_, err := tool.Install("qa", canonical, "")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -126,7 +126,7 @@ func TestClaudeInstallSymlinksToDir(t *testing.T) {
 	}
 
 	tool := ClaudeTool{}
-	paths, err := tool.Install("cleanup", canonicalDir)
+	paths, err := tool.Install("cleanup", canonicalDir, "")
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}

--- a/internal/tools/codex.go
+++ b/internal/tools/codex.go
@@ -31,6 +31,7 @@ func (t CodexTool) Detect() bool {
 }
 
 func (t CodexTool) Install(skillName, canonicalDir, projectRoot string) ([]string, error) {
+	projectRoot = projectionProjectRoot(skillName, projectRoot)
 	if err := ensureCodexCompatibleSkillMD(skillName, canonicalDir); err != nil {
 		return nil, err
 	}

--- a/internal/tools/codex.go
+++ b/internal/tools/codex.go
@@ -30,11 +30,11 @@ func (t CodexTool) Detect() bool {
 	return homeDirExists(filepath.Join(home, ".codex"))
 }
 
-func (t CodexTool) Install(skillName, canonicalDir string) ([]string, error) {
+func (t CodexTool) Install(skillName, canonicalDir, projectRoot string) ([]string, error) {
 	if err := ensureCodexCompatibleSkillMD(skillName, canonicalDir); err != nil {
 		return nil, err
 	}
-	skillsDir, err := codexSkillsDir()
+	skillsDir, err := codexSkillsDir(projectRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (t CodexTool) Install(skillName, canonicalDir string) ([]string, error) {
 }
 
 func (t CodexTool) Uninstall(skillName string) error {
-	skillsDir, err := codexSkillsDir()
+	skillsDir, err := codexSkillsDir("")
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (t CodexTool) Uninstall(skillName string) error {
 }
 
 func (t CodexTool) SkillPath(skillName string) (string, error) {
-	skillsDir, err := codexSkillsDir()
+	skillsDir, err := codexSkillsDir("")
 	if err != nil {
 		return "", err
 	}
@@ -72,7 +72,10 @@ func (t CodexTool) CanonicalTarget(canonicalDir string) (string, bool) {
 	return canonicalDir, true
 }
 
-func codexSkillsDir() (string, error) {
+func codexSkillsDir(projectRoot string) (string, error) {
+	if projectRoot != "" {
+		return filepath.Join(projectRoot, ".codex", "skills"), nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("home dir: %w", err)

--- a/internal/tools/command.go
+++ b/internal/tools/command.go
@@ -24,7 +24,7 @@ func (t CommandTool) Detect() bool {
 	return runShell(t.DetectCommand) == nil
 }
 
-func (t CommandTool) Install(skillName, canonicalDir string) ([]string, error) {
+func (t CommandTool) Install(skillName, canonicalDir, projectRoot string) ([]string, error) {
 	cmd := renderTemplate(t.InstallCommand, t.ToolName, skillName, canonicalDir)
 	if err := runShell(cmd); err != nil {
 		return nil, fmt.Errorf("install %s via %s: %w", skillName, t.ToolName, err)

--- a/internal/tools/cursor.go
+++ b/internal/tools/cursor.go
@@ -33,6 +33,7 @@ func (t CursorTool) Detect() bool {
 }
 
 func (t CursorTool) Install(skillName, canonicalDir, projectRoot string) ([]string, error) {
+	projectRoot = projectionProjectRoot(skillName, projectRoot)
 	// Generate .cursor.mdc from SKILL.md in the store.
 	skillMDPath := filepath.Join(canonicalDir, "SKILL.md")
 	skillMD, err := os.ReadFile(skillMDPath)

--- a/internal/tools/cursor.go
+++ b/internal/tools/cursor.go
@@ -154,6 +154,13 @@ func stripFrontmatter(content []byte) []byte {
 
 func (t CursorTool) installFromMDC(skillName, mdcPath, projectRoot string) ([]string, error) {
 	workDir := projectRoot
+	if skillName == bootstrapSkillName {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("home dir: %w", err)
+		}
+		workDir = home
+	}
 	if workDir == "" {
 		var err error
 		workDir, err = t.resolveWorkDir()

--- a/internal/tools/cursor.go
+++ b/internal/tools/cursor.go
@@ -32,7 +32,7 @@ func (t CursorTool) Detect() bool {
 	return err == nil
 }
 
-func (t CursorTool) Install(skillName, canonicalDir string) ([]string, error) {
+func (t CursorTool) Install(skillName, canonicalDir, projectRoot string) ([]string, error) {
 	// Generate .cursor.mdc from SKILL.md in the store.
 	skillMDPath := filepath.Join(canonicalDir, "SKILL.md")
 	skillMD, err := os.ReadFile(skillMDPath)
@@ -40,7 +40,7 @@ func (t CursorTool) Install(skillName, canonicalDir string) ([]string, error) {
 		if errors.Is(err, fs.ErrNotExist) {
 			mdcPath := filepath.Join(canonicalDir, ".cursor.mdc")
 			if _, statErr := os.Stat(mdcPath); statErr == nil {
-				return t.installFromMDC(skillName, mdcPath)
+				return t.installFromMDC(skillName, mdcPath, projectRoot)
 			}
 			return nil, fmt.Errorf("skill %q has no SKILL.md in store", skillName)
 		}
@@ -53,7 +53,7 @@ func (t CursorTool) Install(skillName, canonicalDir string) ([]string, error) {
 		return nil, fmt.Errorf("write .cursor.mdc for %q: %w", skillName, err)
 	}
 
-	return t.installFromMDC(skillName, mdcPath)
+	return t.installFromMDC(skillName, mdcPath, projectRoot)
 }
 
 func (t CursorTool) Uninstall(skillName string) error {
@@ -151,10 +151,14 @@ func stripFrontmatter(content []byte) []byte {
 	return []byte(strings.TrimLeft(rest[idx+4:], "\n"))
 }
 
-func (t CursorTool) installFromMDC(skillName, mdcPath string) ([]string, error) {
-	workDir, err := t.resolveWorkDir()
-	if err != nil {
-		return nil, err
+func (t CursorTool) installFromMDC(skillName, mdcPath, projectRoot string) ([]string, error) {
+	workDir := projectRoot
+	if workDir == "" {
+		var err error
+		workDir, err = t.resolveWorkDir()
+		if err != nil {
+			return nil, err
+		}
 	}
 	rulesDir := filepath.Join(workDir, ".cursor", "rules")
 	mdcName := SlugifyRegistry(skillName) + ".mdc"

--- a/internal/tools/gemini.go
+++ b/internal/tools/gemini.go
@@ -19,7 +19,7 @@ func (t GeminiTool) Detect() bool {
 	return err == nil
 }
 
-func (t GeminiTool) Install(skillName, canonicalDir string) ([]string, error) {
+func (t GeminiTool) Install(skillName, canonicalDir, projectRoot string) ([]string, error) {
 	cmd := exec.Command(toolGemini, "skills", "link", canonicalDir, "--scope", "user", "--consent")
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -16,8 +16,10 @@ type Tool interface {
 	// Name returns the tool identifier (e.g. "claude", "cursor").
 	Name() string
 	// Install creates a link from the agent's expected directory into canonicalDir
-	// (~/.scribe/skills/<name>). Returns the paths of the links created.
-	Install(skillName, canonicalDir string) (paths []string, err error)
+	// (~/.scribe/skills/<name>). projectRoot scopes tools that support
+	// project-local projections; an empty projectRoot preserves legacy global
+	// projection behavior. Returns the paths of the links created.
+	Install(skillName, canonicalDir, projectRoot string) (paths []string, err error)
 	// Uninstall removes the links for a skill.
 	Uninstall(skillName string) error
 	// Detect reports whether this tool is installed on the machine.

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -5,6 +5,8 @@ package tools
 
 import "os"
 
+const bootstrapSkillName = "scribe-agent"
+
 // SkillFile represents a file to be written to the skill store.
 type SkillFile struct {
 	Path    string // relative to the skill root (e.g. "scripts/deploy.sh")
@@ -59,4 +61,11 @@ func DetectTools() []Tool {
 func homeDirExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+func projectionProjectRoot(skillName, projectRoot string) string {
+	if skillName == bootstrapSkillName {
+		return ""
+	}
+	return projectRoot
 }

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -58,7 +58,7 @@ func TestClaudeInstall(t *testing.T) {
 	canonicalDir := setup(t)
 
 	tool := tools.ClaudeTool{}
-	paths, err := tool.Install("deploy", canonicalDir)
+	paths, err := tool.Install("deploy", canonicalDir, "")
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
@@ -90,10 +90,10 @@ func TestClaudeInstallReplaces(t *testing.T) {
 	tool := tools.ClaudeTool{}
 
 	// Install twice — second should replace the first without error.
-	if _, err := tool.Install("deploy", canonicalDir); err != nil {
+	if _, err := tool.Install("deploy", canonicalDir, ""); err != nil {
 		t.Fatalf("first Install: %v", err)
 	}
-	if _, err := tool.Install("deploy", canonicalDir); err != nil {
+	if _, err := tool.Install("deploy", canonicalDir, ""); err != nil {
 		t.Fatalf("second Install: %v", err)
 	}
 }
@@ -103,7 +103,7 @@ func TestCursorInstall(t *testing.T) {
 	workDir := t.TempDir()
 
 	tool := tools.CursorTool{WorkDir: workDir}
-	paths, err := tool.Install("deploy", canonicalDir)
+	paths, err := tool.Install("deploy", canonicalDir, "")
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestClaudeUninstall(t *testing.T) {
 	canonicalDir := setup(t)
 	tool := tools.ClaudeTool{}
 
-	if _, err := tool.Install("deploy", canonicalDir); err != nil {
+	if _, err := tool.Install("deploy", canonicalDir, ""); err != nil {
 		t.Fatalf("Install: %v", err)
 	}
 	if err := tool.Uninstall("deploy"); err != nil {
@@ -194,7 +194,7 @@ func TestCursorUninstall(t *testing.T) {
 	workDir := t.TempDir()
 	tool := tools.CursorTool{WorkDir: workDir}
 
-	if _, err := tool.Install("deploy", canonicalDir); err != nil {
+	if _, err := tool.Install("deploy", canonicalDir, ""); err != nil {
 		t.Fatalf("Install: %v", err)
 	}
 	if err := tool.Uninstall("deploy"); err != nil {
@@ -232,7 +232,7 @@ func TestGeminiInstallAndUninstall(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "gemini"), "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \""+logPath+"\"\n")
 
 	tool := tools.GeminiTool{}
-	paths, err := tool.Install("deploy", canonicalDir)
+	paths, err := tool.Install("deploy", canonicalDir, "")
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
@@ -279,7 +279,7 @@ func TestCodexInstallAndUninstall(t *testing.T) {
 	canonicalDir := setup(t)
 
 	tool := tools.CodexTool{}
-	paths, err := tool.Install("deploy", canonicalDir)
+	paths, err := tool.Install("deploy", canonicalDir, "")
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestCodexInstall_ProjectsCodexCompatibleSkillMD(t *testing.T) {
 	}
 
 	tool := tools.CodexTool{}
-	paths, err := tool.Install("ascii", canonicalDir)
+	paths, err := tool.Install("ascii", canonicalDir, "")
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
@@ -423,7 +423,7 @@ func TestCommandToolInstallAndUninstall(t *testing.T) {
 		PathTemplate:     "/tmp/{{tool_name}}/{{skill_name}}",
 	}
 
-	paths, err := cmd.Install("deploy", "/tmp/store/deploy")
+	paths, err := cmd.Install("deploy", "/tmp/store/deploy", "")
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
@@ -497,7 +497,7 @@ func TestCursorInstallBareName(t *testing.T) {
 	}
 
 	tool := tools.CursorTool{WorkDir: workDir}
-	paths, err := tool.Install("deploy", dir)
+	paths, err := tool.Install("deploy", dir, "")
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -34,6 +34,19 @@ func setup(t *testing.T) (canonicalDir string) {
 	return dir
 }
 
+func setupNamedSkill(t *testing.T, name string) string {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	dir, err := tools.WriteToStore(name, []tools.SkillFile{{
+		Path:    "SKILL.md",
+		Content: []byte("---\nname: " + name + "\ndescription: test skill\n---\n\n# " + name + "\n"),
+	}})
+	if err != nil {
+		t.Fatalf("WriteToStore: %v", err)
+	}
+	return dir
+}
+
 func TestWriteToStore(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	dir, err := tools.WriteToStore("deploy", testFiles)
@@ -98,6 +111,72 @@ func TestClaudeInstallReplaces(t *testing.T) {
 	}
 }
 
+func TestClaudeInstallProjectRootWritesProjectLocalPath(t *testing.T) {
+	canonicalDir := setup(t)
+	projectRoot := t.TempDir()
+
+	tool := tools.ClaudeTool{}
+	paths, err := tool.Install("deploy", canonicalDir, projectRoot)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	want := filepath.Join(projectRoot, ".claude", "skills", "deploy")
+	if len(paths) != 1 || paths[0] != want {
+		t.Fatalf("paths = %v, want [%s]", paths, want)
+	}
+	if resolved, err := os.Readlink(want); err != nil || resolved != canonicalDir {
+		t.Fatalf("project-local symlink = %q, %v; want %q", resolved, err, canonicalDir)
+	}
+}
+
+func TestClaudeInstallEmptyProjectRootWritesGlobalPath(t *testing.T) {
+	canonicalDir := setup(t)
+	home := os.Getenv("HOME")
+
+	tool := tools.ClaudeTool{}
+	paths, err := tool.Install("deploy", canonicalDir, "")
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	want := filepath.Join(home, ".claude", "skills", "deploy")
+	if len(paths) != 1 || paths[0] != want {
+		t.Fatalf("paths = %v, want [%s]", paths, want)
+	}
+}
+
+func TestScribeAgentAlwaysProjectsGlobal(t *testing.T) {
+	canonicalDir := setupNamedSkill(t, "scribe-agent")
+	home := os.Getenv("HOME")
+	projectRoot := t.TempDir()
+
+	claudePaths, err := tools.ClaudeTool{}.Install("scribe-agent", canonicalDir, projectRoot)
+	if err != nil {
+		t.Fatalf("claude Install: %v", err)
+	}
+	codexPaths, err := tools.CodexTool{}.Install("scribe-agent", canonicalDir, projectRoot)
+	if err != nil {
+		t.Fatalf("codex Install: %v", err)
+	}
+	cursorPaths, err := tools.CursorTool{}.Install("scribe-agent", canonicalDir, projectRoot)
+	if err != nil {
+		t.Fatalf("cursor Install: %v", err)
+	}
+
+	wants := []string{
+		filepath.Join(home, ".claude", "skills", "scribe-agent"),
+		filepath.Join(home, ".codex", "skills", "scribe-agent"),
+		filepath.Join(home, ".cursor", "rules", "scribe-agent.mdc"),
+	}
+	got := []string{claudePaths[0], codexPaths[0], cursorPaths[0]}
+	for i := range wants {
+		if got[i] != wants[i] {
+			t.Fatalf("path[%d] = %q, want %q", i, got[i], wants[i])
+		}
+	}
+}
+
 func TestCursorInstall(t *testing.T) {
 	canonicalDir := setup(t)
 	workDir := t.TempDir()
@@ -138,6 +217,26 @@ func TestCursorInstall(t *testing.T) {
 	}
 	if strings.Contains(content, "license: MIT") {
 		t.Errorf("MDC should not contain SKILL.md frontmatter")
+	}
+}
+
+func TestCursorInstallProjectRootWritesProjectLocalRulesPath(t *testing.T) {
+	canonicalDir := setup(t)
+	workDir := t.TempDir()
+	projectRoot := t.TempDir()
+
+	tool := tools.CursorTool{WorkDir: workDir}
+	paths, err := tool.Install("deploy", canonicalDir, projectRoot)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	want := filepath.Join(projectRoot, ".cursor", "rules", "deploy.mdc")
+	if len(paths) != 1 || paths[0] != want {
+		t.Fatalf("paths = %v, want [%s]", paths, want)
+	}
+	if _, err := os.Lstat(filepath.Join(workDir, ".cursor", "rules", "deploy.mdc")); !os.IsNotExist(err) {
+		t.Fatalf("legacy workdir link exists or stat failed: %v", err)
 	}
 }
 
@@ -300,6 +399,25 @@ func TestCodexInstallAndUninstall(t *testing.T) {
 	}
 	if _, err := os.Lstat(paths[0]); !os.IsNotExist(err) {
 		t.Error("expected codex symlink to be removed after uninstall")
+	}
+}
+
+func TestCodexInstallProjectRootWritesProjectLocalPath(t *testing.T) {
+	canonicalDir := setup(t)
+	projectRoot := t.TempDir()
+
+	tool := tools.CodexTool{}
+	paths, err := tool.Install("deploy", canonicalDir, projectRoot)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	want := filepath.Join(projectRoot, ".codex", "skills", "deploy")
+	if len(paths) != 1 || paths[0] != want {
+		t.Fatalf("paths = %v, want [%s]", paths, want)
+	}
+	if resolved, err := os.Readlink(want); err != nil || resolved != canonicalDir {
+		t.Fatalf("project-local symlink = %q, %v; want %q", resolved, err, canonicalDir)
 	}
 }
 

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -33,13 +33,14 @@ type Bag struct {
 	SkillFilter []string
 
 	// Populated by steps
-	Config     *config.Config
-	State      *state.State
-	Client     *gh.Client
-	Tools      []tools.Tool
-	Repos      []string // filtered registries to process
-	Formatter  Formatter
-	StateDirty bool
+	Config      *config.Config
+	State       *state.State
+	Client      *gh.Client
+	Tools       []tools.Tool
+	ProjectRoot string
+	Repos       []string // filtered registries to process
+	Formatter   Formatter
+	StateDirty  bool
 
 	// Provider is the skill discovery/fetch backend. Set by StepLoadConfig.
 	Provider provider.Provider

--- a/internal/workflow/connect.go
+++ b/internal/workflow/connect.go
@@ -55,6 +55,7 @@ func connectInstallAllTail() []Step {
 		{Name: "LoadState", Fn: StepLoadState},
 		{Name: "SetSingleRepo", Fn: StepSetSingleRepo},
 		{Name: "ResolveTools", Fn: StepResolveTools},
+		{Name: "ResolveProjectRoot", Fn: StepResolveProjectRoot},
 		{Name: "SyncSkills", Fn: StepConnectSyncError},
 	}
 }

--- a/internal/workflow/install.go
+++ b/internal/workflow/install.go
@@ -21,6 +21,7 @@ func InstallSteps() []Step {
 		{"FilterRegistries", StepFilterRegistries},
 		{"ResolveFormatter", StepResolveFormatter},
 		{"ResolveTools", StepResolveTools},
+		{"ResolveProjectRoot", StepResolveProjectRoot},
 		{"SelectSkills", StepSelectSkills},
 		{"SyncSkills", StepSyncSkills},
 	}

--- a/internal/workflow/list.go
+++ b/internal/workflow/list.go
@@ -31,6 +31,7 @@ func ListLoadStepsRemote() []Step {
 		{"LoadConfig", StepLoadConfig},
 		{"LoadState", StepLoadState},
 		{"ResolveTools", StepResolveTools},
+		{"ResolveProjectRoot", StepResolveProjectRoot},
 		{"EnsureScribeAgent", StepEnsureScribeAgent},
 	}
 }

--- a/internal/workflow/list_test.go
+++ b/internal/workflow/list_test.go
@@ -85,8 +85,8 @@ func TestListLoadSteps_Composition(t *testing.T) {
 
 func TestListLoadStepsRemote_Composition(t *testing.T) {
 	steps := ListLoadStepsRemote()
-	if len(steps) != 4 {
-		t.Fatalf("ListLoadStepsRemote() = %d steps, want 4", len(steps))
+	if len(steps) != 5 {
+		t.Fatalf("ListLoadStepsRemote() = %d steps, want 5", len(steps))
 	}
 	if steps[0].Name != "LoadConfig" {
 		t.Errorf("step[0] = %s, want LoadConfig", steps[0].Name)
@@ -97,8 +97,11 @@ func TestListLoadStepsRemote_Composition(t *testing.T) {
 	if steps[2].Name != "ResolveTools" {
 		t.Errorf("step[2] = %s, want ResolveTools", steps[2].Name)
 	}
-	if steps[3].Name != "EnsureScribeAgent" {
-		t.Errorf("step[3] = %s, want EnsureScribeAgent", steps[3].Name)
+	if steps[3].Name != "ResolveProjectRoot" {
+		t.Errorf("step[3] = %s, want ResolveProjectRoot", steps[3].Name)
+	}
+	if steps[4].Name != "EnsureScribeAgent" {
+		t.Errorf("step[4] = %s, want EnsureScribeAgent", steps[4].Name)
 	}
 }
 

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"charm.land/huh/v2"
 	"github.com/mattn/go-isatty"
@@ -13,6 +14,7 @@ import (
 	"github.com/Naoray/scribe/internal/app"
 	"github.com/Naoray/scribe/internal/config"
 	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/reconcile"
 	"github.com/Naoray/scribe/internal/state"
@@ -31,6 +33,7 @@ func SyncSteps() []Step {
 		{"FilterRegistries", StepFilterRegistries},
 		{"ResolveFormatter", StepResolveFormatter},
 		{"ResolveTools", StepResolveTools},
+		{"ResolveProjectRoot", StepResolveProjectRoot},
 		{"EnsureScribeAgent", StepEnsureScribeAgent},
 		{"Adopt", StepAdopt},
 		{"ReconcilePre", StepReconcileSystem},
@@ -44,6 +47,7 @@ func SyncTail() []Step {
 	return []Step{
 		{"ResolveFormatter", StepResolveFormatter},
 		{"ResolveTools", StepResolveTools},
+		{"ResolveProjectRoot", StepResolveProjectRoot},
 		{"EnsureScribeAgent", StepEnsureScribeAgent},
 		{"SyncSkills", StepSyncSkills},
 		{"ReconcilePost", StepReconcileSystem},
@@ -69,6 +73,23 @@ func StepReconcileSystem(_ context.Context, b *Bag) error {
 	}
 	b.Formatter.OnReconcileComplete(sync.ReconcileCompleteMsg{Summary: summary})
 	b.MarkStateDirty()
+	return nil
+}
+
+func StepResolveProjectRoot(_ context.Context, b *Bag) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get working directory: %w", err)
+	}
+	projectFile, err := projectfile.Find(wd)
+	if err != nil {
+		return err
+	}
+	if projectFile == "" {
+		b.ProjectRoot = ""
+		return nil
+	}
+	b.ProjectRoot = filepath.Dir(projectFile)
 	return nil
 }
 
@@ -268,6 +289,7 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 		Executor:    &sync.ShellExecutor{},
 		TrustAll:    b.TrustAllFlag,
 		SkillFilter: b.SkillFilter,
+		ProjectRoot: b.ProjectRoot,
 		// Skip missing skills when no explicit filter/--all: scribe sync only updates
 		// what's already installed. scribe install sets SkillFilter or InstallAllFlag
 		// to opt-in to installing new skills.

--- a/internal/workflow/sync_adopt_test.go
+++ b/internal/workflow/sync_adopt_test.go
@@ -105,7 +105,7 @@ type mockAdoptTool struct {
 func (m *mockAdoptTool) Name() string             { return m.name }
 func (m *mockAdoptTool) Detect() bool             { return true }
 func (m *mockAdoptTool) Uninstall(_ string) error { return nil }
-func (m *mockAdoptTool) Install(skillName, _ string) ([]string, error) {
+func (m *mockAdoptTool) Install(skillName, _, _ string) ([]string, error) {
 	if m.installErr != nil {
 		return nil, m.installErr
 	}


### PR DESCRIPTION
## Summary
- project Claude/Codex/Cursor skill links under the resolved .scribe.yaml project root while preserving global fallback without a project file
- keep scribe-agent pinned to global tool locations so the bootstrap skill is available in every session
- record per-project projection entries in state and preserve managed paths across projects

## Verification
- go build ./...
- go test ./internal/tools/ -count=1
- go test ./... -count=1 -timeout 60s
- go vet ./...