### PR TITLE
feat(budget): per-agent description-byte guardrail (todo #371, GH #114)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -450,6 +450,10 @@ func wireInstallSyncer(syncer *sync.Syncer, registryRepo string, useJSON bool) *
 			} else {
 				fmt.Fprintf(os.Stderr, "  ✗ %-24s error: %v\n", m.Name, m.Err)
 			}
+		case sync.BudgetWarningMsg:
+			if !useJSON {
+				fmt.Fprintf(os.Stderr, "warning: %s\n", m.Message)
+			}
 		}
 	}
 	return results

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -67,6 +67,7 @@ Examples:
 	cmd.Flags().Bool("yes", false, "Skip confirmation prompts")
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.Flags().String("registry", "", "Limit search to a specific registry (owner/repo)")
+	cmd.Flags().Bool("force", false, "Project skills even when an agent budget is exceeded")
 	return markJSONSupported(cmd)
 }
 
@@ -74,6 +75,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	skipConfirm, _ := cmd.Flags().GetBool("yes")
 	jsonFlag := jsonFlagPassed(cmd)
 	registryFilter, _ := cmd.Flags().GetString("registry")
+	forceBudget, _ := cmd.Flags().GetBool("force")
 
 	isTTY := isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
 	useJSON := jsonFlag || !isatty.IsTerminal(os.Stdout.Fd())
@@ -87,6 +89,9 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	st, err := factory.State()
 	if err != nil {
 		return fmt.Errorf("load state: %w", err)
+	}
+	if err := enforceCurrentBudget(factory, forceBudget); err != nil {
+		return err
 	}
 
 	ctx := cmd.Context()
@@ -113,7 +118,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 				clierrors.WithRemediation("run `gh auth login` or set GITHUB_TOKEN"),
 			)
 		}
-		return runAddDirectInstallForCommand(cmd, ctx, registryRepo, skillName, cfg, st, newInstallSyncer(client, targets), true, useJSON, skipConfirm)
+		return runAddDirectInstallForCommand(cmd, ctx, registryRepo, skillName, cfg, st, newInstallSyncer(client, targets, forceBudget), true, useJSON, skipConfirm)
 	}
 
 	// Need at least one connected registry to search/browse.
@@ -185,7 +190,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	return installSelected(ctx, selected, cfg, st, client, targets, skipConfirm)
+	return installSelected(ctx, selected, cfg, st, client, targets, skipConfirm, forceBudget)
 }
 
 // parseSkillRef parses "owner/repo:skillname" into its parts.
@@ -317,6 +322,7 @@ func installSelected(
 	client *gh.Client,
 	targets []tools.Tool,
 	skipConfirm bool,
+	forceBudget bool,
 ) error {
 	// Group by registry.
 	byRegistry := map[string][]sync.SkillStatus{}
@@ -350,7 +356,7 @@ func installSelected(
 		}
 	}
 
-	syncer := newInstallSyncer(client, targets)
+	syncer := newInstallSyncer(client, targets, forceBudget)
 
 	var installErr error
 	for _, registryRepo := range order {
@@ -387,13 +393,18 @@ func installSelected(
 }
 
 // newInstallSyncer constructs a Syncer ready to install skills.
-func newInstallSyncer(client *gh.Client, targets []tools.Tool) *sync.Syncer {
+func newInstallSyncer(client *gh.Client, targets []tools.Tool, forceBudgetOpt ...bool) *sync.Syncer {
+	forceBudget := false
+	if len(forceBudgetOpt) > 0 {
+		forceBudget = forceBudgetOpt[0]
+	}
 	return &sync.Syncer{
 		Client:      sync.WrapGitHubClient(client),
 		Provider:    provider.NewGitHubProvider(provider.WrapGitHubClient(client)),
 		Tools:       targets,
 		Executor:    &sync.ShellExecutor{},
 		ProjectRoot: resolveCurrentProjectRoot(),
+		ForceBudget: forceBudget,
 	}
 }
 

--- a/cmd/add_shared.go
+++ b/cmd/add_shared.go
@@ -277,6 +277,8 @@ func autoSync(ctx context.Context, targetRepo string, st *state.State, client *g
 				fmt.Printf("  %-20s %s\n", m.Name, verb)
 			case sync.SkillErrorMsg:
 				fmt.Fprintf(os.Stderr, "  %-20s error: %v\n", m.Name, m.Err)
+			case sync.BudgetWarningMsg:
+				fmt.Fprintf(os.Stderr, "warning: %s\n", m.Message)
 			}
 		},
 	}

