### PR TITLE
feat(skill): source field for attribution (todo #387, GH #106)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 
 | Command | Flags | Output schema |
 |---|---|---|
-| `scribe add` | --json, --registry, --yes | yes |
+| `scribe add` | --force, --json, --registry, --yes | yes |
 | `scribe adopt` | --dry-run, --json, --verbose, --yes | yes |
 | `scribe browse` | --install, --json, --query, --registry, --yes | no |
 | `scribe config adoption` | --add-path, --json, --mode, --remove-path | no |
@@ -67,8 +67,10 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe doctor` | --fix, --json, --skill | yes |
 | `scribe explain` | --json, --raw | yes |
 | `scribe guide` | --json | yes |
-| `scribe install` | --all, --json, --registry | no |
+| `scribe install` | --all, --force, --json, --registry | no |
 | `scribe list` | --fields, --json, --registry, --remote | yes |
+| `scribe migrate global-to-projects` | --dry-run, --json, --project | no |
+| `scribe migrate` | --json | no |
 | `scribe registry add` | --install, --json, --registry, --yes | no |
 | `scribe registry connect` | --install-all, --json | yes |
 | `scribe registry create` | --json, --owner, --private, --repo, --team | no |
@@ -83,12 +85,13 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe resolve` | --json, --ours, --theirs | no |
 | `scribe restore` | --json | no |
 | `scribe schema` | --all, --json, --markdown | no |
+| `scribe show` | --json | no |
 | `scribe skill edit` | --add, --inherit, --json, --pin, --remove, --tools | no |
 | `scribe skill repair` | --from, --json, --tool | no |
 | `scribe skill tools` | --disable, --enable, --json, --reset | no |
 | `scribe skill` | --json | no |
 | `scribe status` | --json | yes |
-| `scribe sync` | --all, --json, --registry, --trust-all | yes |
+| `scribe sync` | --all, --force, --json, --registry, --trust-all | yes |
 | `scribe tools add` | --detect, --install, --json, --path, --uninstall | no |
 | `scribe tools disable` | --json | no |
 | `scribe tools enable` | --json | no |

--- a/cmd/add_shared.go
+++ b/cmd/add_shared.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/huh/v2"
 
 	"github.com/Naoray/scribe/internal/add"
+	"github.com/Naoray/scribe/internal/discovery"
 	gh "github.com/Naoray/scribe/internal/github"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/migrate"
@@ -18,6 +21,8 @@ import (
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
 )
+
+var githubURLInDescriptionRE = regexp.MustCompile(`https?://github\.com/[^\s)]+`)
 
 // addResult is the per-skill result emitted by registry-push flows.
 type addResult struct {
@@ -72,6 +77,8 @@ func runAddByName(
 			return nil
 		}
 	}
+
+	warnOnMissingSourceAttribution([]add.Candidate{*found})
 
 	results := wireAddEmit(adder, targetRepo, useJSON)
 
@@ -138,6 +145,8 @@ func runAddInteractive(
 		}
 	}
 
+	warnOnMissingSourceAttribution(selected)
+
 	results := wireAddEmit(adder, targetRepo, useJSON)
 
 	if err := adder.Add(ctx, targetRepo, selected); err != nil {
@@ -145,6 +154,27 @@ func runAddInteractive(
 	}
 
 	return finishAdd(ctx, *results, targetRepo, st, client, targets, useJSON)
+}
+
+func warnOnMissingSourceAttribution(candidates []add.Candidate) {
+	for _, candidate := range candidates {
+		if warning := missingSourceWarning(candidate); warning != "" {
+			fmt.Fprintln(os.Stderr, warning)
+		}
+	}
+}
+
+func missingSourceWarning(candidate add.Candidate) string {
+	if candidate.Attribution != (discovery.Source{}) {
+		return ""
+	}
+	if strings.Contains(candidate.Description, "⛔️") {
+		return ""
+	}
+	if !githubURLInDescriptionRE.MatchString(candidate.Description) {
+		return ""
+	}
+	return fmt.Sprintf("warning: %s mentions a GitHub URL in its description but has no source frontmatter", candidate.Name)
 }
 
 // sortCandidates groups by origin (local first, then remote), then by package,

