### PR TITLE
fix(list): cursor viewport + hide bootstrap skill (todos #486 #487)

### DIFF
--- a/cmd/list_tui_keys.go
+++ b/cmd/list_tui_keys.go
@@ -880,6 +880,18 @@ func buildGroupCounts(rows []listRow) map[string]int {
 }
 
 func (m listModel) ensureCursorVisible() listModel {
+	n := len(m.filtered)
+	if n == 0 {
+		m.offset = 0
+		return m
+	}
+	if m.cursor < 0 {
+		m.cursor = 0
+	}
+	if m.cursor >= n {
+		m.cursor = n - 1
+	}
+
 	visible := m.contentHeight()
 	if visible < 3 {
 		visible = 3
@@ -890,6 +902,9 @@ func (m listModel) ensureCursorVisible() listModel {
 	}
 	for m.offset < m.cursor && !m.cursorFitsAt(m.offset, visible) {
 		m.offset++
+	}
+	if m.offset < 0 {
+		m.offset = 0
 	}
 	return m
 }
@@ -909,8 +924,10 @@ func (m listModel) cursorFitsAt(offset, capacity int) bool {
 	}
 	for i := offset; i < len(m.filtered); i++ {
 		row := m.filtered[i]
+		// Match renderRows: empty group names yield no header line, so the
+		// simulation must not charge one when transitioning to/from "".
 		headerLines := 0
-		if row.Group != prevGroup {
+		if row.Group != prevGroup && row.Group != "" {
 			headerLines = 1
 		}
 		needed := headerLines + 1
@@ -918,7 +935,7 @@ func (m listModel) cursorFitsAt(offset, capacity int) bool {
 			needed++
 		}
 		if linesUsed+needed > capacity {
-			return i > m.cursor
+			return false
 		}
 		linesUsed += headerLines + 1
 		prevGroup = row.Group

--- a/cmd/list_tui_test.go
+++ b/cmd/list_tui_test.go
@@ -530,6 +530,141 @@ func TestEnsureCursorVisible_ReservesSlotsForMoreAboveAndBelowIndicators(t *test
 	}
 }
 
+func TestEnsureCursorVisible_CursorArrowAlwaysRendered(t *testing.T) {
+	// Regression for #486: pressing ↓ past the visible region must scroll the
+	// viewport so the focused-row arrow is actually drawn. Renders the rows
+	// and asserts the cursor marker is present in the output for every cursor
+	// position from 0..N-1.
+	cases := []struct {
+		name        string
+		rows        []listRow
+		groupCounts map[string]int
+		height      int
+	}{
+		{
+			name: "single group",
+			rows: func() []listRow {
+				rs := make([]listRow, 50)
+				for i := range rs {
+					rs[i] = listRow{Name: "s", Group: "g"}
+				}
+				return rs
+			}(),
+			groupCounts: map[string]int{"g": 50},
+			height:      27,
+		},
+		{
+			name: "multi group",
+			rows: func() []listRow {
+				rs := make([]listRow, 0, 60)
+				for g := 0; g < 3; g++ {
+					group := string(rune('A' + g))
+					for i := 0; i < 20; i++ {
+						rs = append(rs, listRow{Name: "s", Group: group})
+					}
+				}
+				return rs
+			}(),
+			groupCounts: map[string]int{"A": 20, "B": 20, "C": 20},
+			height:      27,
+		},
+		{
+			name: "mixed empty and non-empty groups",
+			rows: func() []listRow {
+				// 25 unmanaged (Group="") + 25 grouped — exposes the
+				// header-budget divergence between cursorFitsAt and
+				// renderRows for empty group transitions.
+				rs := make([]listRow, 0, 50)
+				for i := 0; i < 25; i++ {
+					rs = append(rs, listRow{Name: "s", Group: "owner/repo"})
+				}
+				for i := 0; i < 25; i++ {
+					rs = append(rs, listRow{Name: "s"})
+				}
+				return rs
+			}(),
+			groupCounts: map[string]int{"owner/repo": 25},
+			height:      27,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			m := listModel{
+				width:       80,
+				height:      tc.height,
+				rows:        tc.rows,
+				filtered:    tc.rows,
+				groupCounts: tc.groupCounts,
+			}
+			for cursor := 0; cursor < len(tc.rows); cursor++ {
+				m.cursor = cursor
+				m = m.ensureCursorVisible()
+
+				var sb strings.Builder
+				m.renderRows(&sb, m.contentHeight(), m.width-4, false)
+				out := sb.String()
+				if !strings.Contains(out, "▸") {
+					t.Fatalf("cursor=%d offset=%d: cursor arrow not rendered\n%s", cursor, m.offset, out)
+				}
+			}
+		})
+	}
+}
+
+func TestEnsureCursorVisible_LastRowSkipsBottomIndicator(t *testing.T) {
+	// Regression for #486: when cursor is on the last row there is no
+	// "↓ N more below" indicator, so cursorFitsAt must not reserve a slot
+	// for it. Otherwise scrolling to the very end leaves cursor off-screen.
+	rows := make([]listRow, 50)
+	for i := range rows {
+		rows[i] = listRow{Name: "s", Group: "g"}
+	}
+	m := listModel{
+		width:       80,
+		height:      27,
+		rows:        rows,
+		filtered:    rows,
+		cursor:      49,
+		groupCounts: map[string]int{"g": 50},
+	}
+	m = m.ensureCursorVisible()
+
+	var sb strings.Builder
+	m.renderRows(&sb, m.contentHeight(), m.width-4, false)
+	out := sb.String()
+	if !strings.Contains(out, "▸") {
+		t.Fatalf("cursor arrow missing at last row\n%s", out)
+	}
+	if strings.Contains(out, "↓ ") {
+		t.Fatalf("bottom indicator should not appear when cursor is on last row\n%s", out)
+	}
+}
+
+func TestEnsureCursorVisible_FirstRowResetsOffset(t *testing.T) {
+	// Regression for #486: pressing Home (or scrolling to top) must reset
+	// the offset back to 0, not leave it stale where the cursor is no
+	// longer in view.
+	rows := make([]listRow, 50)
+	for i := range rows {
+		rows[i] = listRow{Name: "s", Group: "g"}
+	}
+	m := listModel{
+		width:       80,
+		height:      27,
+		rows:        rows,
+		filtered:    rows,
+		cursor:      0,
+		offset:      20,
+		groupCounts: map[string]int{"g": 50},
+	}
+	m = m.ensureCursorVisible()
+	if m.offset != 0 {
+		t.Fatalf("offset should reset to 0 when cursor is at top, got %d", m.offset)
+	}
+}
+
 func TestViewListFull_PadsContentToPinSummaryToBottom(t *testing.T) {
 	// Regression: the summary + help footer must sit at the bottom of the
 	// terminal, not float mid-screen when the filtered list is shorter than

--- a/internal/workflow/list_load.go
+++ b/internal/workflow/list_load.go
@@ -134,6 +134,12 @@ func BuildLocalRows(skills []discovery.Skill, st *state.State) []ListRow {
 	var unmanagedRows []ListRow
 	for i := range skills {
 		sk := &skills[i]
+		// Bootstrap skills (e.g. scribe-agent) are auto-managed by the CLI:
+		// installed/refreshed on every run, not user-installable, not
+		// removable. Hide them from list output to keep the surface clean.
+		if installed, ok := st.Installed[sk.Name]; ok && installed.Origin == state.OriginBootstrap {
+			continue
+		}
 		g := RegistryGroupFromName(sk.Name)
 		row := ListRow{
 			Name:    sk.Name,

--- a/internal/workflow/list_test.go
+++ b/internal/workflow/list_test.go
@@ -393,3 +393,64 @@ func TestPrintLocalJSON(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildLocalRows_HidesBootstrapOrigin(t *testing.T) {
+	// Regression for #487: scribe-agent (Origin=Bootstrap) is auto-managed
+	// by the CLI and shouldn't appear in `scribe list`. It can't be removed
+	// — the next invocation re-installs it — so listing it just clutters.
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"my-skill":     {Origin: state.OriginRegistry},
+		"scribe-agent": {Origin: state.OriginBootstrap},
+	}}
+	skills := []discovery.Skill{
+		{Name: "my-skill", Managed: true},
+		{Name: "scribe-agent", Managed: true},
+	}
+
+	rows := BuildLocalRows(skills, st)
+	if len(rows) != 1 {
+		t.Fatalf("BuildLocalRows returned %d rows, want 1: %+v", len(rows), rows)
+	}
+	if rows[0].Name != "my-skill" {
+		t.Fatalf("row name = %q, want my-skill", rows[0].Name)
+	}
+}
+
+func TestBuildLocalRows_OnlyBootstrapReturnsEmpty(t *testing.T) {
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"scribe-agent": {Origin: state.OriginBootstrap},
+	}}
+	skills := []discovery.Skill{
+		{Name: "scribe-agent", Managed: true},
+	}
+
+	rows := BuildLocalRows(skills, st)
+	if len(rows) != 0 {
+		t.Fatalf("rows = %+v, want empty", rows)
+	}
+}
+
+func TestBuildLocalRowsExcluding_FiltersBootstrapAfterMatching(t *testing.T) {
+	// BuildLocalRowsExcluding delegates to BuildLocalRows after dropping
+	// matched entries. Verify the bootstrap filter survives the exclusion
+	// path (regression for #487 second-order coverage).
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"matched":      {Origin: state.OriginRegistry},
+		"my-skill":     {Origin: state.OriginRegistry},
+		"scribe-agent": {Origin: state.OriginBootstrap},
+	}}
+	skills := []discovery.Skill{
+		{Name: "matched", Managed: true},
+		{Name: "my-skill", Managed: true},
+		{Name: "scribe-agent", Managed: true},
+	}
+	matched := map[string]bool{"matched": true}
+
+	rows := BuildLocalRowsExcluding(skills, matched, st)
+	if len(rows) != 1 {
+		t.Fatalf("rows = %+v, want only my-skill", rows)
+	}
+	if rows[0].Name != "my-skill" {
+		t.Fatalf("row[0].Name = %q, want my-skill", rows[0].Name)
+	}
+}


### PR DESCRIPTION
## Summary

Two list UX bugs surfaced together — both touch list rendering, so they ship in one PR.

### #486 — cursor scrolls past visible viewport

`cursorFitsAt` was budgeting a header line whenever `row.Group != prevGroup`, but `renderRows` only draws a header when `formatGroupHeader` returns a non-empty string (i.e. `Group != ""`). When the filtered list mixed registry-grouped rows with unmanaged (`Group=""`) rows, the simulation over-reserved capacity at the empty-group transition and either left offset stuck or pushed it past where the cursor actually rendered.

Fix:
- `cursorFitsAt` now matches `renderRows` exactly: `headerLines = 1` only when `row.Group != prevGroup && row.Group != ""`.
- The misleading `return i > m.cursor` overflow branch is replaced with `return false`. The old form claimed the cursor fit when iteration walked past it, but that path is unreachable — `if i == m.cursor return true` handles cursor placement first.
- `ensureCursorVisible` clamps cursor to `[0, len(filtered)-1]` and short-circuits on empty filtered, eliminating nonsensical offsets.

### #487 — bootstrap scribe-agent in `scribe list`

`scribe-agent` is the bootstrap skill auto-installed/refreshed on every `scribe` invocation via `agent.EnsureScribeAgent`. It's tagged in state with `Origin=Bootstrap` but `BuildLocalRows` enumerated everything on disk, so it appeared in the list. It can't be removed (re-installed on next run) and isn't user-installable.

Fix: `BuildLocalRows` skips rows where `state.Installed[name].Origin == OriginBootstrap`. `BuildLocalRowsExcluding` inherits the filter via its delegation. No flag — bootstrap is invisible by design.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/ -run List -count=1`
- [x] `go test ./internal/workflow/ -count=1`
- [x] `go test ./... -count=1 -timeout 90s`
- [x] `go vet ./...`
- [x] Cursor-arrow-rendered regression covers single-group, multi-group, and mixed empty/non-empty group scenarios at every cursor position
- [x] Last-row test asserts no spurious `↓ N more below` indicator
- [x] First-row test asserts stale offset resets to 0
- [x] Bootstrap-filter tests cover both `BuildLocalRows` and `BuildLocalRowsExcluding`

Closes #486
Closes #487