### PR TITLE
feat(migrate): scribe migrate global-to-projects (todo #379)

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -28,16 +28,19 @@ var (
 )
 
 func newMigrateCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "migrate [owner/repo]",
-		Short: "Convert a scribe.toml registry to scribe.yaml",
-		Long: `Fetches the existing scribe.toml from a registry, converts it to the
-new scribe.yaml format, and pushes the change as a single commit
-(deleting scribe.toml and creating scribe.yaml).`,
-		Args:       cobra.MaximumNArgs(1),
-		RunE:       runMigrate,
-		Deprecated: "use 'scribe registry migrate' instead",
+		Short: "Run migration commands",
+		Long: `Run Scribe migrations.
+
+The legacy "scribe migrate [owner/repo]" registry migration is still accepted
+for compatibility; prefer "scribe registry migrate [owner/repo]" for registry
+manifest migrations.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runMigrate,
 	}
+	cmd.AddCommand(newGlobalToProjectsCommand())
+	return cmd
 }
 
 func runMigrate(cmd *cobra.Command, args []string) error {

--- a/cmd/migrate_global.go
+++ b/cmd/migrate_global.go
@@ -19,6 +19,10 @@ type projectSelector interface {
 
 type huhProjectSelector struct{}
 
+var globalToProjectsIsTerminal = func() bool {
+	return isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
+}
+
 func newGlobalToProjectsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "global-to-projects",
@@ -73,8 +77,7 @@ func runGlobalToProjectsWithSelector(cmd *cobra.Command, _ []string, selector pr
 	}
 
 	selected := projectFlags
-	isTTY := isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
-	if len(selected) == 0 && !jsonFlag && isTTY {
+	if len(selected) == 0 && !jsonFlag && globalToProjectsIsTerminal() {
 		selected, err = selector.SelectProjects(discovery.Projects)
 		if err != nil {
 			return err

--- a/cmd/migrate_global.go
+++ b/cmd/migrate_global.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"charm.land/huh/v2"
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/cli/envelope"
+	"github.com/Naoray/scribe/internal/projectmigrate"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+type projectSelector interface {
+	SelectProjects([]projectmigrate.ProjectCandidate) ([]string, error)
+}
+
+type huhProjectSelector struct{}
+
+func newGlobalToProjectsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "global-to-projects",
+		Short: "Move legacy global skill links into project .scribe.yaml files",
+		Long: `Detect Scribe-managed symlinks in legacy global tool skill directories,
+let the user choose projects that should keep that skill set, write .scribe.yaml
+files for those projects, and remove the global symlinks.`,
+		Args: cobra.NoArgs,
+		RunE: runGlobalToProjects,
+	}
+	cmd.Flags().Bool("dry-run", false, "Preview migration without writing .scribe.yaml or removing global symlinks")
+	cmd.Flags().StringArray("project", nil, "Project directory to keep the current global skill set (repeatable; skips prompt)")
+	return markJSONSupported(cmd)
+}
+
+func runGlobalToProjects(cmd *cobra.Command, args []string) error {
+	return runGlobalToProjectsWithSelector(cmd, args, huhProjectSelector{})
+}
+
+func runGlobalToProjectsWithSelector(cmd *cobra.Command, _ []string, selector projectSelector) error {
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	jsonFlag := jsonFlagPassed(cmd)
+	projectFlags, _ := cmd.Flags().GetStringArray("project")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("home dir: %w", err)
+	}
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		return fmt.Errorf("store dir: %w", err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getwd: %w", err)
+	}
+
+	factory := commandFactory()
+	st, err := factory.State()
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
+
+	discovery, err := projectmigrate.Discover(projectmigrate.DiscoveryOptions{
+		HomeDir:     home,
+		StoreDir:    storeDir,
+		SearchRoots: []string{wd},
+		State:       st,
+	})
+	if err != nil {
+		return fmt.Errorf("discover migration candidates: %w", err)
+	}
+
+	selected := projectFlags
+	isTTY := isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
+	if len(selected) == 0 && !jsonFlag && isTTY {
+		selected, err = selector.SelectProjects(discovery.Projects)
+		if err != nil {
+			return err
+		}
+	}
+	if len(selected) == 0 && (jsonFlag || dryRun) {
+		selected = projectPaths(discovery.Projects)
+	}
+	if len(selected) == 0 && len(discovery.GlobalSymlinks) > 0 {
+		return fmt.Errorf("no projects selected")
+	}
+
+	plan, err := projectmigrate.BuildPlan(discovery, selected, dryRun)
+	if err != nil {
+		return err
+	}
+	result, err := projectmigrate.Apply(plan, discovery.Projects)
+	if err != nil {
+		return err
+	}
+
+	if jsonFlag {
+		status := envelope.StatusOK
+		if dryRun || result.WroteProjectFiles == 0 && result.RemovedGlobalLinks == 0 {
+			status = envelope.StatusNoChange
+		}
+		return renderMutatorEnvelope(cmd, result, status)
+	}
+
+	printGlobalToProjectsResult(cmd, result)
+	return nil
+}
+
+func (huhProjectSelector) SelectProjects(projects []projectmigrate.ProjectCandidate) ([]string, error) {
+	if len(projects) == 0 {
+		return nil, nil
+	}
+	opts := make([]huh.Option[string], len(projects))
+	for i, project := range projects {
+		opts[i] = huh.NewOption(project.Path, project.Path).Selected(true)
+	}
+
+	var selected []string
+	err := huh.NewMultiSelect[string]().
+		Title("Pick projects that should keep the current global skill set").
+		Options(opts...).
+		Value(&selected).
+		Run()
+	return selected, err
+}
+
+func projectPaths(projects []projectmigrate.ProjectCandidate) []string {
+	paths := make([]string, 0, len(projects))
+	for _, project := range projects {
+		paths = append(paths, project.Path)
+	}
+	return paths
+}
+
+func printGlobalToProjectsResult(cmd *cobra.Command, result projectmigrate.MigrationResult) {
+	out := cmd.OutOrStdout()
+	prefix := ""
+	if result.DryRun {
+		prefix = "Dry run: "
+	}
+	fmt.Fprintf(out, "%sfound %d globally projected skill link(s) for %d skill(s)\n", prefix, result.FoundGlobalLinks, result.FoundSkills)
+	if len(result.ProjectFiles) > 0 {
+		fmt.Fprintf(out, "%swrote .scribe.yaml in %d project(s)\n", prefix, result.WroteProjectFiles)
+		for _, change := range result.ProjectFiles {
+			action := "unchanged"
+			if change.Changed {
+				action = "update"
+			}
+			fmt.Fprintf(out, "  %s %s (%d skill%s)\n", action, change.Project, len(change.Skills), plural(len(change.Skills)))
+		}
+	}
+	fmt.Fprintf(out, "%sremoved %d global symlink(s)\n", prefix, result.RemovedGlobalLinks)
+	if result.SkippedGlobalLinks > 0 {
+		fmt.Fprintf(out, "skipped %d global path(s) that were already gone or no longer symlinks\n", result.SkippedGlobalLinks)
+	}
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/cmd/migrate_global.go
+++ b/cmd/migrate_global.go
@@ -142,7 +142,11 @@ func printGlobalToProjectsResult(cmd *cobra.Command, result projectmigrate.Migra
 	}
 	fmt.Fprintf(out, "%sfound %d globally projected skill link(s) for %d skill(s)\n", prefix, result.FoundGlobalLinks, result.FoundSkills)
 	if len(result.ProjectFiles) > 0 {
-		fmt.Fprintf(out, "%swrote .scribe.yaml in %d project(s)\n", prefix, result.WroteProjectFiles)
+		projectWrites := result.WroteProjectFiles
+		if result.DryRun {
+			projectWrites = result.PlannedProjectFileWrites
+		}
+		fmt.Fprintf(out, "%swrote .scribe.yaml in %d project(s)\n", prefix, projectWrites)
 		for _, change := range result.ProjectFiles {
 			action := "unchanged"
 			if change.Changed {
@@ -151,7 +155,11 @@ func printGlobalToProjectsResult(cmd *cobra.Command, result projectmigrate.Migra
 			fmt.Fprintf(out, "  %s %s (%d skill%s)\n", action, change.Project, len(change.Skills), plural(len(change.Skills)))
 		}
 	}
-	fmt.Fprintf(out, "%sremoved %d global symlink(s)\n", prefix, result.RemovedGlobalLinks)
+	linkRemovals := result.RemovedGlobalLinks
+	if result.DryRun {
+		linkRemovals = result.PlannedGlobalLinkRemovals
+	}
+	fmt.Fprintf(out, "%sremoved %d global symlink(s)\n", prefix, linkRemovals)
 	if result.SkippedGlobalLinks > 0 {
 		fmt.Fprintf(out, "skipped %d global path(s) that were already gone or no longer symlinks\n", result.SkippedGlobalLinks)
 	}

--- a/cmd/migrate_global_test.go
+++ b/cmd/migrate_global_test.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/projectfile"
+	"github.com/Naoray/scribe/internal/projectmigrate"
+)
+
+type fakeProjectSelector struct {
+	selected []string
+}
+
+func (f fakeProjectSelector) SelectProjects(_ []projectmigrate.ProjectCandidate) ([]string, error) {
+	return f.selected, nil
+}
+
+func TestGlobalToProjectsJSONDryRunDoesNotMutateHome(t *testing.T) {
+	home, project, link := setupGlobalToProjectsFixture(t, "claude", "tdd")
+	t.Setenv("HOME", home)
+	t.Chdir(project)
+
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"--json", "migrate", "global-to-projects", "--dry-run", "--project", project})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	var env struct {
+		Status string `json:"status"`
+		Data   struct {
+			DryRun                    bool `json:"dry_run"`
+			PlannedProjectFileWrites  int  `json:"planned_project_file_writes"`
+			PlannedGlobalLinkRemovals int  `json:"planned_global_link_removals"`
+			WroteProjectFiles         int  `json:"wrote_project_files"`
+			RemovedGlobalLinks        int  `json:"removed_global_links"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal stdout: %v\n%s", err, stdout.String())
+	}
+	if env.Status != "no_change" || !env.Data.DryRun {
+		t.Fatalf("env = %#v, want no_change dry-run", env)
+	}
+	if env.Data.PlannedProjectFileWrites != 1 || env.Data.PlannedGlobalLinkRemovals != 1 {
+		t.Fatalf("planned counts = %#v, want one write/removal", env.Data)
+	}
+	if env.Data.WroteProjectFiles != 0 || env.Data.RemovedGlobalLinks != 0 {
+		t.Fatalf("applied counts = %#v, want dry-run no mutation", env.Data)
+	}
+	if _, err := os.Lstat(link); err != nil {
+		t.Fatalf("global symlink should remain after dry-run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(project, projectfile.Filename)); !os.IsNotExist(err) {
+		t.Fatalf(".scribe.yaml should not exist after dry-run, stat err = %v", err)
+	}
+}
+
+func TestGlobalToProjectsInteractiveSelectorAppliesMigration(t *testing.T) {
+	home, project, link := setupGlobalToProjectsFixture(t, "codex", "review")
+	t.Setenv("HOME", home)
+	t.Chdir(project)
+
+	oldTerminal := globalToProjectsIsTerminal
+	globalToProjectsIsTerminal = func() bool { return true }
+	t.Cleanup(func() { globalToProjectsIsTerminal = oldTerminal })
+
+	cmd := newGlobalToProjectsCommand()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if err := runGlobalToProjectsWithSelector(cmd, nil, fakeProjectSelector{selected: []string{project}}); err != nil {
+		t.Fatalf("runGlobalToProjectsWithSelector() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatalf("global symlink still exists or unexpected stat error: %v", err)
+	}
+	pf, err := projectfile.Load(filepath.Join(project, projectfile.Filename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(pf.Add, []string{"review"}) {
+		t.Fatalf("project add = %v, want [review]", pf.Add)
+	}
+}
+
+func setupGlobalToProjectsFixture(t *testing.T, tool, skill string) (home, project, link string) {
+	t.Helper()
+	tmp := t.TempDir()
+	home = filepath.Join(tmp, "home")
+	project = filepath.Join(tmp, "project")
+	storeSkill := filepath.Join(home, ".scribe", "skills", skill)
+	link = filepath.Join(home, "."+tool, "skills", skill)
+	for _, dir := range []string{project, storeSkill, filepath.Dir(link)} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(storeSkill, "SKILL.md"), []byte("---\nname: "+skill+"\ndescription: Test\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(storeSkill, link); err != nil {
+		t.Fatal(err)
+	}
+	return home, project, link
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -199,10 +199,7 @@ func newRootCmd() *cobra.Command {
 	aliasConnect.Deprecated = "use 'scribe registry connect' instead"
 	cmd.AddCommand(aliasConnect)
 
-	aliasMigrate := newMigrateCommand()
-	aliasMigrate.Hidden = true
-	aliasMigrate.Deprecated = "use 'scribe registry migrate' instead"
-	cmd.AddCommand(aliasMigrate)
+	cmd.AddCommand(newMigrateCommand())
 
 	cmd.AddCommand(
 		newListCommand(),

--- a/internal/projectmigrate/discovery.go
+++ b/internal/projectmigrate/discovery.go
@@ -126,6 +126,9 @@ func DiscoverGlobalSymlinks(homeDir, storeDir string, toolNames []string) ([]Glo
 			if !pathWithin(target, storeDir) {
 				continue
 			}
+			if isGlobalSkillException(entry.Name()) {
+				continue
+			}
 			links = append(links, GlobalSymlink{
 				Tool:          tool,
 				Skill:         entry.Name(),

--- a/internal/projectmigrate/discovery.go
+++ b/internal/projectmigrate/discovery.go
@@ -1,0 +1,253 @@
+package projectmigrate
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Naoray/scribe/internal/projectfile"
+	"github.com/Naoray/scribe/internal/state"
+)
+
+// GlobalSymlink is a Scribe-managed skill link in a tool's legacy global
+// skills directory.
+type GlobalSymlink struct {
+	Tool          string `json:"tool"`
+	Skill         string `json:"skill"`
+	Path          string `json:"path"`
+	CanonicalPath string `json:"canonical_path"`
+}
+
+// ProjectCandidate is a directory that can receive a project-local .scribe.yaml.
+type ProjectCandidate struct {
+	Path   string `json:"path"`
+	Source string `json:"source"`
+}
+
+// DiscoveryOptions configures project migration discovery.
+type DiscoveryOptions struct {
+	HomeDir     string
+	StoreDir    string
+	ToolNames   []string
+	SearchRoots []string
+	State       *state.State
+}
+
+// Discovery is the pure discovery result used by both interactive and JSON modes.
+type Discovery struct {
+	GlobalSymlinks []GlobalSymlink    `json:"global_symlinks"`
+	Projects       []ProjectCandidate `json:"projects"`
+	Skills         []string           `json:"skills"`
+}
+
+// DefaultFilesystemToolNames are tools with predictable ~/.<tool>/skills
+// directories. Gemini is intentionally absent because its CLI owns storage.
+func DefaultFilesystemToolNames() []string {
+	return []string{"claude", "cursor", "codex"}
+}
+
+// Discover finds legacy global symlinks and candidate project directories.
+func Discover(opts DiscoveryOptions) (Discovery, error) {
+	toolNames := opts.ToolNames
+	if len(toolNames) == 0 {
+		toolNames = DefaultFilesystemToolNames()
+	}
+
+	links, err := DiscoverGlobalSymlinks(opts.HomeDir, opts.StoreDir, toolNames)
+	if err != nil {
+		return Discovery{}, err
+	}
+
+	projects, err := DiscoverCandidateProjects(opts.SearchRoots, opts.State)
+	if err != nil {
+		return Discovery{}, err
+	}
+
+	return Discovery{
+		GlobalSymlinks: links,
+		Projects:       projects,
+		Skills:         uniqueSkills(links),
+	}, nil
+}
+
+// DiscoverGlobalSymlinks scans ~/.<tool>/skills for symlinks pointing into the
+// canonical Scribe skill store.
+func DiscoverGlobalSymlinks(homeDir, storeDir string, toolNames []string) ([]GlobalSymlink, error) {
+	if homeDir == "" {
+		return nil, errors.New("home dir is required")
+	}
+	if storeDir == "" {
+		return nil, errors.New("store dir is required")
+	}
+
+	storeDir, err := filepath.Abs(storeDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve store dir: %w", err)
+	}
+
+	var links []GlobalSymlink
+	for _, tool := range toolNames {
+		if tool == "" {
+			continue
+		}
+		skillsDir := filepath.Join(homeDir, "."+tool, "skills")
+		entries, err := os.ReadDir(skillsDir)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read %s skills dir: %w", tool, err)
+		}
+
+		for _, entry := range entries {
+			linkPath := filepath.Join(skillsDir, entry.Name())
+			info, err := os.Lstat(linkPath)
+			if err != nil {
+				return nil, fmt.Errorf("stat global skill link: %w", err)
+			}
+			if info.Mode()&os.ModeSymlink == 0 {
+				continue
+			}
+			target, err := os.Readlink(linkPath)
+			if err != nil {
+				return nil, fmt.Errorf("read global skill link: %w", err)
+			}
+			if !filepath.IsAbs(target) {
+				target = filepath.Join(filepath.Dir(linkPath), target)
+			}
+			target, err = filepath.Abs(target)
+			if err != nil {
+				return nil, fmt.Errorf("resolve global skill target: %w", err)
+			}
+			if !pathWithin(target, storeDir) {
+				continue
+			}
+			links = append(links, GlobalSymlink{
+				Tool:          tool,
+				Skill:         entry.Name(),
+				Path:          linkPath,
+				CanonicalPath: target,
+			})
+		}
+	}
+
+	sort.Slice(links, func(i, j int) bool {
+		if links[i].Tool != links[j].Tool {
+			return links[i].Tool < links[j].Tool
+		}
+		return links[i].Skill < links[j].Skill
+	})
+	return links, nil
+}
+
+// DiscoverCandidateProjects combines known state projection projects with
+// search roots containing .scribe.yaml. If a search root has no nested project
+// file, the root itself is still a candidate.
+func DiscoverCandidateProjects(searchRoots []string, st *state.State) ([]ProjectCandidate, error) {
+	candidates := map[string]ProjectCandidate{}
+
+	for _, root := range searchRoots {
+		if root == "" {
+			continue
+		}
+		abs, err := filepath.Abs(root)
+		if err != nil {
+			return nil, fmt.Errorf("resolve project search root: %w", err)
+		}
+		info, err := os.Stat(abs)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("stat project search root: %w", err)
+		}
+		if !info.IsDir() {
+			abs = filepath.Dir(abs)
+		}
+
+		foundInRoot := false
+		err = filepath.WalkDir(abs, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() && path != abs && shouldSkipProjectWalkDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			if d.IsDir() || d.Name() != projectfile.Filename {
+				return nil
+			}
+			foundInRoot = true
+			dir := filepath.Dir(path)
+			candidates[dir] = ProjectCandidate{Path: dir, Source: ".scribe.yaml"}
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("scan project candidates: %w", err)
+		}
+		if !foundInRoot {
+			candidates[abs] = ProjectCandidate{Path: abs, Source: "search_root"}
+		}
+	}
+
+	if st != nil {
+		for _, skill := range st.Installed {
+			for _, projection := range skill.Projections {
+				if projection.Project == "" {
+					continue
+				}
+				abs, err := filepath.Abs(projection.Project)
+				if err != nil {
+					return nil, fmt.Errorf("resolve projected project: %w", err)
+				}
+				if _, ok := candidates[abs]; !ok {
+					candidates[abs] = ProjectCandidate{Path: abs, Source: "state"}
+				}
+			}
+		}
+	}
+
+	out := make([]ProjectCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		out = append(out, candidate)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Path < out[j].Path
+	})
+	return out, nil
+}
+
+func pathWithin(path, root string) bool {
+	path = filepath.Clean(path)
+	root = filepath.Clean(root)
+	if path == root {
+		return true
+	}
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != "." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".."
+}
+
+func shouldSkipProjectWalkDir(name string) bool {
+	switch name {
+	case ".git", ".hg", ".svn", ".anvil", "node_modules", "vendor":
+		return true
+	default:
+		return false
+	}
+}
+
+func uniqueSkills(links []GlobalSymlink) []string {
+	seen := map[string]bool{}
+	for _, link := range links {
+		seen[link.Skill] = true
+	}
+	skills := make([]string, 0, len(seen))
+	for skill := range seen {
+		skills = append(skills, skill)
+	}
+	sort.Strings(skills)
+	return skills
+}

--- a/internal/projectmigrate/discovery_test.go
+++ b/internal/projectmigrate/discovery_test.go
@@ -1,0 +1,110 @@
+package projectmigrate
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/state"
+)
+
+func TestDiscoverGlobalSymlinksFindsStoreLinksOnly(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	store := filepath.Join(home, ".scribe", "skills")
+	mustMkdir(t, filepath.Join(store, "tdd"))
+	mustMkdir(t, filepath.Join(store, "review"))
+	mustMkdir(t, filepath.Join(home, ".claude", "skills"))
+	mustMkdir(t, filepath.Join(home, ".codex", "skills"))
+
+	mustSymlink(t, filepath.Join(store, "tdd"), filepath.Join(home, ".claude", "skills", "tdd"))
+	mustSymlink(t, filepath.Join(store, "review"), filepath.Join(home, ".codex", "skills", "review"))
+	mustSymlink(t, filepath.Join(tmp, "elsewhere"), filepath.Join(home, ".claude", "skills", "external"))
+	if err := os.WriteFile(filepath.Join(home, ".codex", "skills", "real"), []byte("not a symlink"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	links, err := DiscoverGlobalSymlinks(home, store, []string{"claude", "codex"})
+	if err != nil {
+		t.Fatalf("DiscoverGlobalSymlinks() error = %v", err)
+	}
+
+	got := []string{}
+	for _, link := range links {
+		got = append(got, link.Tool+":"+link.Skill)
+		if link.CanonicalPath == "" || link.Path == "" {
+			t.Fatalf("link paths should be populated: %#v", link)
+		}
+	}
+	want := []string{"claude:tdd", "codex:review"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("links = %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCandidateProjectsCombinesSearchRootsAndState(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "workspace")
+	app := filepath.Join(root, "app")
+	nested := filepath.Join(root, "nested")
+	fromState := filepath.Join(tmp, "from-state")
+	mustMkdir(t, app)
+	mustMkdir(t, nested)
+	mustMkdir(t, fromState)
+	if err := os.WriteFile(filepath.Join(app, ".scribe.yaml"), []byte("add:\n  - tdd\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, ".scribe.yaml"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	st := &state.State{
+		Installed: map[string]state.InstalledSkill{
+			"tdd": {
+				Projections: []state.ProjectionEntry{{Project: fromState, Tools: []string{"claude"}}},
+			},
+		},
+	}
+
+	projects, err := DiscoverCandidateProjects([]string{root}, st)
+	if err != nil {
+		t.Fatalf("DiscoverCandidateProjects() error = %v", err)
+	}
+
+	got := []string{}
+	for _, project := range projects {
+		got = append(got, project.Path)
+	}
+	want := []string{fromState, app, nested}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("projects = %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCandidateProjectsIncludesEmptySearchRoot(t *testing.T) {
+	root := t.TempDir()
+
+	projects, err := DiscoverCandidateProjects([]string{root}, nil)
+	if err != nil {
+		t.Fatalf("DiscoverCandidateProjects() error = %v", err)
+	}
+
+	if len(projects) != 1 || projects[0].Path != root || projects[0].Source != "search_root" {
+		t.Fatalf("projects = %#v, want search root candidate", projects)
+	}
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustSymlink(t *testing.T, oldname, newname string) {
+	t.Helper()
+	if err := os.Symlink(oldname, newname); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/projectmigrate/exceptions.go
+++ b/internal/projectmigrate/exceptions.go
@@ -1,0 +1,10 @@
+package projectmigrate
+
+var globalSkillExceptions = map[string]struct{}{
+	"scribe-agent": {},
+}
+
+func isGlobalSkillException(skill string) bool {
+	_, ok := globalSkillExceptions[skill]
+	return ok
+}

--- a/internal/projectmigrate/migrate.go
+++ b/internal/projectmigrate/migrate.go
@@ -32,17 +32,19 @@ type MigrationPlan struct {
 
 // MigrationResult summarizes applied work.
 type MigrationResult struct {
-	DryRun             bool               `json:"dry_run"`
-	FoundGlobalLinks   int                `json:"found_global_links"`
-	FoundSkills        int                `json:"found_skills"`
-	SelectedProjects   int                `json:"selected_projects"`
-	WroteProjectFiles  int                `json:"wrote_project_files"`
-	RemovedGlobalLinks int                `json:"removed_global_links"`
-	SkippedGlobalLinks int                `json:"skipped_global_links"`
-	ProjectFiles       []ProjectChange    `json:"project_files"`
-	RemovedLinks       []GlobalSymlink    `json:"removed_links"`
-	SkippedLinks       []GlobalSymlink    `json:"skipped_links,omitempty"`
-	CandidateProjects  []ProjectCandidate `json:"candidate_projects"`
+	DryRun                    bool               `json:"dry_run"`
+	FoundGlobalLinks          int                `json:"found_global_links"`
+	FoundSkills               int                `json:"found_skills"`
+	SelectedProjects          int                `json:"selected_projects"`
+	PlannedProjectFileWrites  int                `json:"planned_project_file_writes"`
+	PlannedGlobalLinkRemovals int                `json:"planned_global_link_removals"`
+	WroteProjectFiles         int                `json:"wrote_project_files"`
+	RemovedGlobalLinks        int                `json:"removed_global_links"`
+	SkippedGlobalLinks        int                `json:"skipped_global_links"`
+	ProjectFiles              []ProjectChange    `json:"project_files"`
+	RemovedLinks              []GlobalSymlink    `json:"removed_links"`
+	SkippedLinks              []GlobalSymlink    `json:"skipped_links,omitempty"`
+	CandidateProjects         []ProjectCandidate `json:"candidate_projects"`
 }
 
 // BuildPlan creates an idempotent migration plan for selected projects.
@@ -75,21 +77,21 @@ func BuildPlan(discovery Discovery, selectedProjects []string, dryRun bool) (Mig
 // without mutating the filesystem.
 func Apply(plan MigrationPlan, candidates []ProjectCandidate) (MigrationResult, error) {
 	result := MigrationResult{
-		DryRun:            plan.DryRun,
-		FoundGlobalLinks:  len(plan.GlobalLinks),
-		FoundSkills:       len(uniqueSkills(plan.GlobalLinks)),
-		SelectedProjects:  len(plan.ProjectFiles),
-		ProjectFiles:      append([]ProjectChange(nil), plan.ProjectFiles...),
-		CandidateProjects: append([]ProjectCandidate(nil), candidates...),
+		DryRun:                    plan.DryRun,
+		FoundGlobalLinks:          len(plan.GlobalLinks),
+		FoundSkills:               len(uniqueSkills(plan.GlobalLinks)),
+		SelectedProjects:          len(plan.ProjectFiles),
+		PlannedGlobalLinkRemovals: len(plan.RemovedLinks),
+		ProjectFiles:              append([]ProjectChange(nil), plan.ProjectFiles...),
+		CandidateProjects:         append([]ProjectCandidate(nil), candidates...),
+	}
+	for _, change := range plan.ProjectFiles {
+		if change.Changed {
+			result.PlannedProjectFileWrites++
+		}
 	}
 
 	if plan.DryRun {
-		for _, change := range plan.ProjectFiles {
-			if change.Changed {
-				result.WroteProjectFiles++
-			}
-		}
-		result.RemovedGlobalLinks = len(plan.RemovedLinks)
 		result.RemovedLinks = append([]GlobalSymlink(nil), plan.RemovedLinks...)
 		return result, nil
 	}

--- a/internal/projectmigrate/migrate.go
+++ b/internal/projectmigrate/migrate.go
@@ -1,0 +1,252 @@
+package projectmigrate
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/Naoray/scribe/internal/projectfile"
+)
+
+// ProjectChange describes the .scribe.yaml update for one selected project.
+type ProjectChange struct {
+	Project     string   `json:"project"`
+	File        string   `json:"file"`
+	AddedSkills []string `json:"added_skills"`
+	Skills      []string `json:"skills"`
+	Changed     bool     `json:"changed"`
+}
+
+// MigrationPlan is the complete set of writes/removals for the migration.
+type MigrationPlan struct {
+	DryRun        bool            `json:"dry_run"`
+	GlobalLinks   []GlobalSymlink `json:"global_links"`
+	ProjectFiles  []ProjectChange `json:"project_files"`
+	RemovedLinks  []GlobalSymlink `json:"removed_links"`
+	SkippedLinks  []GlobalSymlink `json:"skipped_links,omitempty"`
+	SelectedPaths []string        `json:"selected_paths"`
+}
+
+// MigrationResult summarizes applied work.
+type MigrationResult struct {
+	DryRun             bool               `json:"dry_run"`
+	FoundGlobalLinks   int                `json:"found_global_links"`
+	FoundSkills        int                `json:"found_skills"`
+	SelectedProjects   int                `json:"selected_projects"`
+	WroteProjectFiles  int                `json:"wrote_project_files"`
+	RemovedGlobalLinks int                `json:"removed_global_links"`
+	SkippedGlobalLinks int                `json:"skipped_global_links"`
+	ProjectFiles       []ProjectChange    `json:"project_files"`
+	RemovedLinks       []GlobalSymlink    `json:"removed_links"`
+	SkippedLinks       []GlobalSymlink    `json:"skipped_links,omitempty"`
+	CandidateProjects  []ProjectCandidate `json:"candidate_projects"`
+}
+
+// BuildPlan creates an idempotent migration plan for selected projects.
+func BuildPlan(discovery Discovery, selectedProjects []string, dryRun bool) (MigrationPlan, error) {
+	skills := discovery.Skills
+	if len(skills) == 0 {
+		return MigrationPlan{DryRun: dryRun, GlobalLinks: discovery.GlobalSymlinks}, nil
+	}
+
+	selected := normalizeSelectedProjects(selectedProjects)
+	projectFiles := make([]ProjectChange, 0, len(selected))
+	for _, project := range selected {
+		change, err := prepareProjectChange(project, skills)
+		if err != nil {
+			return MigrationPlan{}, err
+		}
+		projectFiles = append(projectFiles, change)
+	}
+
+	return MigrationPlan{
+		DryRun:        dryRun,
+		GlobalLinks:   append([]GlobalSymlink(nil), discovery.GlobalSymlinks...),
+		ProjectFiles:  projectFiles,
+		RemovedLinks:  append([]GlobalSymlink(nil), discovery.GlobalSymlinks...),
+		SelectedPaths: selected,
+	}, nil
+}
+
+// Apply executes a migration plan. Dry-run plans return the same summary
+// without mutating the filesystem.
+func Apply(plan MigrationPlan, candidates []ProjectCandidate) (MigrationResult, error) {
+	result := MigrationResult{
+		DryRun:            plan.DryRun,
+		FoundGlobalLinks:  len(plan.GlobalLinks),
+		FoundSkills:       len(uniqueSkills(plan.GlobalLinks)),
+		SelectedProjects:  len(plan.ProjectFiles),
+		ProjectFiles:      append([]ProjectChange(nil), plan.ProjectFiles...),
+		CandidateProjects: append([]ProjectCandidate(nil), candidates...),
+	}
+
+	if plan.DryRun {
+		for _, change := range plan.ProjectFiles {
+			if change.Changed {
+				result.WroteProjectFiles++
+			}
+		}
+		result.RemovedGlobalLinks = len(plan.RemovedLinks)
+		result.RemovedLinks = append([]GlobalSymlink(nil), plan.RemovedLinks...)
+		return result, nil
+	}
+
+	for _, change := range plan.ProjectFiles {
+		if !change.Changed {
+			continue
+		}
+		if err := writeProjectChange(change); err != nil {
+			return result, err
+		}
+		result.WroteProjectFiles++
+	}
+
+	for _, link := range plan.RemovedLinks {
+		removed, err := removeGlobalSymlink(link)
+		if err != nil {
+			return result, err
+		}
+		if removed {
+			result.RemovedGlobalLinks++
+			result.RemovedLinks = append(result.RemovedLinks, link)
+		} else {
+			result.SkippedGlobalLinks++
+			result.SkippedLinks = append(result.SkippedLinks, link)
+		}
+	}
+
+	return result, nil
+}
+
+func prepareProjectChange(project string, skills []string) (ProjectChange, error) {
+	abs, err := filepath.Abs(project)
+	if err != nil {
+		return ProjectChange{}, fmt.Errorf("resolve project path: %w", err)
+	}
+	file := filepath.Join(abs, projectfile.Filename)
+	pf, err := projectfile.Load(file)
+	if err != nil {
+		return ProjectChange{}, err
+	}
+
+	addSet := map[string]bool{}
+	for _, skill := range pf.Add {
+		addSet[skill] = true
+	}
+	removeSet := map[string]bool{}
+	for _, skill := range pf.Remove {
+		removeSet[skill] = true
+	}
+
+	var added []string
+	changed := false
+	for _, skill := range skills {
+		if !addSet[skill] {
+			addSet[skill] = true
+			added = append(added, skill)
+			changed = true
+		}
+		if removeSet[skill] {
+			delete(removeSet, skill)
+			changed = true
+		}
+	}
+
+	nextAdd := sortedKeys(addSet)
+	nextRemove := sortedKeys(removeSet)
+	if !sameStrings(pf.Add, nextAdd) || !sameStrings(pf.Remove, nextRemove) {
+		changed = true
+	}
+
+	return ProjectChange{
+		Project:     abs,
+		File:        file,
+		AddedSkills: added,
+		Skills:      nextAdd,
+		Changed:     changed,
+	}, nil
+}
+
+func writeProjectChange(change ProjectChange) error {
+	pf, err := projectfile.Load(change.File)
+	if err != nil {
+		return err
+	}
+	addSet := map[string]bool{}
+	for _, skill := range pf.Add {
+		addSet[skill] = true
+	}
+	removeSet := map[string]bool{}
+	for _, skill := range pf.Remove {
+		removeSet[skill] = true
+	}
+	for _, skill := range change.Skills {
+		addSet[skill] = true
+		delete(removeSet, skill)
+	}
+	pf.Add = sortedKeys(addSet)
+	pf.Remove = sortedKeys(removeSet)
+	return projectfile.Save(change.File, pf)
+}
+
+func removeGlobalSymlink(link GlobalSymlink) (bool, error) {
+	info, err := os.Lstat(link.Path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("stat global link %s: %w", link.Path, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return false, nil
+	}
+	if err := os.Remove(link.Path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return false, fmt.Errorf("remove global link %s: %w", link.Path, err)
+	}
+	return true, nil
+}
+
+func normalizeSelectedProjects(projects []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, project := range projects {
+		if project == "" {
+			continue
+		}
+		abs, err := filepath.Abs(project)
+		if err != nil {
+			continue
+		}
+		if seen[abs] {
+			continue
+		}
+		seen[abs] = true
+		out = append(out, abs)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedKeys(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for key := range set {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/projectmigrate/migrate_test.go
+++ b/internal/projectmigrate/migrate_test.go
@@ -65,6 +65,67 @@ func TestApplyWritesProjectFileRemovesGlobalSymlinksAndIsIdempotent(t *testing.T
 	}
 }
 
+func TestMigrationPreservesScribeAgentGlobalSymlink(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	store := filepath.Join(home, ".scribe", "skills")
+	project := filepath.Join(tmp, "project")
+	normalLink := filepath.Join(home, ".claude", "skills", "tdd")
+	scribeAgentLink := filepath.Join(home, ".claude", "skills", "scribe-agent")
+
+	mustMkdir(t, filepath.Join(store, "tdd"))
+	mustMkdir(t, filepath.Join(store, "scribe-agent"))
+	mustMkdir(t, filepath.Dir(normalLink))
+	mustMkdir(t, project)
+	mustSymlink(t, filepath.Join(store, "tdd"), normalLink)
+	mustSymlink(t, filepath.Join(store, "scribe-agent"), scribeAgentLink)
+
+	discovery, err := Discover(DiscoveryOptions{
+		HomeDir:     home,
+		StoreDir:    store,
+		ToolNames:   []string{"claude"},
+		SearchRoots: []string{project},
+	})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if !reflect.DeepEqual(discovery.Skills, []string{"tdd"}) {
+		t.Fatalf("discovered skills = %v, want [tdd]", discovery.Skills)
+	}
+
+	plan, err := BuildPlan(discovery, []string{project}, false)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	result, err := Apply(plan, discovery.Projects)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	if result.RemovedGlobalLinks != 1 {
+		t.Fatalf("RemovedGlobalLinks = %d, want 1", result.RemovedGlobalLinks)
+	}
+	if _, err := os.Lstat(normalLink); !os.IsNotExist(err) {
+		t.Fatalf("normal global symlink still exists or unexpected stat error: %v", err)
+	}
+	if _, err := os.Lstat(scribeAgentLink); err != nil {
+		t.Fatalf("scribe-agent global symlink should remain: %v", err)
+	}
+
+	pf, err := projectfile.Load(filepath.Join(project, projectfile.Filename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(pf.Add, []string{"tdd"}) {
+		t.Fatalf("project add = %v, want [tdd]", pf.Add)
+	}
+	for _, link := range plan.RemovedLinks {
+		if link.Skill == "scribe-agent" {
+			t.Fatalf("scribe-agent should not be scheduled for removal: %#v", plan.RemovedLinks)
+		}
+	}
+}
+
 func TestApplyDryRunDoesNotMutateFilesystem(t *testing.T) {
 	tmp := t.TempDir()
 	project := filepath.Join(tmp, "project")

--- a/internal/projectmigrate/migrate_test.go
+++ b/internal/projectmigrate/migrate_test.go
@@ -1,0 +1,106 @@
+package projectmigrate
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/projectfile"
+)
+
+func TestApplyWritesProjectFileRemovesGlobalSymlinksAndIsIdempotent(t *testing.T) {
+	tmp := t.TempDir()
+	project := filepath.Join(tmp, "project")
+	store := filepath.Join(tmp, "home", ".scribe", "skills")
+	link := filepath.Join(tmp, "home", ".claude", "skills", "tdd")
+	mustMkdir(t, filepath.Join(store, "tdd"))
+	mustMkdir(t, filepath.Dir(link))
+	mustMkdir(t, project)
+	mustSymlink(t, filepath.Join(store, "tdd"), link)
+
+	discovery := Discovery{
+		GlobalSymlinks: []GlobalSymlink{{
+			Tool:          "claude",
+			Skill:         "tdd",
+			Path:          link,
+			CanonicalPath: filepath.Join(store, "tdd"),
+		}},
+		Projects: []ProjectCandidate{{Path: project, Source: "search_root"}},
+		Skills:   []string{"tdd"},
+	}
+
+	plan, err := BuildPlan(discovery, []string{project}, false)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	result, err := Apply(plan, discovery.Projects)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if result.WroteProjectFiles != 1 || result.RemovedGlobalLinks != 1 {
+		t.Fatalf("result = %#v, want one write and one removal", result)
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatalf("global symlink still exists or unexpected stat error: %v", err)
+	}
+	pf, err := projectfile.Load(filepath.Join(project, projectfile.Filename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(pf.Add, []string{"tdd"}) {
+		t.Fatalf("project add = %v, want [tdd]", pf.Add)
+	}
+
+	plan, err = BuildPlan(discovery, []string{project}, false)
+	if err != nil {
+		t.Fatalf("BuildPlan() second run error = %v", err)
+	}
+	result, err = Apply(plan, discovery.Projects)
+	if err != nil {
+		t.Fatalf("Apply() second run error = %v", err)
+	}
+	if result.WroteProjectFiles != 0 || result.RemovedGlobalLinks != 0 || result.SkippedGlobalLinks != 1 {
+		t.Fatalf("second result = %#v, want idempotent no-op with skipped link", result)
+	}
+}
+
+func TestApplyDryRunDoesNotMutateFilesystem(t *testing.T) {
+	tmp := t.TempDir()
+	project := filepath.Join(tmp, "project")
+	store := filepath.Join(tmp, "home", ".scribe", "skills")
+	link := filepath.Join(tmp, "home", ".codex", "skills", "review")
+	mustMkdir(t, filepath.Join(store, "review"))
+	mustMkdir(t, filepath.Dir(link))
+	mustMkdir(t, project)
+	mustSymlink(t, filepath.Join(store, "review"), link)
+
+	discovery := Discovery{
+		GlobalSymlinks: []GlobalSymlink{{
+			Tool:          "codex",
+			Skill:         "review",
+			Path:          link,
+			CanonicalPath: filepath.Join(store, "review"),
+		}},
+		Projects: []ProjectCandidate{{Path: project, Source: "search_root"}},
+		Skills:   []string{"review"},
+	}
+
+	plan, err := BuildPlan(discovery, []string{project}, true)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	result, err := Apply(plan, discovery.Projects)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if result.PlannedProjectFileWrites != 1 || result.PlannedGlobalLinkRemovals != 1 {
+		t.Fatalf("dry-run result = %#v, want planned write and removal", result)
+	}
+	if _, err := os.Lstat(link); err != nil {
+		t.Fatalf("global symlink should remain in dry-run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(project, projectfile.Filename)); !os.IsNotExist(err) {
+		t.Fatalf(".scribe.yaml should not exist after dry-run, stat err = %v", err)
+	}
+}

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "9fd2f7dd",
+      "content_hash": "b6daf92c",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe-agent",


### PR DESCRIPTION
## Summary
- Add `scribe migrate global-to-projects` as a top-level migration command.
- Discover legacy global symlinks under predictable `~/.<tool>/skills/` directories and candidate projects from `.scribe.yaml` roots plus state projections.
- Support interactive project selection, `--project` for non-interactive selection, `--dry-run`, and `--json` envelope output.
- Write selected projects’ `.scribe.yaml` `add:` entries idempotently and remove matching legacy global symlinks.

## Test plan
- `go test ./...`

## Links
- Solo todo #379