--- a/cmd/budget_helpers.go
+++ b/cmd/budget_helpers.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/Naoray/scribe/internal/budget"
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/kit"
+	"github.com/Naoray/scribe/internal/paths"
+	"github.com/Naoray/scribe/internal/projectfile"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+type resolvedBudgetSet struct {
+	ProjectRoot string
+	Skills      []budget.Skill
+	Missing     []string
+}
+
+func resolveBudgetSet(st *state.State) (resolvedBudgetSet, error) {
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		return resolvedBudgetSet{}, fmt.Errorf("resolve store dir: %w", err)
+	}
+
+	names, projectRoot, err := resolveBudgetSkillNames(st)
+	if err != nil {
+		return resolvedBudgetSet{}, err
+	}
+
+	var out resolvedBudgetSet
+	out.ProjectRoot = projectRoot
+	for _, name := range names {
+		content, err := os.ReadFile(filepath.Join(storeDir, name, "SKILL.md"))
+		if err != nil {
+			out.Missing = append(out.Missing, name)
+			continue
+		}
+		out.Skills = append(out.Skills, budget.Skill{Name: name, Content: content})
+	}
+	return out, nil
+}
+
+func resolveBudgetSkillNames(st *state.State) ([]string, string, error) {
+	installedNames := installedSkillNames(st)
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, "", fmt.Errorf("get working directory: %w", err)
+	}
+	projectPath, err := projectfile.Find(wd)
+	if err != nil {
+		return nil, "", err
+	}
+	if projectPath == "" {
+		return installedNames, "", nil
+	}
+
+	pf, err := projectfile.Load(projectPath)
+	if err != nil {
+		return nil, "", err
+	}
+	scribeDir, err := paths.ScribeDir()
+	if err != nil {
+		return nil, "", err
+	}
+	kits, err := kit.LoadAll(filepath.Join(scribeDir, "kits"))
+	if err != nil {
+		return nil, "", err
+	}
+	resolved, err := kit.Resolve(pf, kits, installedNames)
+	if err != nil {
+		return nil, "", err
+	}
+	return resolved, filepath.Dir(projectPath), nil
+}
+
+func installedSkillNames(st *state.State) []string {
+	if st == nil {
+		return nil
+	}
+	names := make([]string, 0, len(st.Installed))
+	for name, installed := range st.Installed {
+		if installed.Kind == state.KindPackage {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func budgetAgents(_ *config.Config) []string {
+	agents := make([]string, 0, len(budget.AgentBudgets))
+	for agent := range budget.AgentBudgets {
+		agents = append(agents, agent)
+	}
+	sort.Strings(agents)
+	return agents
+}

--- a/cmd/budget_helpers.go
+++ b/cmd/budget_helpers.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/Naoray/scribe/internal/app"
 	"github.com/Naoray/scribe/internal/budget"
 	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/kit"
@@ -101,4 +102,31 @@ func budgetAgents(_ *config.Config) []string {
 	}
 	sort.Strings(agents)
 	return agents
+}
+
+func enforceCurrentBudget(factory *app.Factory, force bool) error {
+	cfg, err := factory.Config()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	st, err := factory.State()
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
+	set, err := resolveBudgetSet(st)
+	if err != nil {
+		return err
+	}
+	for _, agent := range budgetAgents(cfg) {
+		result := budget.CheckBudget(set.Skills, agent)
+		switch result.Status {
+		case budget.StatusRefuse:
+			if !force {
+				return fmt.Errorf("%s\nTry removing one kit, or rerun with --force to project anyway.", budget.FormatOverflow(result))
+			}
+		case budget.StatusWarn:
+			fmt.Fprintf(os.Stderr, "warning: %s\n", budget.FormatResult(result))
+		}
+	}
+	return nil
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -22,13 +22,19 @@ Pass skill names to install specific skills, or use --all to install everything.
 	}
 	cmd.Flags().Bool("all", false, "Install all available skills without prompting")
 	cmd.Flags().String("registry", "", "Limit to a specific registry (owner/repo)")
+	cmd.Flags().Bool("force", false, "Project skills even when an agent budget is exceeded")
 	return cmd
 }
 
 func runInstall(cmd *cobra.Command, args []string) error {
 	allFlag, _ := cmd.Flags().GetBool("all")
 	repoFlag, _ := cmd.Flags().GetString("registry")
+	forceBudget, _ := cmd.Flags().GetBool("force")
 	factory := newCommandFactory()
+
+	if err := enforceCurrentBudget(factory, forceBudget); err != nil {
+		return err
+	}
 
 	if len(args) > 0 {
 		if err := clearRemovedBeforeInstall(factory, args, repoFlag); err != nil {
@@ -40,6 +46,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		Args:             args,
 		InstallAllFlag:   allFlag,
 		RepoFlag:         repoFlag,
+		ForceBudget:      forceBudget,
 		Factory:          factory,
 		FilterRegistries: filterRegistries,
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -213,6 +213,7 @@ func newRootCmd() *cobra.Command {
 		newSyncCommand(),
 		newAdoptCommand(),
 		newStatusCommand(),
+		newShowCommand(),
 		newSchemaCommand(cmd),
 		newResolveCommand(),
 		newRestoreCommand(),

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/budget"
+)
+
+func newShowCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Show the resolved project skill set and agent budgets",
+		RunE:  runShow,
+	}
+}
+
+func runShow(cmd *cobra.Command, args []string) error {
+	factory := newCommandFactory()
+	cfg, err := factory.Config()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	st, err := factory.State()
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
+
+	set, err := resolveBudgetSet(st)
+	if err != nil {
+		return err
+	}
+
+	if set.ProjectRoot == "" {
+		fmt.Fprintln(os.Stdout, "Scope: legacy global projection")
+	} else {
+		fmt.Fprintf(os.Stdout, "Scope: %s\n", set.ProjectRoot)
+	}
+
+	fmt.Fprintf(os.Stdout, "Skills: %d resolved\n", len(set.Skills))
+	for _, skill := range set.Skills {
+		fmt.Fprintf(os.Stdout, "  %s\n", skill.Name)
+	}
+	if len(set.Missing) > 0 {
+		fmt.Fprintf(os.Stderr, "warning: missing SKILL.md for %s\n", strings.Join(set.Missing, ", "))
+	}
+
+	fmt.Fprintln(os.Stdout, "Budgets:")
+	for _, agent := range budgetAgents(cfg) {
+		result := budget.CheckBudget(set.Skills, agent)
+		line := budget.FormatResult(result)
+		if line == "" {
+			continue
+		}
+		switch result.Status {
+		case budget.StatusWarn:
+			fmt.Fprintf(os.Stdout, "  %s — warning\n", line)
+		case budget.StatusRefuse:
+			fmt.Fprintf(os.Stdout, "  %s — exceeded\n", line)
+		default:
+			fmt.Fprintf(os.Stdout, "  %s\n", line)
+		}
+	}
+	return nil
+}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -17,6 +17,7 @@ func newSyncCommand() *cobra.Command {
 	cmd.Flags().String("registry", "", "Sync only this registry (owner/repo or repo name)")
 	cmd.Flags().Bool("trust-all", false, "Approve all package install commands without prompting")
 	cmd.Flags().Bool("all", false, "Sync all registries (default behavior)")
+	cmd.Flags().Bool("force", false, "Project skills even when an agent budget is exceeded")
 	cmd.Flags().MarkHidden("all")
 	return markJSONSupported(cmd)
 }
@@ -25,13 +26,20 @@ func runSync(cmd *cobra.Command, args []string) error {
 	jsonFlag := jsonFlagPassed(cmd)
 	repoFlag, _ := cmd.Flags().GetString("registry")
 	trustAllFlag, _ := cmd.Flags().GetBool("trust-all")
+	forceBudget, _ := cmd.Flags().GetBool("force")
+	factory := commandFactory()
+
+	if err := enforceCurrentBudget(factory, forceBudget); err != nil {
+		return err
+	}
 
 	bag := &workflow.Bag{
 		Args:             args,
 		JSONFlag:         jsonFlag,
 		RepoFlag:         repoFlag,
 		TrustAllFlag:     trustAllFlag,
-		Factory:          commandFactory(),
+		ForceBudget:      forceBudget,
+		Factory:          factory,
 		FilterRegistries: filterRegistries,
 	}
 	if err := workflow.Run(cmd.Context(), workflow.SyncSteps(), bag); err != nil {

--- a/internal/budget/agents.go
+++ b/internal/budget/agents.go
@@ -1,0 +1,7 @@
+package budget
+
+// AgentBudgets is the configurable per-agent description-byte budget table.
+var AgentBudgets = map[string]int{
+	"codex":  5440,
+	"claude": 8000, // TODO: replace with a probed Claude Code hard limit.
+}

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -47,8 +47,13 @@ func (r Result) Percent() int {
 
 func EstimateDescriptionBytes(skill Skill) int {
 	description, body := splitSkill(skill.Content)
+	description = strings.TrimSpace(description)
 	firstParagraph := extractFirstParagraph(body)
-	return len([]byte(strings.TrimSpace(description))) + len([]byte(firstParagraph))
+	used := len([]byte(description)) + len([]byte(firstParagraph))
+	if description != "" && firstParagraph != "" {
+		used += len("\n\n")
+	}
+	return used
 }
 
 func CheckBudget(skills []Skill, agent string) Result {

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -1,0 +1,169 @@
+package budget
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const warnRatio = 0.70
+
+type Status string
+
+const (
+	StatusSilent Status = "silent"
+	StatusWarn   Status = "warn"
+	StatusRefuse Status = "refuse"
+)
+
+type Skill struct {
+	Name    string
+	Content []byte
+}
+
+type Overflow struct {
+	Skill string
+	Bytes int
+}
+
+type Result struct {
+	Agent     string
+	Limit     int
+	Used      int
+	Status    Status
+	Overflow  []Overflow
+	Missing   []string
+	WarnRatio float64
+}
+
+func (r Result) Percent() int {
+	if r.Limit <= 0 {
+		return 0
+	}
+	return (r.Used*100 + r.Limit - 1) / r.Limit
+}
+
+func EstimateDescriptionBytes(skill Skill) int {
+	description, body := splitSkill(skill.Content)
+	firstParagraph := extractFirstParagraph(body)
+	return len([]byte(strings.TrimSpace(description))) + len([]byte(firstParagraph))
+}
+
+func CheckBudget(skills []Skill, agent string) Result {
+	limit := AgentBudgets[strings.ToLower(agent)]
+	result := Result{
+		Agent:     strings.ToLower(agent),
+		Limit:     limit,
+		WarnRatio: warnRatio,
+	}
+	if limit <= 0 {
+		result.Status = StatusSilent
+		return result
+	}
+
+	ordered := append([]Skill(nil), skills...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Name < ordered[j].Name
+	})
+
+	for _, skill := range ordered {
+		size := EstimateDescriptionBytes(skill)
+		before := result.Used
+		result.Used += size
+		if result.Used >= limit {
+			overflow := result.Used - limit
+			if before > limit {
+				overflow = size
+			}
+			result.Overflow = append(result.Overflow, Overflow{
+				Skill: skill.Name,
+				Bytes: overflow,
+			})
+		}
+	}
+
+	switch {
+	case result.Used >= limit:
+		result.Status = StatusRefuse
+	case float64(result.Used) >= float64(limit)*warnRatio:
+		result.Status = StatusWarn
+	default:
+		result.Status = StatusSilent
+	}
+	return result
+}
+
+func FormatResult(result Result) string {
+	if result.Limit <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s budget: %d%% (%d / %d bytes)", title(result.Agent), result.Percent(), result.Used, result.Limit)
+}
+
+func FormatOverflow(result Result) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s skill budget exceeded\n", title(result.Agent))
+	fmt.Fprintf(&b, "estimated: %d / %d bytes (%d%%)\n", result.Used, result.Limit, result.Percent())
+	if len(result.Overflow) > 0 {
+		b.WriteString("overflow caused by:\n")
+		for _, item := range result.Overflow {
+			fmt.Fprintf(&b, "  %s adds %d bytes over budget\n", item.Skill, item.Bytes)
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+type frontmatter struct {
+	Description string `yaml:"description"`
+}
+
+func splitSkill(content []byte) (string, string) {
+	text := normalizeLineEndings(string(content))
+	if !strings.HasPrefix(text, "---\n") {
+		return "", text
+	}
+	rest := text[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return "", text
+	}
+	rawFrontmatter := rest[:end]
+	body := rest[end+len("\n---"):]
+	body = strings.TrimPrefix(body, "\r\n")
+	body = strings.TrimPrefix(body, "\n")
+
+	var fm frontmatter
+	if err := yaml.Unmarshal([]byte(rawFrontmatter), &fm); err != nil {
+		return "", body
+	}
+	return fm.Description, body
+}
+
+func extractFirstParagraph(body string) string {
+	lines := strings.Split(normalizeLineEndings(body), "\n")
+	var paragraph []string
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			if len(paragraph) > 0 {
+				break
+			}
+			continue
+		}
+		paragraph = append(paragraph, line)
+	}
+	return strings.Join(strings.Fields(strings.Join(paragraph, " ")), " ")
+}
+
+func normalizeLineEndings(s string) string {
+	return strings.ReplaceAll(s, "\r\n", "\n")
+}
+
+func title(s string) string {
+	if s == "" {
+		return ""
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -18,7 +18,7 @@ func TestEstimateDescriptionBytes(t *testing.T) {
 				"description: é\n" +
 				"---\n\n" +
 				"你好\n",
-			want: len([]byte("é")) + len([]byte("你好")),
+			want: len([]byte("é")) + len("\n\n") + len([]byte("你好")),
 		},
 		{
 			name: "empty description still counts first body paragraph",
@@ -38,7 +38,7 @@ func TestEstimateDescriptionBytes(t *testing.T) {
 				"First paragraph spans\n" +
 				"two lines.\n\n" +
 				"Second paragraph is ignored.\n",
-			want: len("Frontmatter description.") + len("First paragraph spans two lines."),
+			want: len("Frontmatter description.") + len("\n\n") + len("First paragraph spans two lines."),
 		},
 		{
 			name: "no frontmatter counts first body paragraph",

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -1,0 +1,122 @@
+package budget
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEstimateDescriptionBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{
+			name: "counts UTF-8 bytes",
+			content: "---\n" +
+				"name: utf8\n" +
+				"description: é\n" +
+				"---\n\n" +
+				"你好\n",
+			want: len([]byte("é")) + len([]byte("你好")),
+		},
+		{
+			name: "empty description still counts first body paragraph",
+			content: "---\n" +
+				"name: empty-description\n" +
+				"description: \"\"\n" +
+				"---\n\n" +
+				"First body paragraph.\n",
+			want: len("First body paragraph."),
+		},
+		{
+			name: "uses only first body paragraph",
+			content: "---\n" +
+				"name: multi-paragraph\n" +
+				"description: Frontmatter description.\n" +
+				"---\n\n" +
+				"First paragraph spans\n" +
+				"two lines.\n\n" +
+				"Second paragraph is ignored.\n",
+			want: len("Frontmatter description.") + len("First paragraph spans two lines."),
+		},
+		{
+			name: "no frontmatter counts first body paragraph",
+			content: "First paragraph.\n\n" +
+				"Second paragraph.\n",
+			want: len("First paragraph."),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EstimateDescriptionBytes(Skill{Name: tt.name, Content: []byte(tt.content)})
+			if got != tt.want {
+				t.Fatalf("EstimateDescriptionBytes() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckBudgetThresholdBoundaries(t *testing.T) {
+	tests := []struct {
+		name string
+		used int
+		want Status
+	}{
+		{name: "below warn threshold is silent", used: 3807, want: StatusSilent},
+		{name: "warn threshold warns", used: 3808, want: StatusWarn},
+		{name: "below hard limit warns", used: 5439, want: StatusWarn},
+		{name: "hard limit refuses", used: 5440, want: StatusRefuse},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckBudget([]Skill{skillWithDescription("one", tt.used)}, "codex")
+			if result.Status != tt.want {
+				t.Fatalf("Status = %s, want %s", result.Status, tt.want)
+			}
+			if result.Used != tt.used {
+				t.Fatalf("Used = %d, want %d", result.Used, tt.used)
+			}
+		})
+	}
+}
+
+func TestCheckBudgetOverflowBreakdown(t *testing.T) {
+	skills := []Skill{
+		skillWithDescription("a", 3000),
+		skillWithDescription("b", 2500),
+		skillWithDescription("c", 100),
+	}
+
+	result := CheckBudget(skills, "codex")
+	if result.Status != StatusRefuse {
+		t.Fatalf("Status = %s, want %s", result.Status, StatusRefuse)
+	}
+	if result.Used != 5600 {
+		t.Fatalf("Used = %d, want 5600", result.Used)
+	}
+	want := []Overflow{
+		{Skill: "b", Bytes: 60},
+		{Skill: "c", Bytes: 100},
+	}
+	if len(result.Overflow) != len(want) {
+		t.Fatalf("Overflow = %#v, want %#v", result.Overflow, want)
+	}
+	for i := range want {
+		if result.Overflow[i] != want[i] {
+			t.Fatalf("Overflow[%d] = %#v, want %#v", i, result.Overflow[i], want[i])
+		}
+	}
+}
+
+func skillWithDescription(name string, bytes int) Skill {
+	return Skill{
+		Name: name,
+		Content: []byte("---\n" +
+			"name: " + name + "\n" +
+			"description: " + strings.Repeat("x", bytes) + "\n" +
+			"---\n"),
+	}
+}

--- a/internal/sync/events.go
+++ b/internal/sync/events.go
@@ -159,6 +159,13 @@ type SkillErrorMsg struct {
 	Err  error
 }
 
+// BudgetWarningMsg is emitted when a post-change projected skill set enters
+// an agent's warning band but remains below the hard refusal limit.
+type BudgetWarningMsg struct {
+	Agent   string
+	Message string
+}
+
 // SkillAdoptionNeededMsg is sent when install refused to overwrite a real
 // (non-Scribe) directory at a tool projection path. Run `scribe adopt <name>`
 // to import the existing content, then re-sync.

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -630,11 +630,11 @@ func (s *Syncer) checkBudgetBeforeProjection(st *state.State, incomingName strin
 		return nil
 	}
 
-	skills, err := budgetSkillsFromStore(st, incomingName, incomingContent)
-	if err != nil {
-		return err
-	}
 	for _, agent := range agents {
+		skills, err := budgetSkillsForProjection(st, incomingName, incomingContent, s.ProjectRoot, agent)
+		if err != nil {
+			return err
+		}
 		result := ibudget.CheckBudget(skills, agent)
 		if result.Status != ibudget.StatusRefuse {
 			continue
@@ -668,23 +668,27 @@ func budgetedToolNames(toolSet []tools.Tool) []string {
 	return agents
 }
 
-func budgetSkillsFromStore(st *state.State, incomingName string, incomingContent []byte) ([]ibudget.Skill, error) {
+func budgetSkillsForProjection(st *state.State, incomingName string, incomingContent []byte, projectRoot, agent string) ([]ibudget.Skill, error) {
 	storeDir, err := tools.StoreDir()
 	if err != nil {
 		return nil, fmt.Errorf("resolve store dir: %w", err)
 	}
 
-	names := make([]string, 0, len(st.Installed)+1)
 	seen := map[string]bool{}
 	for name, installed := range st.Installed {
 		if installed.Kind == state.KindPackage {
 			continue
 		}
-		names = append(names, name)
+		if name == incomingName || !projectedToAgent(installed, projectRoot, agent) {
+			continue
+		}
 		seen[name] = true
 	}
-	if !seen[incomingName] {
-		names = append(names, incomingName)
+	seen[incomingName] = true
+
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
 	}
 	sort.Strings(names)
 
@@ -701,6 +705,27 @@ func budgetSkillsFromStore(st *state.State, incomingName string, incomingContent
 		skills = append(skills, ibudget.Skill{Name: name, Content: content})
 	}
 	return skills, nil
+}
+
+func projectedToAgent(installed state.InstalledSkill, projectRoot, agent string) bool {
+	for _, projection := range installed.Projections {
+		if projection.Project == projectRoot && containsString(projection.Tools, agent) {
+			return true
+		}
+	}
+	if projectRoot != "" || len(installed.Projections) > 0 {
+		return false
+	}
+	return containsString(installed.Tools, agent)
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func mergeProjection(installed *state.InstalledSkill, projectRoot string, toolNames []string) []state.ProjectionEntry {

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	ibudget "github.com/Naoray/scribe/internal/budget"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/migrate"
 	"github.com/Naoray/scribe/internal/provider"
@@ -59,6 +60,10 @@ type Syncer struct {
 
 	// TrustAll skips approval prompts for packages (--trust-all flag).
 	TrustAll bool
+
+	// ForceBudget allows projection even when an agent description-byte budget
+	// would otherwise be exceeded.
+	ForceBudget bool
 
 	// ApprovalFunc is called when a package needs interactive approval.
 	// Returns true if approved, false if denied.
@@ -437,6 +442,14 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 			// selection; inherit mode uses every globally-enabled tool).
 			effectiveTools := selectEffectiveTools(s.Tools, installed)
 
+			if !s.ForceBudget {
+				if err := s.checkBudgetBeforeProjection(st, sk.Name, tFiles, effectiveTools); err != nil {
+					s.emit(SkillErrorMsg{Name: sk.Name, Err: err})
+					summary.Failed++
+					continue
+				}
+			}
+
 			var paths []string
 			var toolNames []string
 			toolFailed := false
@@ -604,6 +617,90 @@ func selectEffectiveTools(global []tools.Tool, installed *state.InstalledSkill) 
 		}
 	}
 	return out
+}
+
+func (s *Syncer) checkBudgetBeforeProjection(st *state.State, incomingName string, files []tools.SkillFile, effectiveTools []tools.Tool) error {
+	incomingContent, ok := skillMDContent(files)
+	if !ok {
+		return nil
+	}
+
+	agents := budgetedToolNames(effectiveTools)
+	if len(agents) == 0 {
+		return nil
+	}
+
+	skills, err := budgetSkillsFromStore(st, incomingName, incomingContent)
+	if err != nil {
+		return err
+	}
+	for _, agent := range agents {
+		result := ibudget.CheckBudget(skills, agent)
+		if result.Status != ibudget.StatusRefuse {
+			continue
+		}
+		return fmt.Errorf("%s\nTry removing one kit, or rerun with --force to project anyway.", ibudget.FormatOverflow(result))
+	}
+	return nil
+}
+
+func skillMDContent(files []tools.SkillFile) ([]byte, bool) {
+	for _, file := range files {
+		if file.Path == "SKILL.md" {
+			return file.Content, true
+		}
+	}
+	return nil, false
+}
+
+func budgetedToolNames(toolSet []tools.Tool) []string {
+	seen := map[string]bool{}
+	var agents []string
+	for _, tool := range toolSet {
+		name := tool.Name()
+		if _, ok := ibudget.AgentBudgets[name]; !ok || seen[name] {
+			continue
+		}
+		seen[name] = true
+		agents = append(agents, name)
+	}
+	sort.Strings(agents)
+	return agents
+}
+
+func budgetSkillsFromStore(st *state.State, incomingName string, incomingContent []byte) ([]ibudget.Skill, error) {
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve store dir: %w", err)
+	}
+
+	names := make([]string, 0, len(st.Installed)+1)
+	seen := map[string]bool{}
+	for name, installed := range st.Installed {
+		if installed.Kind == state.KindPackage {
+			continue
+		}
+		names = append(names, name)
+		seen[name] = true
+	}
+	if !seen[incomingName] {
+		names = append(names, incomingName)
+	}
+	sort.Strings(names)
+
+	skills := make([]ibudget.Skill, 0, len(names))
+	for _, name := range names {
+		if name == incomingName {
+			skills = append(skills, ibudget.Skill{Name: name, Content: incomingContent})
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(storeDir, name, "SKILL.md"))
+		if err != nil {
+			continue
+		}
+		skills = append(skills, ibudget.Skill{Name: name, Content: content})
+	}
+	return skills, nil
 }
 
 func mergeProjection(installed *state.InstalledSkill, projectRoot string, toolNames []string) []state.ProjectionEntry {

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -636,10 +636,12 @@ func (s *Syncer) checkBudgetBeforeProjection(st *state.State, incomingName strin
 			return err
 		}
 		result := ibudget.CheckBudget(skills, agent)
-		if result.Status != ibudget.StatusRefuse {
-			continue
+		switch result.Status {
+		case ibudget.StatusRefuse:
+			return fmt.Errorf("%s\nTry removing one kit, or rerun with --force to project anyway.", ibudget.FormatOverflow(result))
+		case ibudget.StatusWarn:
+			s.emit(BudgetWarningMsg{Agent: agent, Message: ibudget.FormatResult(result)})
 		}
-		return fmt.Errorf("%s\nTry removing one kit, or rerun with --force to project anyway.", ibudget.FormatOverflow(result))
 	}
 	return nil
 }

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -603,6 +603,59 @@ func TestRunWithDiff_BudgetUsesCurrentProjectProjection(t *testing.T) {
 	}
 }
 
+func TestRunWithDiff_EmitsBudgetWarningForPostChangeProjection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		t.Fatalf("store dir: %v", err)
+	}
+	projectRoot := t.TempDir()
+	writeStoredSkill(t, storeDir, "existing", strings.Repeat("x", 3600))
+
+	var events []any
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{
+			files: []tools.SkillFile{{Path: "SKILL.md", Content: skillContent("incoming", strings.Repeat("y", 220))}},
+		},
+		Tools:       []tools.Tool{tools.CodexTool{}},
+		ProjectRoot: projectRoot,
+		Emit:        func(msg any) { events = append(events, msg) },
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"existing": {
+			Tools: []string{"codex"},
+			Projections: []state.ProjectionEntry{{
+				Project: projectRoot,
+				Tools:   []string{"codex"},
+			}},
+		},
+	}}
+	statuses := []sync.SkillStatus{{
+		Name:   "incoming",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "incoming", Source: "github:acme/skills@main"},
+	}}
+
+	if err := syncer.RunWithDiff(context.Background(), "acme/skills", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+
+	for _, event := range events {
+		if msg, ok := event.(sync.BudgetWarningMsg); ok {
+			if msg.Agent != "codex" {
+				t.Fatalf("Agent = %q, want codex", msg.Agent)
+			}
+			if !strings.Contains(msg.Message, "Codex budget") {
+				t.Fatalf("Message = %q, want Codex budget warning", msg.Message)
+			}
+			return
+		}
+	}
+	t.Fatal("expected BudgetWarningMsg")
+}
+
 // TestApply_RealDirectoryAtProjectionPath verifies that sync emits an actionable
 // SkillErrorMsg and preserves the real directory when a non-scribe directory
 // exists at the tool projection path.

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -555,6 +555,54 @@ func TestApply_PackageOutdated_NoUpdateCmd(t *testing.T) {
 	}
 }
 
+func TestRunWithDiff_BudgetUsesCurrentProjectProjection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		t.Fatalf("store dir: %v", err)
+	}
+	writeStoredSkill(t, storeDir, "unrelated", strings.Repeat("x", 6000))
+
+	projectRoot := t.TempDir()
+	var events []any
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{
+			files: []tools.SkillFile{{Path: "SKILL.md", Content: skillContent("incoming", "small")}},
+		},
+		Tools:       []tools.Tool{tools.CodexTool{}},
+		ProjectRoot: projectRoot,
+		Emit:        func(msg any) { events = append(events, msg) },
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"unrelated": {
+			Tools: []string{"codex"},
+			Projections: []state.ProjectionEntry{{
+				Project: t.TempDir(),
+				Tools:   []string{"codex"},
+			}},
+		},
+	}}
+	statuses := []sync.SkillStatus{{
+		Name:   "incoming",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "incoming", Source: "github:acme/skills@main"},
+	}}
+
+	if err := syncer.RunWithDiff(context.Background(), "acme/skills", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+	for _, event := range events {
+		if msg, ok := event.(sync.SkillErrorMsg); ok {
+			t.Fatalf("unexpected SkillErrorMsg: %v", msg.Err)
+		}
+	}
+	if _, ok := st.Installed["incoming"]; !ok {
+		t.Fatal("incoming skill was not installed")
+	}
+}
+
 // TestApply_RealDirectoryAtProjectionPath verifies that sync emits an actionable
 // SkillErrorMsg and preserves the real directory when a non-scribe directory
 // exists at the tool projection path.
@@ -624,4 +672,22 @@ func TestApply_RealDirectoryAtProjectionPath(t *testing.T) {
 	if _, ok := st.Installed["qa"]; ok {
 		t.Error("skill should not be in state when install failed")
 	}
+}
+
+func writeStoredSkill(t *testing.T, storeDir, name, description string) {
+	t.Helper()
+	skillDir := filepath.Join(storeDir, name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir stored skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), skillContent(name, description), 0o644); err != nil {
+		t.Fatalf("write stored skill: %v", err)
+	}
+}
+
+func skillContent(name, description string) []byte {
+	return []byte("---\n" +
+		"name: " + name + "\n" +
+		"description: " + description + "\n" +
+		"---\n")
 }

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -24,6 +24,7 @@ type Bag struct {
 	InitialQuery   string // initial search/filter text for TUI surfaces
 	TrustAllFlag   bool   // --trust-all: approve all package commands without prompting
 	InstallAllFlag bool   // --all: install all available skills without prompting
+	ForceBudget    bool   // --force: allow projection over agent description-byte budgets
 	LazyGitHub     bool   // skip eager GitHub client/provider setup for local-only flows
 	Factory        *app.Factory
 

--- a/internal/workflow/formatter.go
+++ b/internal/workflow/formatter.go
@@ -22,6 +22,7 @@ type Formatter interface {
 	OnSkillSkipped(name string, status sync.SkillStatus)
 	OnSkillSkippedByDenyList(name, registry string)
 	OnSkillError(name string, err error)
+	OnBudgetWarning(agent, message string)
 	OnSyncComplete(summary sync.SyncCompleteMsg)
 	OnReconcileConflict(name string, conflict state.ProjectionConflict)
 	OnReconcileComplete(summary sync.ReconcileCompleteMsg)

--- a/internal/workflow/formatter_json.go
+++ b/internal/workflow/formatter_json.go
@@ -135,6 +135,8 @@ func (f *jsonFormatter) OnSkillError(name string, err error) {
 	})
 }
 
