### PR TITLE
feat(state): legacy global-projection compat mode (todo #378)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/cli/output"
 	"github.com/Naoray/scribe/internal/firstrun"
+	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/storemigrate"
 	"github.com/Naoray/scribe/internal/tools"
 )
@@ -54,6 +55,8 @@ var commandFactory = newCommandFactory
 var rootCmd = newRootCmd()
 
 const jsonSupportedAnnotation = "json_supported"
+
+type legacyGlobalProjectionCompatKey struct{}
 
 func Execute() {
 	err := rootCmd.Execute()
@@ -120,6 +123,15 @@ func newRootCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			wd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("get working directory: %w", err)
+			}
+			compat, err := state.DetectLegacyGlobalProjectionCompat(st, wd)
+			if err != nil {
+				return err
+			}
+			c.SetContext(context.WithValue(c.Context(), legacyGlobalProjectionCompatKey{}, compat))
 
 			added, builtinsFirstRun := firstrun.ApplyBuiltins(cfg)
 			removed, removedRan := firstrun.ApplyBuiltinsRemove(cfg, st, []string{"openai/codex-skills"})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,6 +132,15 @@ func newRootCmd() *cobra.Command {
 				return err
 			}
 			c.SetContext(context.WithValue(c.Context(), legacyGlobalProjectionCompatKey{}, compat))
