### PR TITLE
docs: split README into front-page + docs/ reference (todo #491)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,38 +7,21 @@
 |___/\___|_|_\___|___/___|
 ```
 
-Your team's AI coding skills, always in sync. One manifest, one command.
+> Agent-first skill manager for Claude Code, Codex, and Cursor. Your team's AI coding skills, always in sync — one manifest, one command.
 
-AI coding agents like Claude Code, Cursor, and Codex work better when you teach them how your team works — code review style, deployment checklists, Laravel patterns. These "skills" are markdown instruction files that live in `~/.claude/skills/` and similar dirs.
+<!-- TODO: hero terminal screenshot or asciinema GIF of `scribe list` TUI -->
 
-The problem: once you've built them, sharing means Slack links and manual copying. New teammates have no idea what exists. Skills get stale without anyone noticing.
+## What it does
 
-Scribe fixes this. Put your team's skills in a GitHub repo with a `scribe.yaml` manifest. Teammates run `scribe registry connect`. Then `scribe sync` keeps every machine current — canonical store, tool-facing installs, and adoption of any hand-rolled skills already on the machine. One manifest works across Claude Code, Codex, and Cursor.
+AI coding agents work better when you teach them how your team works — code review style, deployment checklists, framework patterns. These [SKILL.md](https://agentskills.io) files live in `~/.claude/skills/`, `~/.codex/skills/`, and similar directories. Sharing them used to mean Slack links and manual copying. Skills got stale; new teammates had no idea what existed.
 
-## Install with your agent
+Scribe makes the skill set declarative.
 
-Paste this into any agent with shell access (Claude Code, Cursor, Codex, etc.) to install Scribe on the machine without touching a terminal yourself:
+- **One source of truth.** Put your team's skills in a GitHub repo with a `scribe.yaml` manifest. Teammates run `scribe registry connect` once.
+- **Cross-tool projection.** One canonical store under `~/.scribe/skills/` projects to Claude Code, Codex, and Cursor at the right paths.
+- **Agent-first, scriptable.** Every migrated command emits a versioned JSON envelope (`{status, format_version, data, meta}`) with exit codes, partial-success semantics, and JSON Schema introspection.
 
-```
-I want to use Scribe to manage my AI coding-agent skills on this machine.
-Repo: https://github.com/Naoray/scribe  (setup steps: /blob/main/SKILL.md)
-
-Please set it up for me:
-  1. If `scribe --version` fails, install it. Prefer methods that land the binary on PATH:
-       a. Homebrew: `brew install Naoray/tap/scribe`
-       b. Release binary to /usr/local/bin, e.g. Apple Silicon:
-          `curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_darwin_arm64.tar.gz | tar xz && sudo mv scribe /usr/local/bin/`
-          (swap the asset for your OS/arch — see https://github.com/Naoray/scribe/releases/latest)
-       c. Last resort: `go install github.com/Naoray/scribe/cmd/scribe@latest`
-          (lands in ~/go/bin which is often NOT on PATH — only use if a and b aren't available,
-          and add the go bin dir to PATH afterwards)
-  2. Register Scribe's own agent-facing skill locally so future sessions pick it up from
-     `~/.scribe/skills/scribe-agent/`:
-        scribe add Naoray/scribe:scribe-agent --yes --json
-  3. Show me `scribe list --json` to confirm.
-```
-
-## Install manually
+## Install
 
 **Homebrew (recommended):**
 
@@ -49,15 +32,15 @@ brew install Naoray/tap/scribe
 **Binary (macOS / Linux):**
 
 ```bash
-# macOS (Apple Silicon)
+# macOS Apple Silicon
 curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_darwin_arm64.tar.gz | tar xz
 sudo mv scribe /usr/local/bin/
 
-# macOS (Intel)
+# macOS Intel
 curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_darwin_amd64.tar.gz | tar xz
 sudo mv scribe /usr/local/bin/
 
-# Linux (amd64)
+# Linux amd64
 curl -L https://github.com/Naoray/scribe/releases/latest/download/scribe_linux_amd64.tar.gz | tar xz
 sudo mv scribe /usr/local/bin/
 ```
@@ -68,307 +51,93 @@ sudo mv scribe /usr/local/bin/
 go install github.com/Naoray/scribe/cmd/scribe@latest
 ```
 
-Verify: `scribe --version`
+Verify: `scribe --version`. Update via `brew upgrade scribe`, the same `go install` line, or replacing the binary from the releases page.
 
-**Updating:**
+### Install via your agent
 
-```bash
-brew upgrade scribe                          # Homebrew
-go install github.com/Naoray/scribe/cmd/scribe@latest   # Go
-# Binary: replace from the releases page
+Paste this into Claude Code, Cursor, or Codex with shell access — it installs scribe and registers the agent skill so future sessions pick it up automatically:
+
+```
+I want to use Scribe to manage my AI coding-agent skills on this machine.
+Repo: https://github.com/Naoray/scribe (setup steps: /blob/main/SKILL.md)
+
+Please set it up for me:
+  1. If `scribe --version` fails, install it (prefer brew, fall back to release binary, last resort `go install`).
+  2. Register Scribe's own agent-facing skill: `scribe add Naoray/scribe:scribe-agent --yes --json`
+  3. Show me `scribe list --json` to confirm.
 ```
 
-## Quickstart
-
-### Joining a team that already uses Scribe
+## 60-second start
 
 ```bash
 scribe registry connect ArtistfyHQ/team-skills   # connect once
-scribe sync                                        # install everything
-scribe list                                        # verify
+scribe sync                                       # install everything
+scribe list                                       # verify
 ```
 
-Run `scribe sync` again anytime to pick up new skills.
+Run `scribe sync` again anytime to pick up new skills. Setting up a registry from scratch? `scribe registry create` scaffolds the repo, `scribe.yaml`, and connection in one prompt.
 
-### Setting up a shared registry
+## What you get
 
-**Let Scribe scaffold it:**
-
-```bash
-scribe registry create
-# Prompts for team name, GitHub org, repo name, visibility
-# Creates the repo, pushes scribe.yaml + README, and connects automatically
-```
-
-**Manual setup:**
-
-1. Create a GitHub repo (can be private)
-2. Add `scribe.yaml` at the root:
-
-```yaml
-apiVersion: scribe/v1
-kind: Registry
-team:
-  name: artistfy
-  description: Artistfy dev team skill stack
-catalog:
-  - name: gstack
-    source: "github:garrytan/gstack@v0.12.9.0"
-    author: garrytan
-  - name: deploy
-    source: "github:ArtistfyHQ/team-skills@main"
-    path: krishan/deploy
-    author: krishan
-```
-
-3. Add skill files at the matching paths:
-
-```
-ArtistfyHQ/team-skills/
-  scribe.yaml
-  krishan/
-    deploy/
-      SKILL.md
-```
-
-4. Share the repo name — teammates run `scribe registry connect ArtistfyHQ/team-skills`
-
-## Commands
-
-### Daily use
-
-| Command | What it does |
-|---|---|
-| `scribe` | Open the local skill manager |
-| `scribe list` | Show all skills on this machine (managed + unmanaged) |
-| `scribe browse` | Discover and install skills from connected registries |
-| `scribe add [query]` | Find and install skills from registries (legacy; prefer `browse`) |
-| `scribe install --all` | Install every catalog entry from a registry in one shot |
-| `scribe adopt [name]` | Import hand-rolled skills from `~/.claude/skills` etc. into the store |
-| `scribe remove <skill>` | Remove a skill from this machine (records a deny-list entry) |
-| `scribe sync` | Reconcile local skill state, tool installs, and connected registries |
-| `scribe doctor` | Inspect managed skills and projections for repairable issues |
-| `scribe doctor --fix` | Normalize canonical skill metadata and repair affected projections |
-| `scribe doctor --skill recap --fix` | Repair a single managed skill and its projections |
-| `scribe skill repair <skill> --tool <tool>` | Resolve drift when a tool-local copy diverges from the store |
-| `scribe status` | Show connected registries, installed count, and last sync |
-| `scribe tools` | List detected AI tools, enable/disable |
-| `scribe explain <skill>` | AI-powered skill explanation (or `--raw` for rendered SKILL.md) |
-| `scribe upgrade-agent` | Refresh the embedded scribe-agent bootstrap skill |
-
-### Registry management
-
-| Command | What it does |
-|---|---|
-| `scribe registry connect <repo>` | Connect to a skill registry |
-| `scribe registry create` | Scaffold a new registry repo on GitHub |
-| `scribe registry add [name]` | Share a local skill to a registry |
-| `scribe registry list` | Show connected registries with skill counts |
-| `scribe registry enable/disable` | Enable or disable a connected registry |
-| `scribe registry migrate` | Convert a `scribe.toml` registry to `scribe.yaml` |
-
-### Other
-
-| Command | What it does |
-|---|---|
-| `scribe guide` | Interactive setup guide |
-| `scribe schema <command> --json` | Print the JSON Schema for a command's `--json` envelope |
-| `scribe --version` | Show version |
-
-### What `scribe list` looks like
-
-```
-Team: artistfy (ArtistfyHQ/team-skills) · Last sync: 2 hours ago
-
-SKILL              VERSION         STATUS       TARGETS
-gstack             v0.12.9.0       ✓ current    claude
-laravel-init       v1.0.0          ⬆ outdated   claude, cursor
-deploy             main@a3f2c1b    ✓ current    claude
-frontend-prs       main@c9f1d2e    ● missing    claude
-my-old-skill       —               ◇ extra      claude
-
-3 current · 1 outdated · 1 missing · 1 extra
-```
-
-- `✓ current` — matches team version
-- `⬆ outdated` — installed, team has a newer version
-- `● missing` — in team registry, not installed locally
-- `◇ extra` — installed locally, not in team registry (informational, never auto-removed)
-
-### What `scribe sync` looks like
-
-```
-syncing ArtistfyHQ/team-skills...
-
-  gstack               ok (v0.12.9.0)
-  laravel-init         updated to v1.1.0
-  deploy               ok (main@a3f2c1b)
-  frontend-prs         installed main@c9f1d2e
-repaired 1 tool installs
-
-done: 1 installed, 1 updated, 2 current, 0 failed
-```
-
-When sync finds divergent content in a managed tool path, it preserves the content and prints a repair hint rather than overwriting:
-
-```
-conflict: recap in codex differs from managed copy
-run `scribe skill repair recap --tool codex` to resolve
-```
-
-### `scribe doctor` v1 scope
-
-```bash
-scribe doctor
-scribe doctor --fix
-scribe doctor --skill recap --fix
-```
-
-`scribe doctor` audits managed skills for canonical `SKILL.md` metadata issues and projection drift.
-`scribe doctor --fix` applies safe metadata normalization and then repairs affected tool projections.
-
-`scribe doctor` v1 does not attempt to rewrite mixed package layouts for Codex.
-It focuses on canonical metadata health plus projection repair.
-
-## Adoption — claim skills you already have
-
-If you've been hand-rolling skills in `~/.claude/skills/` or `~/.codex/skills/`, Scribe adopts them into the canonical store on first sync. The original path becomes a symlink — nothing moves, everything still works, and now Scribe manages it.
-
-```bash
-scribe adopt                 # interactive: review conflicts, adopt clean candidates
-scribe adopt --yes           # auto-adopt all clean candidates
-scribe adopt --dry-run       # preview the plan, no writes
-scribe adopt <name>          # adopt a single named skill
-```
-
-Adopted skills appear with `(local)` in `scribe list`. They have no upstream and stay until you `scribe remove` them.
-
-### Adoption mode
-
-`scribe sync` runs adoption as a prelude. Configure it via `~/.scribe/config.yaml`:
-
-```yaml
-adoption:
-  mode: auto       # auto | prompt | off
-  paths:           # optional extra dirs beyond the defaults
-    - ~/src/my-skills
-```
-
-- `auto` (default) — silently adopt clean candidates on every sync
-- `prompt` — defer to `scribe adopt`; interactive prompts only when you run the dedicated command
-- `off` — never adopt automatically; unmanaged skills still appear in `scribe list`
-
-Or manage without touching YAML:
-
-```bash
-scribe config adoption                          # show current settings
-scribe config adoption --mode off
-scribe config adoption --add-path ~/src/my-skills
-scribe config adoption --remove-path ~/src/my-skills
-```
-
-## Private skills
-
-Private GitHub repos work automatically if you're authenticated with the `gh` CLI:
-
-```bash
-gh auth login   # if not already done
-```
-
-Auth fallback chain: `gh auth token` → `GITHUB_TOKEN` env → `~/.scribe/config.yaml` → unauthenticated (public repos only).
-
-## CI and agent use
-
-Scribe auto-detects non-TTY environments. Use `--json` for structured output in CI pipelines or agent scripts. Migrated commands now wrap their payload in a versioned envelope:
+`scribe list` opens an interactive TUI on a terminal. Piped or in CI, it emits the JSON envelope:
 
 ```json
 {
   "status": "ok",
   "format_version": "1",
-  "data": { /* command payload */ },
-  "meta": {
-    "duration_ms": 12,
-    "bootstrap_ms": 3,
-    "command": "scribe sync",
-    "scribe_version": "..."
+  "data": {
+    "packages": [
+      { "name": "superpowers", "revision": 1, "sources": ["obra/superpowers"] }
+    ],
+    "skills": [
+      {
+        "name": "add-init",
+        "description": "Create a new /init-* command.",
+        "revision": 1,
+        "content_hash": "e42bc8ef",
+        "targets": ["claude", "codex", "cursor", "gemini"],
+        "managed": true
+      }
+    ]
+  },
+  "meta": { "duration_ms": 478, "command": "scribe list", "scribe_version": "dev" }
+}
+```
+
+`scribe sync` reports a structured envelope per run, with `partial_success` + exit code `10` when any item failed:
+
+```json
+{
+  "status": "partial_success",
+  "format_version": "1",
+  "data": {
+    "reconcile": { "installed": 2, "relinked": 0, "removed": 2, "conflicts_count": 0 },
+    "summary":   { "failed": 1, "installed": 0, "skipped": 73, "updated": 0 }
   }
 }
 ```
 
-Migration: previously top-level keys are now under `data`. Update parsers from `jq '.foo'` to `jq '.data.foo'`. When `data.summary.failed > 0`, `status` becomes `"partial_success"` and the process exits with code `10`.
+## Why scribe?
 
-Use `scribe schema <command> --json` to fetch the JSON Schema (2020-12) for a migrated command's input flags and output envelope before composing calls. Use `--fields name,version` on read-only tabular commands to project specific columns.
+- **Agents-first**: versioned JSON envelope, JSON Schema for every migrated command, distinct exit codes, machine-readable error remediation. Drops cleanly into Claude Code / Codex / Cursor agent loops.
+- **Project-local projection**: scopes skill availability to the project you're in, instead of dumping every installed skill into every session. Keeps Codex inside its 5440-byte description budget by construction.
+- **Adoption, not migration**: claims hand-rolled skills already in `~/.claude/skills/` etc. via symlink — nothing moves, nothing breaks, scribe just starts managing them.
+- **One manifest, every tool**: `scribe.yaml` works across Claude Code, Codex, and Cursor. No per-tool maintenance.
 
-```bash
-scribe list --json
-scribe list --json --fields name,status
-scribe status --json
-scribe sync --json | jq '.data.summary'
-scribe schema sync --json
-scribe add --json owner/repo:skill --yes
-```
+## Documentation
 
-### Exit codes
+- [Commands reference](docs/commands.md) — every subcommand grouped by use
+- [JSON envelope + agent contract](docs/json-envelope.md) — envelope shape, exit codes, `--fields`, schema introspection
+- [Projects, kits, and snippets](docs/projects-and-kits.md) — `.scribe.yaml`, kits, snippet rules
+- [Adoption](docs/adoption.md) — claim hand-rolled skills already on the machine
+- [Troubleshooting](docs/troubleshooting.md) — `scribe doctor`, repair flows, common issues
 
-| Code | Meaning |
-|---:|---|
-| 0 | success |
-| 1 | general operational failure |
-| 2 | usage or invalid flags |
-| 3 | not found (command, registry, skill, schema) |
-| 4 | permission or authentication failure |
-| 5 | conflict requiring user action |
-| 6 | network or remote service failure |
-| 7 | temporarily unavailable local dependency |
-| 8 | validation failure |
-| 9 | user canceled |
-| 10 | partial success — inspect `data.summary.failed` |
-
-## Project config
-
-A `.scribe.yaml` at a project root declares which kits, snippets, or extra skills that project wants. The parser and schema have shipped; CLI surfaces that act on them ride on top as they land.
-
-```yaml
-# .scribe.yaml — all keys optional, omit what you don't need
-kits:
-  - laravel-baseline
-snippets:
-  - commit-discipline
-add:
-  - owner/repo:extra-skill
-remove:
-  - skill-this-project-doesnt-want
-```
-
-Empty or missing files are treated as no project-level intent.
-
-## Health checks
-
-`scribe doctor` inspects managed skill health and reports drift between the canonical store and tool-facing projections:
-
-```bash
-scribe doctor               # check all managed skills
-scribe doctor --skill recap  # check a single skill
-scribe doctor --json         # machine-readable output
-```
-
-## Skill format
-
-Scribe follows the [agentskills.io](https://agentskills.io) SKILL.md specification. Any skill that works with `skills.sh` or Paks works with Scribe. A skill is a directory with a `SKILL.md` at the root — frontmatter declares the name, description, and compatible tools.
-
-## Data stored locally
-
-```
-~/.scribe/
-  config.yaml    # connected registries, tool settings
-  state.json     # what's installed, last sync time
-  skills/        # canonical skill store (symlinked by tools)
-```
+Skill format follows [agentskills.io](https://agentskills.io). Anything that works with `skills.sh` or Paks works with scribe.
 
 ## Requirements
 
 - macOS or Linux
-- GitHub account with access to your team skills repo
+- GitHub account with access to your team's skills repo
 - `gh` CLI recommended for auth (not required for public repos)
 
 ## Contributing
@@ -378,7 +147,11 @@ See the [open issues](https://github.com/Naoray/scribe/issues) — each one has 
 ```bash
 git clone https://github.com/Naoray/scribe
 cd scribe
-go build ./...
+go build ./cmd/scribe
 go run ./cmd/scribe --help
 go test ./...
 ```
+
+## License
+
+MIT

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -1,0 +1,70 @@
+# Adoption — claim skills you already have
+
+If you've been hand-rolling skills in `~/.claude/skills/`, `~/.codex/skills/`, or `~/.cursor/rules/`, scribe can adopt them into the canonical store without moving anything. The original path becomes a symlink to `~/.scribe/skills/<name>` — nothing breaks for the tool, and now scribe manages the file.
+
+## Quick start
+
+```bash
+scribe adopt                 # interactive: review conflicts, adopt clean candidates
+scribe adopt --yes           # auto-adopt all clean candidates
+scribe adopt --dry-run       # preview the plan, no writes
+scribe adopt <name>          # adopt a single named skill
+scribe adopt --json          # machine-readable plan + result
+```
+
+Adopted skills appear with `(local)` in `scribe list`. They have no upstream and stay until you `scribe remove` them.
+
+## Conflict handling
+
+`scribe adopt` distinguishes three cases per candidate:
+
+- **clean** — the file on disk does not collide with anything in the store. Adoption is safe to run unattended.
+- **collision** — a managed skill of the same name already exists, with different content. Adoption refuses and shows a diff hint.
+- **identical** — already in the store, same content hash. Skipped silently.
+
+Pass `--verbose` (or inspect `data.conflicts` in `--json` mode) to see why anything was deferred.
+
+## Adoption mode in `scribe sync`
+
+`scribe sync` runs adoption as a prelude. Configure how aggressively it adopts via `~/.scribe/config.yaml`:
+
+```yaml
+adoption:
+  mode: auto       # auto | prompt | off
+  paths:           # optional extra dirs beyond the defaults
+    - ~/src/my-skills
+```
+
+- `auto` (default) — silently adopt clean candidates on every sync
+- `prompt` — defer to the dedicated `scribe adopt` command; sync only adopts if you run it explicitly
+- `off` — never adopt automatically; unmanaged skills still appear in `scribe list` so you can see what's there
+
+Or manage without touching YAML:
+
+```bash
+scribe config adoption                          # show current settings
+scribe config adoption --mode off
+scribe config adoption --add-path ~/src/my-skills
+scribe config adoption --remove-path ~/src/my-skills
+```
+
+## What adoption does on disk
+
+For a clean candidate at `~/.claude/skills/my-skill/`:
+
+1. Copy directory contents into `~/.scribe/skills/my-skill/`
+2. Compute content hash, write into the canonical store's metadata
+3. Replace the original directory with a symlink to the canonical path
+4. Record an `origin: local` entry in scribe's state so it shows as `(local)` in `list`
+
+The replacement is a single `os.Remove` + `os.Symlink`, performed only after the canonical copy is in place. Sync's reconcile layer is non-destructive on purpose; the destructive `RemoveAll` lives in adopt where it has explicit user intent.
+
+## Deny-list
+
+When you `scribe remove <skill>`, scribe records a deny-list entry in `~/.scribe/config.yaml`. The skill won't come back on the next sync even if it's still in a connected registry. To un-deny, edit the config or `scribe add` it again explicitly.
+
+## Surface area
+
+- `scribe adopt` — see [`commands.md`](commands.md)
+- `scribe schema adopt --json` — input flags and output envelope
+- `data.summary` in `--json` mode reports `adopted`, `skipped`, `conflicted` counts

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,88 @@
+# Commands reference
+
+Every scribe subcommand, grouped by what you reach for it for.
+
+For machine-readable details (input flags, output schema, exit codes), pair this page with [`docs/json-envelope.md`](json-envelope.md) and `scribe schema <command> --json`.
+
+## Daily use
+
+| Command | What it does |
+|---|---|
+| `scribe` | Open the local skill manager (interactive TUI when stdout is a TTY) |
+| `scribe list` | Show all skills on this machine (managed + unmanaged) |
+| `scribe browse` | Discover and install skills from connected registries |
+| `scribe add [query]` | Find and install skills from registries (legacy; prefer `browse`) |
+| `scribe install --all` | Install every catalog entry from a registry in one shot |
+| `scribe adopt [name]` | Import hand-rolled skills from `~/.claude/skills` etc. into the canonical store |
+| `scribe remove <skill>` | Remove a skill from this machine (records a deny-list entry so it does not come back on the next sync) |
+| `scribe sync` | Reconcile local skill state, tool installs, and connected registries |
+| `scribe doctor` | Inspect managed skills and projections for repairable issues |
+| `scribe doctor --fix` | Normalize canonical skill metadata and repair affected projections |
+| `scribe doctor --skill <name> --fix` | Repair a single managed skill and its projections |
+| `scribe skill repair <skill> --tool <tool>` | Resolve drift when a tool-local copy diverges from the canonical store |
+| `scribe status` | Show connected registries, installed count, and last sync |
+| `scribe tools` | List detected AI tools on this machine; enable, disable, or register custom ones |
+| `scribe explain <skill>` | AI-powered skill explanation (or `--raw` for the rendered SKILL.md body) |
+| `scribe upgrade-agent` | Refresh the embedded scribe-agent bootstrap skill |
+
+## Registry management
+
+| Command | What it does |
+|---|---|
+| `scribe registry connect <repo>` | Connect to a skill registry (alias: `scribe connect`) |
+| `scribe registry create` | Scaffold a new registry repo on GitHub interactively |
+| `scribe registry add [name]` | Share a local skill into a connected registry |
+| `scribe registry list` | Show connected registries with skill counts |
+| `scribe registry enable <repo>` / `disable <repo>` | Toggle a connected registry without forgetting it |
+| `scribe registry forget <repo>` | Disconnect a registry (does not remove already-installed skills) |
+| `scribe registry resync <repo>` | Force-fetch a registry's catalog from upstream |
+| `scribe registry migrate` | Convert a `scribe.toml` registry to `scribe.yaml` |
+
+## Skills and tools
+
+| Command | What it does |
+|---|---|
+| `scribe skill edit <name>` | Edit per-skill metadata (`--add`, `--remove`, `--inherit`, `--pin`, `--tools`) |
+| `scribe skill repair <name>` | Re-write a tool-facing projection from the canonical store |
+| `scribe skill tools <name>` | Per-skill tool projection controls (`--enable`, `--disable`, `--reset`) |
+| `scribe tools` | List, enable, or disable detected tools machine-wide |
+| `scribe tools add` | Register a custom tool integration (`--detect`, `--install`, `--path`, `--uninstall`) |
+
+## Conflicts and recovery
+
+| Command | What it does |
+|---|---|
+| `scribe resolve <skill>` | Resolve a sync conflict with `--ours` (keep canonical) or `--theirs` (accept tool-local) |
+| `scribe restore <skill>` | Restore a skill from the canonical store after manual deletion |
+
+## Configuration
+
+| Command | What it does |
+|---|---|
+| `scribe config` | Show current `~/.scribe/config.yaml` |
+| `scribe config set <key> <value>` | Set a config value (e.g. `editor`) |
+| `scribe config adoption` | Show adoption settings (`--mode`, `--add-path`, `--remove-path`) |
+
+## Other
+
+| Command | What it does |
+|---|---|
+| `scribe guide` | Interactive setup guide |
+| `scribe schema <command> --json` | Print the JSON Schema for a command's `--json` envelope (input + output) |
+| `scribe schema --all --json` | List every command that has a published schema |
+| `scribe upgrade --check` | Check whether a newer scribe release is available |
+| `scribe --version` | Show the installed version |
+
+## Discovery tips
+
+- `scribe schema --all --json | jq 'keys'` — list every command whose `--json` output is migrated to the v1 envelope. Anything not in that list still emits its pre-envelope shape.
+- `scribe schema <command> --json | jq '.data.input_schema.properties'` — see the flag schema before composing a call.
+- `scribe list --json --fields name,managed,targets` — project specific columns from a tabular command.
+- `scribe doctor --json` — health report without running any fixes.
+
+## Where to look next
+
+- Agent-friendly envelope, exit codes, partial success: [`json-envelope.md`](json-envelope.md)
+- Project-level config (`.scribe.yaml`), kits, snippets: [`projects-and-kits.md`](projects-and-kits.md)
+- Adopting hand-rolled skills already on the machine: [`adoption.md`](adoption.md)
+- Diagnosing drift with `scribe doctor`: [`troubleshooting.md`](troubleshooting.md)

--- a/docs/json-envelope.md
+++ b/docs/json-envelope.md
@@ -1,0 +1,177 @@
+# JSON envelope and agent-first contract
+
+Scribe targets AI coding agents as a first-class consumer. Every migrated command emits a versioned envelope on stdout (or stderr on error) so an agent can parse the result without scraping human-formatted text.
+
+## Envelope shape
+
+```json
+{
+  "status": "ok",
+  "format_version": "1",
+  "data": { /* command payload */ },
+  "meta": {
+    "duration_ms": 12,
+    "bootstrap_ms": 3,
+    "command": "scribe sync",
+    "scribe_version": "dev"
+  }
+}
+```
+
+Status values:
+
+- `ok` — fully succeeded
+- `partial_success` — some items failed; inspect `data.summary.failed` or item-level errors. Exit code is `10`.
+- `error` — full failure. Body lives under `error.{code,message,retryable,remediation,exit_code}` instead of `data`.
+
+`format_version` lets parsers reject envelopes they don't understand. The current schema is `"1"`. Breaking shape changes will bump it.
+
+`meta.duration_ms` measures leaf `RunE` execution. `meta.bootstrap_ms` covers first-run, store migration, builtins apply, and embedded-agent refresh work that ran before the leaf command.
+
+## Detection
+
+Scribe auto-detects non-TTY environments. When stdout is not a TTY (piped, redirected, captured by a subprocess), commands emit JSON by default. Pass `--json` to force it even in interactive shells. `CI=true` also forces JSON.
+
+```bash
+scribe list                           # JSON when piped, TUI on TTY
+scribe list --json                    # always JSON
+CI=true scribe list                   # always JSON
+```
+
+## Live examples
+
+`scribe list --json` (skill array trimmed for brevity):
+
+```json
+{
+  "status": "ok",
+  "format_version": "1",
+  "data": {
+    "packages": [
+      { "name": "superpowers", "revision": 1, "path": "/Users/me/.scribe/packages/superpowers", "sources": ["obra/superpowers"] }
+    ],
+    "skills": [
+      {
+        "name": "add-init",
+        "description": "Create a new /init-* command.",
+        "revision": 1,
+        "content_hash": "e42bc8ef",
+        "targets": ["claude", "codex", "cursor", "gemini"],
+        "managed": true,
+        "path": "/Users/me/.scribe/skills/add-init"
+      }
+    ]
+  },
+  "meta": {
+    "duration_ms": 478,
+    "bootstrap_ms": 6,
+    "command": "scribe list",
+    "scribe_version": "dev"
+  }
+}
+```
+
+`scribe sync --json` with one failed install:
+
+```json
+{
+  "status": "partial_success",
+  "format_version": "1",
+  "data": {
+    "reconcile": { "installed": 2, "relinked": 0, "removed": 2, "conflicts_count": 0 },
+    "summary":   { "failed": 1, "installed": 0, "skipped": 73, "updated": 0 }
+  },
+  "meta": {
+    "duration_ms": 8999,
+    "bootstrap_ms": 4,
+    "command": "scribe sync",
+    "scribe_version": "dev"
+  }
+}
+```
+
+`scribe status --json`:
+
+```json
+{
+  "status": "ok",
+  "format_version": "1",
+  "data": {
+    "version": "dev",
+    "registries": ["Artistfy/hq", "anthropics/skills", "Naoray/skills"],
+    "installed_count": 129,
+    "last_sync": "2026-04-30T10:10:47Z"
+  },
+  "meta": { "duration_ms": 2, "bootstrap_ms": 3, "command": "scribe status", "scribe_version": "dev" }
+}
+```
+
+## Exit codes
+
+| Code | Meaning |
+|---:|---|
+| 0 | success |
+| 1 | general operational failure |
+| 2 | usage or invalid flags |
+| 3 | not found (command, registry, skill, schema) |
+| 4 | permission or authentication failure |
+| 5 | conflict requiring user action |
+| 6 | network or remote service failure |
+| 7 | temporarily unavailable local dependency |
+| 8 | validation failure |
+| 9 | user canceled |
+| 10 | partial success — inspect `data.summary.failed` or item-level errors |
+
+## Field projection (`--fields`)
+
+Read-only tabular commands accept `--fields name,version,...` to project specific columns. Fields not listed in the schema are silently ignored. Use `scribe schema <command> --json | jq '.data.output_schema'` to enumerate available fields before calling.
+
+```bash
+scribe list --json --fields name,managed,targets
+```
+
+## Schema introspection
+
+Scribe ships JSON Schema (Draft 2020-12) for every migrated command's input flags and output payload.
+
+```bash
+scribe schema list --json
+scribe schema --all --json | jq 'keys'        # list migrated commands
+scribe schema sync --json | jq '.data.output_schema'
+```
+
+Use the schema before composing calls so flag typos and shape drift fail loudly.
+
+## Pre-envelope commands
+
+Some wave-3 commands still reject `--json` with the error `JSON_NOT_SUPPORTED` and exit code `2`. Their pre-envelope shape is unchanged. The remediation field points at the relevant migration todo so you can track when they land.
+
+```json
+{
+  "status": "error",
+  "format_version": "1",
+  "error": {
+    "code": "JSON_NOT_SUPPORTED",
+    "message": "scribe registry list does not support --json yet",
+    "retryable": false,
+    "remediation": "scribe schema --all --json | jq 'keys' lists JSON-capable commands",
+    "exit_code": 2
+  },
+  "meta": {}
+}
+```
+
+## Migration notes
+
+Previously top-level keys are now nested under `data`:
+
+- `jq '.skills'` → `jq '.data.skills'`
+- `jq '.summary'` → `jq '.data.summary'`
+- `jq '.installed_count'` → `jq '.data.installed_count'`
+
+`status` becomes `"partial_success"` when `data.summary.failed > 0`. Pair the status check with the exit code (`10`) for double safety in shell pipelines.
+
+## Spec deviations
+
+- `--fields name,version` is a separate flag rather than overloaded `--json name,version`. Keeps boolean `--json=true` compatibility intact.
+- `meta.duration_ms` is leaf execution only; `meta.bootstrap_ms` is everything before that. Sum them for wall time.

--- a/docs/projects-and-kits.md
+++ b/docs/projects-and-kits.md
@@ -1,0 +1,98 @@
+# Projects, kits, and snippets
+
+Scribe scopes skill availability to the project you're working in, instead of dumping every installed skill into every session. The pieces:
+
+- `.scribe.yaml` — a per-repo declaration of which kits, snippets, or extra skills the project wants
+- **Kits** — named, reusable bundles of skills, stackable per project
+- **Snippets** — rules / behavior directives injected into agent rules files (`CLAUDE.md`, `AGENTS.md`, `.cursorrules`)
+
+Full design rationale lives in [`docs/superpowers/specs/2026-04-29-kits-and-snippets-design.md`](superpowers/specs/2026-04-29-kits-and-snippets-design.md). This page documents the shipped surface.
+
+## Why projection moved project-local
+
+Earlier scribe symlinked `~/.scribe/skills/<name>` → `~/.claude/skills/<name>`, machine-globally. Every session saw every skill — bad for Codex's 5440-byte description budget (issue #114) and bad for routing quality once you accumulate hundreds of skills.
+
+Now scribe symlinks into `<project>/.claude/skills/<name>` and `<project>/.codex/skills/<name>`. Both Claude Code and Codex already read project-local skill directories without any flag. The canonical store at `~/.scribe/skills/` is unchanged.
+
+Effect: a session's skill set is determined by `cwd`. Two repos see two different skill sets, even if you only ran `scribe sync` once. Parallel sessions in the same repo with different kits are handled by anvil worktrees.
+
+## `.scribe.yaml`
+
+A `.scribe.yaml` at a project root declares the project's intent. All keys are optional.
+
+```yaml
+# .scribe.yaml — committed to the repo so the team shares the same skill set
+kits:
+  - laravel-baseline
+snippets:
+  - commit-discipline
+add:
+  - owner/repo:extra-skill
+remove:
+  - skill-this-project-doesnt-want
+```
+
+Empty or missing files are treated as "no project-level intent" — sync still runs, but nothing is added or removed at the project level.
+
+The dotfile (`.scribe.yaml`) is distinct from `scribe.yaml` used inside skill **registry** repos as a manifest. Same format, different role, different name.
+
+## Kits
+
+A kit is a curated, stackable list of skills. Kits live under `~/.scribe/kits/<name>.yaml`.
+
+```yaml
+# ~/.scribe/kits/laravel-baseline.yaml
+apiVersion: scribe/v1
+kind: Kit
+name: laravel-baseline
+description: Default skill set for Laravel app work
+skills:
+  - init-laravel
+  - init-livewire
+  - init-filament
+  - tdd
+  - debugger
+```
+
+Projects list which kits they want via `kits:` in `.scribe.yaml`. Multiple kits union; the project may add or remove individual skills on top with `add:` / `remove:`.
+
+Kits are **not** personas. The forward path for role specialization (adversarial review, security/a11y experts, context isolation) is subagent routing metadata inside kits — not a separate primitive. That metadata is not in the v1 surface.
+
+### Codex budget guardrail
+
+Codex's 5440-byte skill-description budget is enforced as a real refusal, not a warning:
+
+- below 70% of budget → silent
+- 70%–100% → warn but proceed
+- at or above 100% → refuse with the list of skills causing the overflow
+
+You retry with `--force` or trim the kit. The structural guardrail makes the original Codex truncation bug impossible to reintroduce by accident.
+
+## Snippets
+
+A snippet is a Markdown body with frontmatter declaring which agents it targets. Scribe injects snippet bodies into the project's agent rules files (`CLAUDE.md`, `AGENTS.md`, `.cursorrules`) inside scribe-managed marker blocks.
+
+```markdown
+---
+name: commit-discipline
+description: Commit-message rules and agent commit discipline
+targets: [claude, codex, cursor]
+---
+
+Commit after each logical phase of work, not just at the end.
+Use `[agent]` prefix on every commit message...
+```
+
+Snippets stack like kits — `snippets:` in `.scribe.yaml` lists the order, and scribe writes one block per snippet. Content **outside** the marker blocks is preserved, so you can edit your `CLAUDE.md` freely; scribe only owns the marked region.
+
+Snippets are deliberately plain text in v1: no variables, no conditionals, no liquid-style logic. They exist to share rules, not to template.
+
+## Migration from global projection
+
+Existing global-projection installs are not auto-migrated on upgrade. Scribe ships a compatibility mode that keeps `~/.claude/skills/` symlinks working with a deprecation banner. A dedicated migration command walks projects you select interactively. Compat mode is removed at v1.0.
+
+## Where to look next
+
+- [`commands.md`](commands.md) — full command surface
+- [`adoption.md`](adoption.md) — claim hand-rolled skills already on the machine
+- [`docs/superpowers/specs/2026-04-29-kits-and-snippets-design.md`](superpowers/specs/2026-04-29-kits-and-snippets-design.md) — full design doc, non-goals, parking lot

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,119 @@
+# Troubleshooting
+
+When something looks off, start with `scribe doctor`. It compares the canonical store under `~/.scribe/skills/` against the tool-facing projections (e.g. `<project>/.claude/skills/`, `~/.codex/skills/`) and reports anything inconsistent.
+
+## `scribe doctor`
+
+```bash
+scribe doctor                          # check everything, no writes
+scribe doctor --skill recap            # check a single skill
+scribe doctor --json                   # machine-readable report
+scribe doctor --fix                    # apply safe normalization + reproject affected skills
+scribe doctor --skill recap --fix      # repair just one skill
+```
+
+Live `scribe doctor --json` excerpt:
+
+```json
+{
+  "status": "ok",
+  "format_version": "1",
+  "data": {
+    "fix": false,
+    "summary": null,
+    "issues_sample": [
+      {
+        "skill": "add-init",
+        "tool": "cursor",
+        "kind": "projection_drift",
+        "status": "warn",
+        "message": "unexpected managed projection at ...; missing managed projection for cursor at ..."
+      }
+    ]
+  },
+  "meta": { "duration_ms": 25, "bootstrap_ms": 4, "command": "scribe doctor", "scribe_version": "dev" }
+}
+```
+
+`kind` values you'll see today:
+
+- `projection_drift` — a tool-facing copy is missing, in the wrong place, or no longer matches the canonical store
+- `metadata_normalization` — frontmatter in the canonical `SKILL.md` deviates from the canonical shape (whitespace, ordering, frontmatter casing)
+- `opaque_tool` — a registered tool reports as opaque, so projection comparison is intentionally skipped (informational, not a real problem)
+
+`scribe doctor` v1 does not attempt to rewrite mixed package layouts for Codex. It focuses on canonical-metadata health plus projection repair.
+
+## Common situations
+
+### "I edited a skill in `~/.claude/skills/` and now sync says it differs"
+
+When a tool-local copy diverges from the canonical store, `scribe sync` preserves the local content and prints a repair hint instead of overwriting:
+
+```
+conflict: recap in codex differs from managed copy
+run `scribe skill repair recap --tool codex` to resolve
+```
+
+Pick a side:
+
+```bash
+scribe skill repair recap --tool codex            # accept canonical, overwrite local
+scribe resolve recap --theirs                     # accept local, overwrite canonical
+scribe resolve recap --ours                       # accept canonical (same as repair)
+```
+
+### "A skill I uninstalled keeps coming back"
+
+`scribe remove <skill>` records a deny-list entry in `~/.scribe/config.yaml` that survives across syncs. If a skill keeps reappearing, check that the remove command actually ran (`scribe config | jq '.deny'` in a future migrated version, or grep the config) — and confirm you removed via scribe rather than just `rm`-ing the symlink.
+
+### "scribe list shows everything as `(local)`"
+
+That means scribe adopted a bunch of hand-rolled skills it wasn't expecting. Either:
+
+- Run `scribe config adoption --mode off` to stop auto-adoption, then decide which skills you actually want adopted, or
+- Let it stand — adopted skills are first-class managed entries; they just have no upstream.
+
+See [`adoption.md`](adoption.md) for the full adoption story.
+
+### "Codex truncated all my skill descriptions"
+
+Symptom of issue [#114](https://github.com/Naoray/scribe/issues/114) — Codex's 5440-byte description budget overflowed. The kits/snippets work introduces a real refusal at 100% of budget. If you're still on global-projection compat mode, switch to project-local projection by adding a `.scribe.yaml` with the kits you actually need. See [`projects-and-kits.md`](projects-and-kits.md).
+
+### "Private repos don't authenticate"
+
+Auth fallback chain:
+
+1. `gh auth token` (preferred)
+2. `GITHUB_TOKEN` environment variable
+3. `~/.scribe/config.yaml` token field
+4. unauthenticated (public repos only)
+
+Run `gh auth login` if scribe can't reach a private registry. Scribe does not store tokens of its own.
+
+### "I don't know which commands support `--json`"
+
+```bash
+scribe schema --all --json | jq 'keys'
+```
+
+Anything not in that list is still pre-envelope and rejects `--json` with `JSON_NOT_SUPPORTED`. Inspect `data.error.remediation` for the migration todo.
+
+## Where things live
+
+```
+~/.scribe/
+  config.yaml              # connected registries, tool settings, adoption mode, deny-list
+  state.json               # what's installed, last sync time, projection map
+  skills/                  # canonical skill store (symlinked by tools)
+  kits/                    # user-defined kit YAMLs
+  packages/                # registry packages cloned for catalog metadata
+```
+
+If you want to start over, deleting `~/.scribe/` is safe (you'll lose deny-list and projections) — your hand-rolled skills in `~/.claude/skills/` etc. are still there because adoption only ever symlinked them.
+
+## Where to look next
+
+- Daily commands: [`commands.md`](commands.md)
+- Projecting skills onto the right projects: [`projects-and-kits.md`](projects-and-kits.md)
+- Adopting hand-rolled skills: [`adoption.md`](adoption.md)
+- Envelope shape, exit codes, schema introspection: [`json-envelope.md`](json-envelope.md)


### PR DESCRIPTION
## Summary

Splits the ~385-line monolithic README into:

- **`README.md`** — slim front-facing promo page (~157 lines): hero + value prop, install, 60s quickstart, refreshed JSON sample, why-scribe positioning, doc links.
- **`docs/`** — five new reference files extracted from the old README:
  - `docs/commands.md` — full command surface, grouped (daily / registry / skills+tools / conflicts / config / other)
  - `docs/json-envelope.md` — envelope shape, exit codes, partial-success, `--fields`, schema introspection, pre-envelope command behavior
  - `docs/projects-and-kits.md` — `.scribe.yaml`, kits, snippets; cites the design spec
  - `docs/adoption.md` — `scribe adopt`, `adoption.mode` config, deny-list, on-disk behavior
  - `docs/troubleshooting.md` — `scribe doctor` output (live envelope), repair flows, common situations

## Sample refresh

The "what scribe list/sync/doctor look like" blocks in the old README were stale (pre-envelope shape, missing `partial_success`, fictional registry names). Replaced with envelope captures from the current binary at HEAD `84232c9`:

- `list --json` — `data.packages` + `data.skills`, `meta.duration_ms`, `format_version: "1"`
- `sync --json` — `partial_success` status, `data.reconcile.{installed,relinked,removed,conflicts_count}`, `data.summary`
- `doctor --json` — `kind: projection_drift`, `status: warn` issue shape

## What does NOT land

Per todo body scope: no source changes, no `CLAUDE.md` / `SKILL.md` / `CHANGELOG.md` edits, no `docs/superpowers/` touches. Pure docs split.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] Reviewer skim of new `docs/*.md` for accuracy
- [ ] Reviewer skim of slimmed `README.md` for tone + flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)