### PR TITLE
fix(doctor): skip projection-drift check for opaque tools (todo #488)

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -204,6 +204,7 @@ func inspectProjectionDrift(cfg *config.Config, skillName string, skill state.In
 
 	expectedPaths := make(map[string]expectedProjection, len(expectedTools))
 	opaquePaths := make(map[string]bool, len(expectedTools))
+	opaqueTools := make(map[string]bool, len(expectedTools))
 	canonicalDir, err := storeSkillDir(skillName)
 	if err != nil {
 		return Issue{
@@ -225,6 +226,19 @@ func inspectProjectionDrift(cfg *config.Config, skillName string, skill state.In
 				Message: fmt.Sprintf("resolve tool %q: %v", toolName, err),
 			}, true
 		}
+		// Opacity check FIRST. Opaque tools (gemini, custom CommandTools)
+		// own their on-disk projection — scribe cannot drift-check it.
+		// SkillPath may legitimately error for opaque tools (gemini does
+		// so by design); calling it before the opacity check turns that
+		// intentional error into a bogus projection_drift report.
+		target, inspectable := tool.CanonicalTarget(canonicalDir)
+		if !inspectable {
+			opaqueTools[toolName] = true
+			if path, err := tool.SkillPath(skillName); err == nil {
+				opaquePaths[path] = true
+			}
+			continue
+		}
 		path, err := tool.SkillPath(skillName)
 		if err != nil {
 			return Issue{
@@ -234,11 +248,6 @@ func inspectProjectionDrift(cfg *config.Config, skillName string, skill state.In
 				Status:  "error",
 				Message: fmt.Sprintf("resolve projection path for %q: %v", toolName, err),
 			}, true
-		}
-		target, inspectable := tool.CanonicalTarget(canonicalDir)
-		if !inspectable {
-			opaquePaths[path] = true
-			continue
 		}
 		expectedPaths[path] = expectedProjection{Tool: toolName, Target: target}
 	}
@@ -256,7 +265,7 @@ func inspectProjectionDrift(cfg *config.Config, skillName string, skill state.In
 	primaryTool := ""
 
 	for _, conflict := range skill.Conflicts {
-		if opaquePaths[conflict.Path] {
+		if opaquePaths[conflict.Path] || opaqueTools[conflict.Tool] {
 			continue
 		}
 		details = append(details, fmt.Sprintf("%s projection at %s is conflicted", conflict.Tool, conflict.Path))
@@ -272,7 +281,7 @@ func inspectProjectionDrift(cfg *config.Config, skillName string, skill state.In
 		if _, ok := expectedPaths[path]; ok {
 			continue
 		}
-		if opaquePaths[path] {
+		if opaquePaths[path] || pathOwnedByOpaqueTool(path, opaqueTools) {
 			continue
 		}
 		toolName := inferToolName(path, cfg, skillName)
@@ -309,6 +318,23 @@ func inspectProjectionDrift(cfg *config.Config, skillName string, skill state.In
 		Status:  "warn",
 		Message: strings.Join(details, "; "),
 	}, true
+}
+
+// pathOwnedByOpaqueTool reports whether path uses a `<tool>:` scheme prefix
+// belonging to one of the opaque tools. Opaque tools that cannot expose a
+// filesystem location (e.g. gemini) record managed paths as pseudo-URIs like
+// "gemini:user:recap"; without this check the actuals loop would flag them
+// as unexpected projections.
+func pathOwnedByOpaqueTool(path string, opaqueTools map[string]bool) bool {
+	for toolName := range opaqueTools {
+		if toolName == "" {
+			continue
+		}
+		if strings.HasPrefix(path, toolName+":") {
+			return true
+		}
+	}
+	return false
 }
 
 func projectionPaths(skill state.InstalledSkill) []string {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -267,6 +267,176 @@ description: Keep daily notes and summaries.
 	}
 }
 
+// TestInspectSkipsOpaqueToolWhenSkillPathErrors covers the gemini-style
+// failure mode: an opaque tool that intentionally returns an error from
+// SkillPath (because it cannot expose a filesystem location). The opacity
+// check must run BEFORE SkillPath so the intentional error is not wrapped
+// as a bogus projection_drift issue. See todo #488.
+func TestInspectSkipsOpaqueToolWhenSkillPathErrors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	writeSkill(t, "recap", []byte(`---
+name: recap
+description: Keep daily notes and summaries.
+---
+
+# Recap
+`))
+
+	// Custom tool with no Path template — SkillPath will return an error,
+	// mirroring the gemini case. CommandTool.CanonicalTarget always returns
+	// ok=false, so this tool is opaque from doctor's perspective.
+	cfg := &config.Config{
+		Tools: []config.ToolConfig{
+			{
+				Name:      "ghost",
+				Enabled:   true,
+				Install:   "echo install",
+				Uninstall: "echo uninstall",
+			},
+		},
+	}
+	st := managedState("recap", []string{"ghost"}, []string{"ghost:user:recap"})
+
+	report, err := InspectManagedSkills(cfg, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+	for _, issue := range report.Issues {
+		if issue.Kind == IssueProjectionDrift {
+			t.Fatalf("unexpected projection_drift issue for opaque tool: %+v", issue)
+		}
+	}
+}
+
+// TestInspectStillReportsDriftForInspectableTool guards against regressing
+// drift detection while fixing the opacity bug. A real inspectable tool with
+// a missing projection on disk must still surface as projection_drift.
+func TestInspectStillReportsDriftForInspectableTool(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	writeSkill(t, "recap", []byte(`---
+name: recap
+description: Keep daily notes and summaries.
+---
+
+# Recap
+`))
+
+	// claude is an inspectable builtin. Skill state claims a projection at
+	// the expected claude path, but no symlink is on disk → drift.
+	claudePath := filepath.Join(home, ".claude", "skills", "recap")
+	st := managedState("recap", []string{"claude"}, []string{claudePath})
+	cfg := &config.Config{
+		Tools: []config.ToolConfig{
+			{Name: "claude", Enabled: true},
+		},
+	}
+
+	report, err := InspectManagedSkills(cfg, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+
+	var drift *Issue
+	for i := range report.Issues {
+		if report.Issues[i].Kind == IssueProjectionDrift {
+			drift = &report.Issues[i]
+			break
+		}
+	}
+	if drift == nil {
+		t.Fatalf("expected a projection_drift issue, got: %+v", report.Issues)
+	}
+	if drift.Tool != "claude" {
+		t.Fatalf("Tool = %q, want claude", drift.Tool)
+	}
+	if !strings.Contains(drift.Message, "missing managed projection") &&
+		!strings.Contains(drift.Message, "does not point to the canonical target") {
+		t.Fatalf("Message = %q, want drift detail", drift.Message)
+	}
+}
+
+// TestInspectSkipsConflictsFromOpaqueTools verifies the conflicts loop
+// suppresses entries whose tool is opaque. Without the opaqueTools-by-name
+// guard, conflicts recorded against an opaque tool (which has no
+// scribe-known path) would still surface as drift.
+func TestInspectSkipsConflictsFromOpaqueTools(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	canonical := writeSkill(t, "recap", []byte(`---
+name: recap
+description: Keep daily notes and summaries.
+---
+
+# Recap
+`))
+
+	codexPath := filepath.Join(home, ".codex", "skills", "recap")
+	if err := os.MkdirAll(filepath.Dir(codexPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(canonical, codexPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	st := &state.State{
+		SchemaVersion: 4,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Revision:      1,
+				InstalledHash: "hash",
+				Tools:         []string{"ghost", "codex"},
+				ToolsMode:     state.ToolsModePinned,
+				ManagedPaths:  []string{codexPath, "ghost:user:recap"},
+				Paths:         []string{codexPath, "ghost:user:recap"},
+				Conflicts: []state.ProjectionConflict{
+					{Tool: "ghost", Path: "ghost:user:recap"},
+					{Tool: "codex", Path: codexPath},
+				},
+			},
+		},
+	}
+	cfg := &config.Config{
+		Tools: []config.ToolConfig{
+			{Name: "codex", Enabled: true},
+			{
+				Name:      "ghost",
+				Enabled:   true,
+				Install:   "echo install",
+				Uninstall: "echo uninstall",
+			},
+		},
+	}
+
+	report, err := InspectManagedSkills(cfg, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+
+	var drift *Issue
+	for i := range report.Issues {
+		if report.Issues[i].Kind == IssueProjectionDrift {
+			drift = &report.Issues[i]
+			break
+		}
+	}
+	if drift == nil {
+		t.Fatalf("expected drift issue from codex conflict, got: %+v", report.Issues)
+	}
+	if strings.Contains(drift.Message, "ghost") {
+		t.Fatalf("opaque ghost conflict leaked into details: %q", drift.Message)
+	}
+	if !strings.Contains(drift.Message, "codex") {
+		t.Fatalf("expected codex conflict detail, got: %q", drift.Message)
+	}
+}
+
 func TestInspectContinuesWithInvalidUnrelatedToolConfig(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary

`scribe doctor` was reporting a false `projection_drift` ERROR for every skill against the gemini tool:

```
resolve projection path for "gemini": gemini: skill path not available (managed by gemini CLI)
```

Output became unusable — every skill triggered a fake error. Closes Solo todo #488.

## Root cause

`internal/doctor/doctor.go` called `tool.SkillPath(skillName)` **before** the opacity check `tool.CanonicalTarget(canonicalDir)`. Gemini's `SkillPath` intentionally errors because the gemini CLI owns its skill dir (opaque tool) — `CanonicalTarget` correctly returns `ok=false` to signal opacity, but the SkillPath error short-circuited drift detection into a bogus issue before opacity could bail out.

## Fix

Reorder so opacity is checked first. When a tool is opaque:

- Track its name in `opaqueTools` so conflicts with that tool are suppressed.
- Still try `SkillPath` opportunistically (for `CommandTool` which has a path template) and record the path in `opaquePaths` if it succeeds; SkillPath errors are tolerated.
- For pseudo-URI managed paths like `gemini:user:recap`, the actuals loop now checks `pathOwnedByOpaqueTool` (prefix-match against opaque tool names) so they aren't flagged as unexpected projections.

```go
// before — buggy
path, err := tool.SkillPath(skillName)              // gemini errors here
if err != nil { return Issue{...projection_drift...}, true }
target, inspectable := tool.CanonicalTarget(canonicalDir)
if !inspectable { opaquePaths[path] = true; continue }

// after — opacity first
target, inspectable := tool.CanonicalTarget(canonicalDir)
if !inspectable {
    opaqueTools[toolName] = true
    if path, err := tool.SkillPath(skillName); err == nil {
        opaquePaths[path] = true
    }
    continue
}
path, err := tool.SkillPath(skillName)
if err != nil { return Issue{...projection_drift...}, true }
expectedPaths[path] = expectedProjection{Tool: toolName, Target: target}
```

## Test plan

- [x] `TestInspectSkipsOpaqueToolWhenSkillPathErrors` — gemini-style failure mode (opaque + SkillPath errors) produces no `projection_drift` issue
- [x] `TestInspectStillReportsDriftForInspectableTool` — regression guard: a real drift on an inspectable builtin (claude) still surfaces as `projection_drift`
- [x] `TestInspectSkipsConflictsFromOpaqueTools` — conflict against an opaque tool is suppressed; conflict against an inspectable tool in the same skill still surfaces
- [x] Existing `TestInspectSkipsOpaqueToolProjections` (CommandTool with path template) still passes — opaque-path tracking preserved
- [x] `go build ./...`, `go vet ./...`, `go test ./internal/doctor/ -count=1`

Note: one unrelated pre-existing failure in `cmd` (`TestListEnvelopeDataMatchesLegacyGolden`, golden hash mismatch on the embedded `scribe-agent` skill) reproduces on `origin/main` and is not introduced by this PR.

Out of scope: the `canonical_metadata: SKILL.md needs canonical normalization` warnings the user log mentioned on ~10 skills — separate todo if confirmed.