--- a/cmd/add_shared.go
+++ b/cmd/add_shared.go
@@ -168,10 +168,14 @@ func missingSourceWarning(candidate add.Candidate) string {
 	if candidate.Attribution != (discovery.Source{}) {
 		return ""
 	}
-	if strings.Contains(candidate.Description, "⛔️") {
+	description := candidate.RawDescription
+	if description == "" {
+		description = candidate.Description
+	}
+	if strings.Contains(description, "⛔️") {
 		return ""
 	}
-	if !githubURLInDescriptionRE.MatchString(candidate.Description) {
+	if !githubURLInDescriptionRE.MatchString(description) {
 		return ""
 	}
 	return fmt.Sprintf("warning: %s mentions a GitHub URL in its description but has no source frontmatter", candidate.Name)

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -218,18 +218,24 @@ func explainJSON(w io.Writer, skill discovery.Skill, content string) error {
 }
 
 type explainOutput struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description,omitempty"`
-	Revision    int      `json:"revision,omitempty"`
-	Targets     []string `json:"targets,omitempty"`
-	Path        string   `json:"path,omitempty"`
-	Content     string   `json:"content"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Source      *discovery.Source `json:"source,omitempty"`
+	Revision    int               `json:"revision,omitempty"`
+	Targets     []string          `json:"targets,omitempty"`
+	Path        string            `json:"path,omitempty"`
+	Content     string            `json:"content"`
 }
 
 func buildExplainOutput(skill discovery.Skill, content string) explainOutput {
+	var source *discovery.Source
+	if skill.Source != (discovery.Source{}) {
+		source = &skill.Source
+	}
 	return explainOutput{
 		Name:        skill.Name,
 		Description: skill.Description,
+		Source:      source,
 		Revision:    skill.Revision,
 		Targets:     skill.Targets,
 		Path:        skill.LocalPath,

--- a/cmd/explain_schema.go
+++ b/cmd/explain_schema.go
@@ -8,6 +8,15 @@ var explainOutputSchema = `{
   "properties": {
     "name": { "type": "string" },
     "description": { "type": "string" },
+    "source": {
+      "type": "object",
+      "properties": {
+        "url": { "type": "string" },
+        "author": { "type": "string" },
+        "note": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
     "revision": { "type": "integer" },
     "targets": { "type": "array", "items": { "type": "string" } },
     "path": { "type": "string" },

--- a/cmd/explain_test.go
+++ b/cmd/explain_test.go
@@ -336,9 +336,14 @@ func TestExplainJSONUnit(t *testing.T) {
 	skill := discovery.Skill{
 		Name:        "my-skill",
 		Description: "Does things",
-		Revision:    2,
-		Targets:     []string{"claude"},
-		LocalPath:   "/tmp/skills/my-skill",
+		Source: discovery.Source{
+			URL:    "https://github.com/acme/my-skill",
+			Author: "acme",
+			Note:   "original source",
+		},
+		Revision:  2,
+		Targets:   []string{"claude"},
+		LocalPath: "/tmp/skills/my-skill",
 	}
 	content := "# My Skill\n\nHello world."
 
@@ -357,5 +362,11 @@ func TestExplainJSONUnit(t *testing.T) {
 	}
 	if !strings.Contains(output, `"content": "# My Skill\n\nHello world."`) {
 		t.Errorf("expected content field, got:\n%s", output)
+	}
+	if !strings.Contains(output, `"source": {`) {
+		t.Errorf("expected source object, got:\n%s", output)
+	}
+	if !strings.Contains(output, `"author": "acme"`) {
+		t.Errorf("expected source author, got:\n%s", output)
 	}
 }

--- a/cmd/list_tui_render.go
+++ b/cmd/list_tui_render.go
@@ -334,6 +334,7 @@ func (m listModel) formatRow(row listRow, isCursor bool, nameCol int, compact bo
 	if compact {
 		if !row.HasStatus {
 			line := prefix + nameStyle.Render(name)
+			line += sourceAttributionMarker(row)
 			if !row.Managed {
 				line += " " + ltDimStyle.Render("[unmanaged]")
 			}
@@ -349,6 +350,7 @@ func (m listModel) formatRow(row listRow, isCursor bool, nameCol int, compact bo
 
 	if !row.HasStatus {
 		line := prefix + nameStyle.Render(name)
+		line += sourceAttributionMarker(row)
 		if !row.Managed {
 			line += " " + ltDimStyle.Render("[unmanaged]")
 		} else if m.backgroundLoad && row.Origin == state.OriginRegistry && row.Group != "" {
@@ -373,6 +375,7 @@ func (m listModel) formatRow(row listRow, isCursor bool, nameCol int, compact bo
 	author = runewidth.FillRight(author, 12)
 
 	line := prefix + nameStyle.Render(name) + "  " + ltDimStyle.Render(ver) + "  " + ltDimStyle.Render(author)
+	line += sourceAttributionMarker(row)
 
 	if row.HasStatus {
 		icon := statusStyles[row.Status].Render(row.Status.Display().Icon)
@@ -385,6 +388,13 @@ func (m listModel) formatRow(row listRow, isCursor bool, nameCol int, compact bo
 	}
 
 	return line
+}
+
+func sourceAttributionMarker(row listRow) string {
+	if row.Source.Author == "" {
+		return ""
+	}
+	return " " + ltDimStyle.Render("ℹ️ (via "+row.Source.Author+")")
 }
 
 func (m listModel) renderSkeletonColumns(row listRow) (string, string) {

--- a/cmd/list_tui_test.go
+++ b/cmd/list_tui_test.go
@@ -1293,6 +1293,28 @@ func TestFormatRow_LocalRowsDoNotShowPlaceholderColumns(t *testing.T) {
 	}
 }
 
+func TestFormatRow_LocalRowsShowSourceAttributionMarker(t *testing.T) {
+	m := listModel{width: 120}
+	row := listRow{
+		Name:    "recap",
+		Managed: true,
+		Local: &discovery.Skill{
+			Name: "recap",
+			Source: discovery.Source{
+				Author: "acme",
+			},
+		},
+		Source: discovery.Source{
+			Author: "acme",
+		},
+	}
+
+	formatted := m.formatRow(row, false, 20, false)
+	if !strings.Contains(formatted, "ℹ️ (via acme)") {
+		t.Fatalf("local row should show source marker, got: %q", formatted)
+	}
+}
+
 func TestFormatRow_LocalRegistryRowsShowSkeletonWhileBackgroundLoading(t *testing.T) {
 	m := listModel{width: 120, backgroundLoad: true, spinnerFrame: 0}
 	row := listRow{

--- a/cmd/registry_test.go
+++ b/cmd/registry_test.go
@@ -1,6 +1,11 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Naoray/scribe/internal/add"
+	"github.com/Naoray/scribe/internal/discovery"
+)
 
 func TestResolveRegistry(t *testing.T) {
 	repos := []string{"ArtistfyHQ/team-skills", "vercel/skills", "acme/skills"}
@@ -39,6 +44,30 @@ func TestResolveRegistry(t *testing.T) {
 				t.Errorf("got %q, want %q", got, c.want)
 			}
 		})
+	}
+}
+
+func TestMissingSourceWarning(t *testing.T) {
+	candidate := add.Candidate{
+		Name:        "borrowed",
+		Description: "Imported from https://github.com/acme/borrowed",
+		LocalPath:   "/tmp/borrowed",
+	}
+
+	got := missingSourceWarning(candidate)
+	if got == "" {
+		t.Fatal("expected warning for GitHub URL without source frontmatter")
+	}
+
+	candidate.Attribution = discovery.Source{URL: "https://github.com/acme/borrowed"}
+	if got := missingSourceWarning(candidate); got != "" {
+		t.Fatalf("expected no warning when source is set, got %q", got)
+	}
+
+	candidate.Attribution = discovery.Source{}
+	candidate.Description = "⛔️ https://github.com/acme/borrowed"
+	if got := missingSourceWarning(candidate); got != "" {
+		t.Fatalf("expected opt-out marker to suppress warning, got %q", got)
 	}
 }
 

--- a/cmd/registry_test.go
+++ b/cmd/registry_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Naoray/scribe/internal/add"
 	"github.com/Naoray/scribe/internal/discovery"
+	"github.com/Naoray/scribe/internal/state"
 )
 
 func TestResolveRegistry(t *testing.T) {
@@ -68,6 +72,61 @@ func TestMissingSourceWarning(t *testing.T) {
 	candidate.Description = "⛔️ https://github.com/acme/borrowed"
 	if got := missingSourceWarning(candidate); got != "" {
 		t.Fatalf("expected opt-out marker to suppress warning, got %q", got)
+	}
+}
+
+func TestMissingSourceWarningUsesRawDiscoveredDescription(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	longPrefix := strings.Repeat("background ", 8)
+	descriptionWithURL := longPrefix + "Imported from https://github.com/acme/upstreamed-skill"
+
+	writeSkill := func(name, body string) {
+		t.Helper()
+		skillDir := filepath.Join(home, ".scribe", "skills", name)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeSkill("upstreamed", "---\nname: upstreamed\ndescription: "+descriptionWithURL+"\n---\n")
+	writeSkill("plain", "---\nname: plain\ndescription: "+longPrefix+"Locally authored helper\n---\n")
+	writeSkill("sourced", "---\nname: sourced\ndescription: "+descriptionWithURL+"\nsource:\n  url: https://github.com/acme/upstreamed-skill\n---\n")
+
+	adder := &add.Adder{}
+	candidates, err := adder.DiscoverLocal(&state.State{Installed: map[string]state.InstalledSkill{}})
+	if err != nil {
+		t.Fatalf("DiscoverLocal: %v", err)
+	}
+
+	byName := map[string]add.Candidate{}
+	for _, candidate := range candidates {
+		byName[candidate.Name] = candidate
+	}
+
+	upstreamed := byName["upstreamed"]
+	if upstreamed.RawDescription != descriptionWithURL {
+		t.Fatalf("RawDescription = %q, want %q", upstreamed.RawDescription, descriptionWithURL)
+	}
+	if upstreamed.Description == upstreamed.RawDescription {
+		t.Fatalf("Description was not truncated: %q", upstreamed.Description)
+	}
+	if githubURLInDescriptionRE.MatchString(upstreamed.Description) {
+		t.Fatalf("truncated Description unexpectedly contains a GitHub URL: %q", upstreamed.Description)
+	}
+	if got := missingSourceWarning(upstreamed); got == "" {
+		t.Fatal("expected warning for raw GitHub URL without source frontmatter")
+	}
+
+	if got := missingSourceWarning(byName["plain"]); got != "" {
+		t.Fatalf("expected no warning without GitHub URL, got %q", got)
+	}
+	if got := missingSourceWarning(byName["sourced"]); got != "" {
+		t.Fatalf("expected no warning with source frontmatter, got %q", got)
 	}
 }
 

--- a/internal/add/add.go
+++ b/internal/add/add.go
@@ -19,13 +19,14 @@ import (
 
 // Candidate represents a skill that can be added to a registry.
 type Candidate struct {
-	Name        string // skill name (directory basename)
-	Description string // short description from SKILL.md
-	Origin      string // "local" or "registry:owner/repo"
-	Package     string // parent package name if sub-skill (e.g. "gstack")
-	Source      string // "github:owner/repo@ref" or empty for local-only
-	Attribution discovery.Source
-	LocalPath   string // absolute path on disk, empty for remote-only
+	Name           string // skill name (directory basename)
+	Description    string // short description from SKILL.md
+	RawDescription string // untruncated description from SKILL.md
+	Origin         string // "local" or "registry:owner/repo"
+	Package        string // parent package name if sub-skill (e.g. "gstack")
+	Source         string // "github:owner/repo@ref" or empty for local-only
+	Attribution    discovery.Source
+	LocalPath      string // absolute path on disk, empty for remote-only
 }
 
 // NeedsUpload reports whether this candidate requires uploading files to the
@@ -60,13 +61,14 @@ func (a *Adder) DiscoverLocal(st *state.State) ([]Candidate, error) {
 	for _, sk := range skills {
 		source := sourceFromState(st, sk.Name)
 		candidates = append(candidates, Candidate{
-			Name:        sk.Name,
-			Description: sk.Description,
-			Origin:      "local",
-			Package:     sk.Package,
-			LocalPath:   sk.LocalPath,
-			Source:      source,
-			Attribution: sk.Source,
+			Name:           sk.Name,
+			Description:    sk.Description,
+			RawDescription: sk.RawDescription,
+			Origin:         "local",
+			Package:        sk.Package,
+			LocalPath:      sk.LocalPath,
+			Source:         source,
+			Attribution:    sk.Source,
 		})
 	}
 

--- a/internal/add/add.go
+++ b/internal/add/add.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Naoray/scribe/internal/tools"
 )
 
-
 // Candidate represents a skill that can be added to a registry.
 type Candidate struct {
 	Name        string // skill name (directory basename)
@@ -25,6 +24,7 @@ type Candidate struct {
 	Origin      string // "local" or "registry:owner/repo"
 	Package     string // parent package name if sub-skill (e.g. "gstack")
 	Source      string // "github:owner/repo@ref" or empty for local-only
+	Attribution discovery.Source
 	LocalPath   string // absolute path on disk, empty for remote-only
 }
 
@@ -37,9 +37,9 @@ func (c Candidate) NeedsUpload() bool {
 // Adder wires discovery and GitHub push together.
 // Emits events via the Emit callback — the caller decides output format.
 type Adder struct {
-	Client  *gh.Client
-	Tools []tools.Tool
-	Emit    func(any)
+	Client *gh.Client
+	Tools  []tools.Tool
+	Emit   func(any)
 }
 
 func (a *Adder) emit(msg any) {
@@ -66,6 +66,7 @@ func (a *Adder) DiscoverLocal(st *state.State) ([]Candidate, error) {
 			Package:     sk.Package,
 			LocalPath:   sk.LocalPath,
 			Source:      source,
+			Attribution: sk.Source,
 		})
 	}
 
@@ -329,4 +330,3 @@ func (a *Adder) fetchManifest(ctx context.Context, owner, repo string) (*manifes
 	m, _, err := manifest.FetchWithFallback(ctx, a.Client, owner, repo, migrate.Convert)
 	return m, err
 }
-

--- a/internal/add/add_test.go
+++ b/internal/add/add_test.go
@@ -181,6 +181,35 @@ func TestDiscoverLocal_SourceFromState(t *testing.T) {
 	}
 }
 
+func TestDiscoverLocal_AttributionFromFrontmatterSource(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	skillDir := filepath.Join(home, ".scribe", "skills", "upstreamed")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\nname: upstreamed\ndescription: From https://github.com/acme/upstreamed\nsource:\n  url: https://github.com/acme/upstreamed\n  author: acme\n---\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adder := &add.Adder{}
+	candidates, err := adder.DiscoverLocal(&state.State{Installed: map[string]state.InstalledSkill{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("got %d candidates, want 1", len(candidates))
+	}
+	if candidates[0].Attribution.URL != "https://github.com/acme/upstreamed" {
+		t.Fatalf("Attribution.URL = %q", candidates[0].Attribution.URL)
+	}
+	if candidates[0].Attribution.Author != "acme" {
+		t.Fatalf("Attribution.Author = %q", candidates[0].Attribution.Author)
+	}
+}
+
 func TestDiscoverLocalSkipsEmptyDirs(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -21,11 +21,12 @@ var validSkillName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
 // SkillMeta holds metadata parsed from SKILL.md frontmatter.
 type SkillMeta struct {
-	Name        string
-	Description string
-	Version     string
-	Author      string
-	Source      Source
+	Name           string
+	Description    string
+	RawDescription string
+	Version        string
+	Author         string
+	Source         Source
 }
 
 // Source holds optional upstream attribution parsed from SKILL.md frontmatter.
@@ -54,17 +55,18 @@ var reservedNames = map[string]bool{
 
 // Skill represents a skill found on disk, optionally enriched with state info.
 type Skill struct {
-	Name        string
-	Description string   // short description from SKILL.md frontmatter or first paragraph
-	Source      Source   // optional upstream attribution from SKILL.md frontmatter
-	Package     string   // parent package name if skill is a symlink sub-skill (e.g. "gstack")
-	LocalPath   string   // absolute path on disk
-	ContentHash string   // deterministic content fingerprint
-	Targets     []string // from state if tracked, else inferred from location
-	Modified    bool     // SKILL.md hash differs from installed_hash in state
-	Conflicted  bool     // SKILL.md contains unresolved merge conflict markers
-	Revision    int      // from state
-	Managed     bool     // tracked in state AND LocalPath is inside ~/.scribe/skills/
+	Name           string
+	Description    string   // short description from SKILL.md frontmatter or first paragraph
+	RawDescription string   // untruncated description from SKILL.md frontmatter or first paragraph
+	Source         Source   // optional upstream attribution from SKILL.md frontmatter
+	Package        string   // parent package name if skill is a symlink sub-skill (e.g. "gstack")
+	LocalPath      string   // absolute path on disk
+	ContentHash    string   // deterministic content fingerprint
+	Targets        []string // from state if tracked, else inferred from location
+	Modified       bool     // SKILL.md hash differs from installed_hash in state
+	Conflicted     bool     // SKILL.md contains unresolved merge conflict markers
+	Revision       int      // from state
+	Managed        bool     // tracked in state AND LocalPath is inside ~/.scribe/skills/
 	// IsPackage reports whether this row represents a ~/.scribe/packages/<name>/
 	// tree package rather than a regular skill. Packages self-install and
 	// don't get projected into tool skill dirs.
@@ -344,13 +346,14 @@ func buildSkill(name, skillDir, scanBase, target string, st *state.State, scribe
 	}
 
 	sk := Skill{
-		Name:        name,
-		Description: meta.Description,
-		Source:      meta.Source,
-		LocalPath:   skillDir,
-		Package:     detectPackage(skillDir, scanBase),
-		ContentHash: hash,
-		Conflicted:  conflicted,
+		Name:           name,
+		Description:    meta.Description,
+		RawDescription: meta.RawDescription,
+		Source:         meta.Source,
+		LocalPath:      skillDir,
+		Package:        detectPackage(skillDir, scanBase),
+		ContentHash:    hash,
+		Conflicted:     conflicted,
 	}
 
 	if installed, ok := st.Installed[name]; ok {
@@ -438,7 +441,8 @@ func readSkillMetadata(skillDir string) SkillMeta {
 
 	fm := extractFrontmatter(data)
 	if fm == "" {
-		return SkillMeta{Description: extractFirstParagraph(data)}
+		rawDescription := extractFirstParagraphRaw(data)
+		return SkillMeta{Description: truncateDescription(rawDescription), RawDescription: rawDescription}
 	}
 
 	var raw rawFrontmatter
@@ -447,11 +451,12 @@ func readSkillMetadata(skillDir string) SkillMeta {
 	}
 
 	meta := SkillMeta{
-		Name:        raw.Name,
-		Description: truncateDescription(raw.Description),
-		Version:     raw.Version,
-		Author:      raw.Author,
-		Source:      raw.Source,
+		Name:           raw.Name,
+		Description:    truncateDescription(raw.Description),
+		RawDescription: strings.TrimSpace(raw.Description),
+		Version:        raw.Version,
+		Author:         raw.Author,
+		Source:         raw.Source,
 	}
 
 	// metadata.* overrides top-level (agentskills spec).
@@ -463,7 +468,8 @@ func readSkillMetadata(skillDir string) SkillMeta {
 	}
 
 	if meta.Description == "" {
-		meta.Description = extractFirstParagraph(data)
+		meta.RawDescription = extractFirstParagraphRaw(data)
+		meta.Description = truncateDescription(meta.RawDescription)
 	}
 
 	return meta
@@ -489,6 +495,10 @@ func extractFrontmatter(data []byte) string {
 
 // extractFirstParagraph returns the first non-empty line after a # heading.
 func extractFirstParagraph(data []byte) string {
+	return truncateDescription(extractFirstParagraphRaw(data))
+}
+
+func extractFirstParagraphRaw(data []byte) string {
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	pastTitle := false
 	for scanner.Scan() {
@@ -498,7 +508,7 @@ func extractFirstParagraph(data []byte) string {
 			continue
 		}
 		if pastTitle && strings.TrimSpace(line) != "" {
-			return truncateDescription(strings.TrimSpace(line))
+			return strings.TrimSpace(line)
 		}
 	}
 	return ""

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -25,6 +25,14 @@ type SkillMeta struct {
 	Description string
 	Version     string
 	Author      string
+	Source      Source
+}
+
+// Source holds optional upstream attribution parsed from SKILL.md frontmatter.
+type Source struct {
+	URL    string `yaml:"url" json:"url,omitempty"`
+	Author string `yaml:"author" json:"author,omitempty"`
+	Note   string `yaml:"note" json:"note,omitempty"`
 }
 
 // rawFrontmatter maps the YAML frontmatter structure in SKILL.md files.
@@ -33,6 +41,7 @@ type rawFrontmatter struct {
 	Description string         `yaml:"description"`
 	Version     string         `yaml:"version"`
 	Author      string         `yaml:"author"`
+	Source      Source         `yaml:"source"`
 	Metadata    map[string]any `yaml:"metadata"`
 }
 
@@ -47,6 +56,7 @@ var reservedNames = map[string]bool{
 type Skill struct {
 	Name        string
 	Description string   // short description from SKILL.md frontmatter or first paragraph
+	Source      Source   // optional upstream attribution from SKILL.md frontmatter
 	Package     string   // parent package name if skill is a symlink sub-skill (e.g. "gstack")
 	LocalPath   string   // absolute path on disk
 	ContentHash string   // deterministic content fingerprint
@@ -336,6 +346,7 @@ func buildSkill(name, skillDir, scanBase, target string, st *state.State, scribe
 	sk := Skill{
 		Name:        name,
 		Description: meta.Description,
+		Source:      meta.Source,
 		LocalPath:   skillDir,
 		Package:     detectPackage(skillDir, scanBase),
 		ContentHash: hash,
@@ -440,6 +451,7 @@ func readSkillMetadata(skillDir string) SkillMeta {
 		Description: truncateDescription(raw.Description),
 		Version:     raw.Version,
 		Author:      raw.Author,
+		Source:      raw.Source,
 	}
 
 	// metadata.* overrides top-level (agentskills spec).

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestReadSkillMetadata_FullFrontmatter(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: browse\nversion: 1.1.0\ndescription: Fast headless browser for QA testing.\n---\n\n# Browse\n\nContent here.\n"), 0o644)
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: browse\nversion: 1.1.0\ndescription: Fast headless browser for QA testing.\nsource:\n  url: https://github.com/acme/browse\n  author: acme\n  note: upstream skill\n---\n\n# Browse\n\nContent here.\n"), 0o644)
 
 	meta := readSkillMetadata(dir)
 
@@ -22,6 +22,15 @@ func TestReadSkillMetadata_FullFrontmatter(t *testing.T) {
 	}
 	if meta.Description != "Fast headless browser for QA testing." {
 		t.Errorf("Description: got %q", meta.Description)
+	}
+	if meta.Source.URL != "https://github.com/acme/browse" {
+		t.Errorf("Source.URL: got %q", meta.Source.URL)
+	}
+	if meta.Source.Author != "acme" {
+		t.Errorf("Source.Author: got %q", meta.Source.Author)
+	}
+	if meta.Source.Note != "upstream skill" {
+		t.Errorf("Source.Note: got %q", meta.Source.Note)
 	}
 }
 
@@ -364,7 +373,7 @@ func TestOnDiskManagedField(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Store scan finds "bar" first; claude-dir symlink pass skips it as a duplicate.
-			// Result: exactly one entry, Managed=true because state tracks it.
+		// Result: exactly one entry, Managed=true because state tracks it.
 		var found *Skill
 		for i := range skills {
 			if skills[i].Name == "bar" {

--- a/internal/workflow/list_load.go
+++ b/internal/workflow/list_load.go
@@ -28,6 +28,7 @@ type ListRow struct {
 	HasStatus bool
 	Version   string
 	Author    string
+	Source    discovery.Source
 	Targets   []string
 	Local     *discovery.Skill
 	Entry     *manifest.Entry
@@ -110,6 +111,7 @@ func BuildRows(ctx context.Context, bag *Bag) ([]ListRow, []string, error) {
 			}
 			if local != nil {
 				row.Managed = local.Managed
+				row.Source = local.Source
 			}
 			if installed, ok := bag.State.Installed[ss.Name]; ok {
 				row.Origin = installed.Origin
@@ -144,6 +146,7 @@ func BuildLocalRows(skills []discovery.Skill, st *state.State) []ListRow {
 		row := ListRow{
 			Name:    sk.Name,
 			Group:   g,
+			Source:  sk.Source,
 			Targets: sk.Targets,
 			Local:   sk,
 			Managed: sk.Managed,

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "b6daf92c",
+      "content_hash": "0e97a648",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe-agent",


### PR DESCRIPTION
Adds optional source.url/author/note to SKILL.md frontmatter.

## Summary
- Frontmatter schema, parser, tests
- explain --json surfaces source
- list/browse show (via author) when set
- registry add warns when description has URL but no source

Closes #106

## Test plan
- [x] go test ./...
- [ ] scribe explain <skill-with-source> --json | jq '.data.source'
- [ ] scribe list shows ℹ️ marker for source-tagged skills