+			if compat.Enabled {
+				emit, err := state.ShouldEmitLegacyGlobalProjectionCompatBanner(time.Now())
+				if err != nil {
+					return err
+				}
+				if emit {
+					fmt.Fprintln(c.ErrOrStderr(), state.LegacyGlobalProjectionCompatBanner)
+				}
+			}
 
 			added, builtinsFirstRun := firstrun.ApplyBuiltins(cfg)
 			removed, removedRan := firstrun.ApplyBuiltinsRemove(cfg, st, []string{"openai/codex-skills"})

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -8,6 +8,8 @@ import (
 	"runtime/debug"
 	"strings"
 	"testing"
+
+	"github.com/Naoray/scribe/internal/state"
 )
 
 func TestResolveVersion(t *testing.T) {
@@ -238,4 +240,96 @@ builtins_version: 3
 	if !strings.Contains(configText, "anthropics/skills") {
 		t.Fatalf("renamed anthropics/skills entry missing:\n%s", configText)
 	}
+}
+
+func TestRoot_LegacyCompatBannerThrottleFailureDoesNotBlockCommand(t *testing.T) {
+	home := setupLegacyCompatBannerHome(t)
+	timestampPath := filepath.Join(home, ".scribe", "legacy-global-projection-banner.date")
+	if err := os.Mkdir(timestampPath, 0o755); err != nil {
+		t.Fatalf("mkdir timestamp path: %v", err)
+	}
+
+	stdout, stderr := executeRootForLegacyCompatBannerTest(t, home, []string{"list", "--json"})
+	if !strings.Contains(stderr, state.LegacyGlobalProjectionCompatBanner) {
+		t.Fatalf("stderr missing compat banner:\n%s", stderr)
+	}
+	var anyJSON interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &anyJSON); err != nil {
+		t.Fatalf("stdout not clean JSON: %v\nstdout=%q\nstderr=%q", err, stdout, stderr)
+	}
+}
+
+func TestRoot_LegacyCompatBannerCorruptTimestampDoesNotBlockCommand(t *testing.T) {
+	home := setupLegacyCompatBannerHome(t)
+	timestampPath := filepath.Join(home, ".scribe", "legacy-global-projection-banner.date")
+	if err := os.WriteFile(timestampPath, []byte("not-a-date\n"), 0o644); err != nil {
+		t.Fatalf("write corrupt timestamp: %v", err)
+	}
+
+	stdout, stderr := executeRootForLegacyCompatBannerTest(t, home, []string{"list", "--json"})
+	if !strings.Contains(stderr, state.LegacyGlobalProjectionCompatBanner) {
+		t.Fatalf("stderr missing compat banner:\n%s", stderr)
+	}
+	var anyJSON interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &anyJSON); err != nil {
+		t.Fatalf("stdout not clean JSON: %v\nstdout=%q\nstderr=%q", err, stdout, stderr)
+	}
+}
+
+func setupLegacyCompatBannerHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd := filepath.Join(home, "workspace")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("mkdir cwd: %v", err)
+	}
+	t.Chdir(cwd)
+
+	configDir := filepath.Join(home, ".scribe")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(`registries:
+  - repo: anthropics/skills
+    enabled: true
+    builtin: true
+    type: community
+builtins_version: 3
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	st := &state.State{
+		SchemaVersion: 5,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Revision:      1,
+				InstalledHash: "hash",
+				Projections: []state.ProjectionEntry{{
+					Project: "",
+					Tools:   []string{"claude"},
+				}},
+			},
+		},
+		Kits:     map[string]state.InstalledKit{},
+		Snippets: map[string]state.InstalledSnippet{},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	return home
+}
+
+func executeRootForLegacyCompatBannerTest(t *testing.T, home string, args []string) (string, string) {
+	t.Helper()
+	t.Setenv("PATH", home)
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs(args)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute(%v): %v\nstdout=%s\nstderr=%s", args, err, stdout.String(), stderr.String())
+	}
+	return stdout.String(), stderr.String()
 }

--- a/internal/state/compat.go
+++ b/internal/state/compat.go
@@ -1,0 +1,101 @@
+package state
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const projectFileName = ".scribe.yaml"
+
+// LegacyGlobalProjectionCompat describes whether Scribe should preserve the
+// pre-project global projection behavior for this invocation.
+type LegacyGlobalProjectionCompat struct {
+	Enabled              bool
+	CWD                  string
+	HasGlobalProjections bool
+	ProjectFile          string
+}
+
+// DetectLegacyGlobalProjectionCompat enables compatibility mode only when
+// state still records global projections and the current directory is not
+// inside a project with .scribe.yaml.
+//
+// TODO(v1.0): remove this legacy global-projection compatibility path and
+// direct users to clean up orphaned global symlinks via migration.
+func DetectLegacyGlobalProjectionCompat(st *State, cwd string) (LegacyGlobalProjectionCompat, error) {
+	result := LegacyGlobalProjectionCompat{CWD: cwd}
+	if st == nil {
+		return result, nil
+	}
+
+	result.HasGlobalProjections = st.HasLegacyGlobalProjections()
+	if !result.HasGlobalProjections {
+		return result, nil
+	}
+
+	projectFile, err := findProjectFile(cwd)
+	if err != nil {
+		return result, err
+	}
+	result.ProjectFile = projectFile
+	result.Enabled = projectFile == ""
+	return result, nil
+}
+
+// HasLegacyGlobalProjections reports whether any installed skill still has an
+// empty-project projection entry, the state shape used before project-local
+// projection was introduced.
+func (s *State) HasLegacyGlobalProjections() bool {
+	if s == nil {
+		return false
+	}
+	for _, installed := range s.Installed {
+		for _, projection := range installed.Projections {
+			if projection.Project == "" && len(projection.Tools) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func findProjectFile(startDir string) (string, error) {
+	if startDir == "" {
+		var err error
+		startDir, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("get working directory: %w", err)
+		}
+	}
+
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve start dir: %w", err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		return "", fmt.Errorf("stat start dir: %w", err)
+	}
+	if !info.IsDir() {
+		dir = filepath.Dir(dir)
+	}
+
+	for {
+		candidate := filepath.Join(dir, projectFileName)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("stat project file: %w", err)
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", nil
+		}
+		dir = parent
+	}
+}

--- a/internal/state/compat.go
+++ b/internal/state/compat.go
@@ -73,7 +73,8 @@ func (s *State) HasLegacyGlobalProjections() bool {
 func ShouldEmitLegacyGlobalProjectionCompatBanner(now time.Time) (bool, error) {
 	path, err := LegacyGlobalProjectionCompatBannerPath()
 	if err != nil {
-		return false, err
+		debugLegacyGlobalProjectionCompatBannerThrottle("resolve timestamp path: %v", err)
+		return true, nil
 	}
 	return ShouldEmitLegacyGlobalProjectionCompatBannerAt(path, now)
 }
@@ -95,15 +96,25 @@ func ShouldEmitLegacyGlobalProjectionCompatBannerAt(timestampPath string, now ti
 		return false, nil
 	}
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return false, fmt.Errorf("read compat banner timestamp: %w", err)
+		debugLegacyGlobalProjectionCompatBannerThrottle("read timestamp: %v", err)
+		return true, nil
 	}
 	if err := os.MkdirAll(filepath.Dir(timestampPath), 0o755); err != nil {
-		return false, fmt.Errorf("create compat banner timestamp dir: %w", err)
+		debugLegacyGlobalProjectionCompatBannerThrottle("create timestamp dir: %v", err)
+		return true, nil
 	}
 	if err := os.WriteFile(timestampPath, []byte(today+"\n"), 0o644); err != nil {
-		return false, fmt.Errorf("write compat banner timestamp: %w", err)
+		debugLegacyGlobalProjectionCompatBannerThrottle("write timestamp: %v", err)
+		return true, nil
 	}
 	return true, nil
+}
+
+func debugLegacyGlobalProjectionCompatBannerThrottle(format string, args ...any) {
+	if os.Getenv("SCRIBE_DEBUG") == "" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "scribe: debug: compat banner throttle: "+format+"\n", args...)
 }
 
 func findProjectFile(startDir string) (string, error) {

--- a/internal/state/compat.go
+++ b/internal/state/compat.go
@@ -6,9 +6,15 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Naoray/scribe/internal/paths"
 )
 
 const projectFileName = ".scribe.yaml"
+
+const LegacyGlobalProjectionCompatBanner = "scribe: legacy global-projection compatibility mode is active; run `scribe migrate global-to-projects` to move to project-local `.scribe.yaml` projection before v1.0."
 
 // LegacyGlobalProjectionCompat describes whether Scribe should preserve the
 // pre-project global projection behavior for this invocation.
@@ -60,6 +66,44 @@ func (s *State) HasLegacyGlobalProjections() bool {
 		}
 	}
 	return false
+}
+
+// ShouldEmitLegacyGlobalProjectionCompatBanner applies the per-user daily
+// throttle for the legacy global-projection deprecation banner.
+func ShouldEmitLegacyGlobalProjectionCompatBanner(now time.Time) (bool, error) {
+	path, err := LegacyGlobalProjectionCompatBannerPath()
+	if err != nil {
+		return false, err
+	}
+	return ShouldEmitLegacyGlobalProjectionCompatBannerAt(path, now)
+}
+
+func LegacyGlobalProjectionCompatBannerPath() (string, error) {
+	dir, err := paths.ScribeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "legacy-global-projection-banner.date"), nil
+}
+
+// ShouldEmitLegacyGlobalProjectionCompatBannerAt returns true at most once per
+// local calendar day, updating timestampPath when the banner should be shown.
+func ShouldEmitLegacyGlobalProjectionCompatBannerAt(timestampPath string, now time.Time) (bool, error) {
+	today := now.Format("2006-01-02")
+	data, err := os.ReadFile(timestampPath)
+	if err == nil && strings.TrimSpace(string(data)) == today {
+		return false, nil
+	}
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return false, fmt.Errorf("read compat banner timestamp: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(timestampPath), 0o755); err != nil {
+		return false, fmt.Errorf("create compat banner timestamp dir: %w", err)
+	}
+	if err := os.WriteFile(timestampPath, []byte(today+"\n"), 0o644); err != nil {
+		return false, fmt.Errorf("write compat banner timestamp: %w", err)
+	}
+	return true, nil
 }
 
 func findProjectFile(startDir string) (string, error) {

--- a/internal/state/compat_test.go
+++ b/internal/state/compat_test.go
@@ -1,0 +1,102 @@
+package state_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Naoray/scribe/internal/state"
+)
+
+func TestDetectLegacyGlobalProjectionCompat(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "nested", "pkg")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested project: %v", err)
+	}
+
+	withGlobal := &state.State{
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Projections: []state.ProjectionEntry{{
+					Project: "",
+					Tools:   []string{"claude"},
+				}},
+			},
+		},
+	}
+	withoutGlobal := &state.State{
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Projections: []state.ProjectionEntry{{
+					Project: root,
+					Tools:   []string{"claude"},
+				}},
+			},
+		},
+	}
+
+	got, err := state.DetectLegacyGlobalProjectionCompat(withGlobal, nested)
+	if err != nil {
+		t.Fatalf("DetectLegacyGlobalProjectionCompat() error = %v", err)
+	}
+	if !got.Enabled {
+		t.Fatalf("Enabled = false, want true for global projection without .scribe.yaml")
+	}
+	if !got.HasGlobalProjections {
+		t.Fatalf("HasGlobalProjections = false, want true")
+	}
+
+	projectFile := filepath.Join(root, ".scribe.yaml")
+	if err := os.WriteFile(projectFile, []byte("kits: []\n"), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+	got, err = state.DetectLegacyGlobalProjectionCompat(withGlobal, nested)
+	if err != nil {
+		t.Fatalf("DetectLegacyGlobalProjectionCompat() with project file error = %v", err)
+	}
+	if got.Enabled {
+		t.Fatalf("Enabled = true, want false when .scribe.yaml exists")
+	}
+	if got.ProjectFile != projectFile {
+		t.Fatalf("ProjectFile = %q, want %q", got.ProjectFile, projectFile)
+	}
+
+	got, err = state.DetectLegacyGlobalProjectionCompat(withoutGlobal, nested)
+	if err != nil {
+		t.Fatalf("DetectLegacyGlobalProjectionCompat() without global error = %v", err)
+	}
+	if got.Enabled || got.HasGlobalProjections {
+		t.Fatalf("got %+v, want no compat mode without global projections", got)
+	}
+}
+
+func TestShouldEmitLegacyGlobalProjectionCompatBannerAt(t *testing.T) {
+	timestampPath := filepath.Join(t.TempDir(), ".scribe", "legacy-global-projection-banner.date")
+	first := time.Date(2026, 4, 30, 9, 0, 0, 0, time.Local)
+
+	emit, err := state.ShouldEmitLegacyGlobalProjectionCompatBannerAt(timestampPath, first)
+	if err != nil {
+		t.Fatalf("first ShouldEmitLegacyGlobalProjectionCompatBannerAt() error = %v", err)
+	}
+	if !emit {
+		t.Fatalf("first emit = false, want true")
+	}
+
+	emit, err = state.ShouldEmitLegacyGlobalProjectionCompatBannerAt(timestampPath, first.Add(6*time.Hour))
+	if err != nil {
+		t.Fatalf("same-day ShouldEmitLegacyGlobalProjectionCompatBannerAt() error = %v", err)
+	}
+	if emit {
+		t.Fatalf("same-day emit = true, want false")
+	}
+
+	emit, err = state.ShouldEmitLegacyGlobalProjectionCompatBannerAt(timestampPath, first.AddDate(0, 0, 1))
+	if err != nil {
+		t.Fatalf("next-day ShouldEmitLegacyGlobalProjectionCompatBannerAt() error = %v", err)
+	}
+	if !emit {
+		t.Fatalf("next-day emit = false, want true")
+	}
+}

--- a/internal/state/compat_test.go
+++ b/internal/state/compat_test.go
@@ -100,3 +100,63 @@ func TestShouldEmitLegacyGlobalProjectionCompatBannerAt(t *testing.T) {
 		t.Fatalf("next-day emit = false, want true")
 	}
 }
+
+func TestShouldEmitLegacyGlobalProjectionCompatBannerAtFailOpen(t *testing.T) {
+	now := time.Date(2026, 4, 30, 9, 0, 0, 0, time.Local)
+
+	t.Run("unreadable timestamp path", func(t *testing.T) {
+		timestampPath := filepath.Join(t.TempDir(), "legacy-global-projection-banner.date")
+		if err := os.Mkdir(timestampPath, 0o755); err != nil {
+			t.Fatalf("mkdir timestamp path: %v", err)
+		}
+
+		emit, err := state.ShouldEmitLegacyGlobalProjectionCompatBannerAt(timestampPath, now)
+		if err != nil {
+			t.Fatalf("ShouldEmitLegacyGlobalProjectionCompatBannerAt() error = %v", err)
+		}
+		if !emit {
+			t.Fatalf("emit = false, want true")
+		}
+	})
+
+	t.Run("unwritable timestamp path", func(t *testing.T) {
+		parentFile := filepath.Join(t.TempDir(), "not-a-directory")
+		if err := os.WriteFile(parentFile, []byte("file blocks timestamp dir\n"), 0o644); err != nil {
+			t.Fatalf("write parent file: %v", err)
+		}
+		timestampPath := filepath.Join(parentFile, "legacy-global-projection-banner.date")
+
+		emit, err := state.ShouldEmitLegacyGlobalProjectionCompatBannerAt(timestampPath, now)
+		if err != nil {
+			t.Fatalf("ShouldEmitLegacyGlobalProjectionCompatBannerAt() error = %v", err)
+		}
+		if !emit {
+			t.Fatalf("emit = false, want true")
+		}
+	})
+
+	t.Run("corrupted timestamp file", func(t *testing.T) {
+		timestampPath := filepath.Join(t.TempDir(), ".scribe", "legacy-global-projection-banner.date")
+		if err := os.MkdirAll(filepath.Dir(timestampPath), 0o755); err != nil {
+			t.Fatalf("mkdir timestamp dir: %v", err)
+		}
+		if err := os.WriteFile(timestampPath, []byte("not-a-date\n"), 0o644); err != nil {
+			t.Fatalf("write corrupt timestamp: %v", err)
+		}
+
+		emit, err := state.ShouldEmitLegacyGlobalProjectionCompatBannerAt(timestampPath, now)
+		if err != nil {
+			t.Fatalf("ShouldEmitLegacyGlobalProjectionCompatBannerAt() error = %v", err)
+		}
+		if !emit {
+			t.Fatalf("emit = false, want true")
+		}
+		got, err := os.ReadFile(timestampPath)
+		if err != nil {
+			t.Fatalf("read repaired timestamp: %v", err)
+		}
+		if string(got) != "2026-04-30\n" {
+			t.Fatalf("timestamp = %q, want repaired date", got)
+		}
+	})
+}

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "9fd2f7dd",
+      "content_hash": "b6daf92c",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe-agent",


### PR DESCRIPTION
Summary:
- Add state-level detection for legacy global projections when no .scribe.yaml is present in the current directory tree.
- Emit a once-per-day deprecation banner pointing users to scribe migrate global-to-projects.
- Preserve existing global projection behavior by leaving the project root empty in compat mode.
- Add v1.0 removal TODO in code and tracker follow-up todo #493.

Test plan:
- go test ./...

Links:
- Solo todo #378
- Follow-up tracker: solo todo #493