+func (f *jsonFormatter) OnBudgetWarning(_, _ string) {}
+
 func (f *jsonFormatter) OnSyncComplete(summary sync.SyncCompleteMsg) {
 	f.summary.Installed += summary.Installed
 	f.summary.Updated += summary.Updated

--- a/internal/workflow/formatter_text.go
+++ b/internal/workflow/formatter_text.go
@@ -64,6 +64,10 @@ func (f *textFormatter) OnSkillError(name string, err error) {
 	fmt.Fprintf(f.errOut, "  %-20s error: %v\n", name, err)
 }
 
+func (f *textFormatter) OnBudgetWarning(_, message string) {
+	fmt.Fprintf(f.errOut, "warning: %s\n", message)
+}
+
 func (f *textFormatter) OnSyncComplete(summary sync.SyncCompleteMsg) {
 	f.totalSummary.Installed += summary.Installed
 	f.totalSummary.Updated += summary.Updated

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -310,6 +310,8 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 				b.Formatter.OnSkillInstalled(m.Name, m.Updated)
 			case sync.SkillErrorMsg:
 				b.Formatter.OnSkillError(m.Name, m.Err)
+			case sync.BudgetWarningMsg:
+				b.Formatter.OnBudgetWarning(m.Agent, m.Message)
 			case sync.SkillAdoptionNeededMsg:
 				// Handled implicitly by the SkillErrorMsg that follows it.
 			case sync.LegacyFormatMsg:

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -288,6 +288,7 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 		Tools:       b.Tools,
 		Executor:    &sync.ShellExecutor{},
 		TrustAll:    b.TrustAllFlag,
+		ForceBudget: b.ForceBudget,
 		SkillFilter: b.SkillFilter,
 		ProjectRoot: b.ProjectRoot,
 		// Skip missing skills when no explicit filter/--all: scribe sync only updates

--- a/internal/workflow/sync_adopt_test.go
+++ b/internal/workflow/sync_adopt_test.go
@@ -49,6 +49,7 @@ func (r *adoptRecorder) OnSkillInstalled(_ string, _ bool)                      
 func (r *adoptRecorder) OnSkillSkipped(_ string, _ isync.SkillStatus)             {}
 func (r *adoptRecorder) OnSkillSkippedByDenyList(_, _ string)                     {}
 func (r *adoptRecorder) OnSkillError(_ string, _ error)                           {}
+func (r *adoptRecorder) OnBudgetWarning(_, _ string)                              {}
 func (r *adoptRecorder) OnSyncComplete(_ isync.SyncCompleteMsg)                   {}
 func (r *adoptRecorder) OnReconcileConflict(_ string, _ state.ProjectionConflict) {}
 func (r *adoptRecorder) OnReconcileComplete(_ isync.ReconcileCompleteMsg)         {}

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "9fd2f7dd",
+      "content_hash": "b6daf92c",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe-agent",


### PR DESCRIPTION
Summary:
- Add internal/budget estimator and per-agent budget checks for Codex/Claude.
- Add scribe show output for resolved skill budget utilization.
- Refuse over-budget projections in sync/install/add unless --force is passed.
- Cover UTF-8, empty descriptions, multi-paragraph bodies, thresholds, and overflow breakdowns.

Test plan:
- go test ./internal/budget
- go test ./cmd ./internal/sync ./internal/workflow (fails only existing TestListEnvelopeDataMatchesLegacyGolden embedded scribe-agent hash mismatch: want 9fd2f7dd, got b6daf92c)
- go test ./... (same existing cmd golden mismatch)

Links:
- Fixes #114
- Solo todo #371