### PR TITLE
feat(push): scribe push <skill> command (todo #389, GH #45)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe list` | --fields, --json, --registry, --remote | yes |
 | `scribe migrate global-to-projects` | --dry-run, --json, --project | no |
 | `scribe migrate` | --json | no |
+| `scribe push` | --json | yes |
 | `scribe registry add` | --install, --json, --registry, --yes | no |
 | `scribe registry connect` | --install-all, --json | yes |
 | `scribe registry create` | --json, --owner, --private, --repo, --team | no |

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/Naoray/scribe/internal/discovery"
+	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/registry"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+type pushOutput struct {
+	Skill     string `json:"skill"`
+	Registry  string `json:"registry"`
+	CommitSHA string `json:"commit_sha"`
+	CommitURL string `json:"commit_url"`
+}
+
+type pushAuthClient interface {
+	IsAuthenticated() bool
+	AuthenticatedUser(ctx context.Context) (gh.AuthenticatedUser, error)
+}
+
+var (
+	pushGitConfigEmail = gitConfigUserEmail
+	newRegistryPusher  = registry.NewGitHubPusher
+)
+
+func newPushCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "push <skill>",
+		Short: "Push local skill edits to their source registry",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runPush,
+	}
+	return markJSONSupported(cmd)
+}
+
+func runPush(cmd *cobra.Command, args []string) error {
+	factory := commandFactory()
+	st, err := factory.State()
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
+	client, err := factory.Client()
+	if err != nil {
+		return err
+	}
+	result, err := runPushWithDeps(cmd.Context(), args[0], st, client, newRegistryPusher(client), pushGitConfigEmail)
+	if err != nil {
+		return err
+	}
+
+	out := pushOutput{
+		Skill:     result.Skill,
+		Registry:  result.Registry,
+		CommitSHA: result.CommitSHA,
+		CommitURL: result.CommitURL,
+	}
+	if jsonFlagPassed(cmd) {
+		r := jsonRendererForCommand(cmd, true)
+		if err := r.Result(out); err != nil {
+			return err
+		}
+		return r.Flush()
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Pushed %s to %s at %s\n", out.Skill, out.Registry, out.CommitSHA)
+	return nil
+}
+
+func runPushWithDeps(ctx context.Context, skillName string, st *state.State, auth pushAuthClient, pusher registry.GitHubPusher, gitEmail func(context.Context) string) (registry.PushResult, error) {
+	installed, ok := st.Installed[skillName]
+	if !ok {
+		err := fmt.Errorf("skill %q not found", skillName)
+		return registry.PushResult{}, clierrors.Wrap(err, "SKILL_NOT_FOUND", clierrors.ExitNotFound,
+			clierrors.WithResource(skillName),
+			clierrors.WithRemediation("Run `scribe list` to see installed skills."),
+		)
+	}
+	if installed.IsPackage() {
+		err := fmt.Errorf("skill %q is a package and cannot be pushed with this command", skillName)
+		return registry.PushResult{}, clierrors.Wrap(err, "PUSH_UNSUPPORTED_PACKAGE", clierrors.ExitConflict,
+			clierrors.WithResource(skillName),
+		)
+	}
+
+	source, ok := pushSource(installed)
+	if !ok {
+		err := fmt.Errorf("skill %q has no registry source metadata", skillName)
+		return registry.PushResult{}, clierrors.Wrap(err, "PUSH_SOURCE_MISSING", clierrors.ExitPerm,
+			clierrors.WithResource(skillName),
+			clierrors.WithRemediation("install or sync this skill from a registry before pushing"),
+		)
+	}
+	if strings.TrimSpace(source.Author) == "" {
+		err := fmt.Errorf("skill %q has no recorded author", skillName)
+		return registry.PushResult{}, clierrors.Wrap(err, "PUSH_AUTHOR_MISSING", clierrors.ExitPerm,
+			clierrors.WithResource(skillName),
+			clierrors.WithRemediation("re-sync the skill from a registry that declares an author"),
+		)
+	}
+	if auth == nil || !auth.IsAuthenticated() {
+		err := errors.New("GitHub authentication required")
+		return registry.PushResult{}, clierrors.Wrap(err, "PUSH_AUTH_REQUIRED", clierrors.ExitPerm,
+			clierrors.WithRemediation("run `gh auth login` or set GITHUB_TOKEN"),
+		)
+	}
+	if !authorMatches(ctx, source.Author, auth, gitEmail) {
+		err := fmt.Errorf("local user is not the author of %q", skillName)
+		return registry.PushResult{}, clierrors.Wrap(err, "PUSH_AUTHOR_MISMATCH", clierrors.ExitPerm,
+			clierrors.WithResource(skillName),
+			clierrors.WithRemediation("only the recorded skill author may push updates"),
+		)
+	}
+
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		return registry.PushResult{}, fmt.Errorf("resolve store dir: %w", err)
+	}
+	skillDir := filepath.Join(storeDir, skillName)
+	if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
+		if os.IsNotExist(err) {
+			return registry.PushResult{}, clierrors.Wrap(err, "SKILL_NOT_FOUND", clierrors.ExitNotFound,
+				clierrors.WithResource(skillName),
+				clierrors.WithRemediation("Run `scribe sync` before pushing this skill."),
+			)
+		}
+		return registry.PushResult{}, fmt.Errorf("stat SKILL.md: %w", err)
+	}
+
+	meta, err := discovery.ReadSkillMetadata(skillDir)
+	if err != nil {
+		return registry.PushResult{}, clierrors.Wrap(err, "PUSH_VALIDATION_FAILED", clierrors.ExitValid,
+			clierrors.WithResource(skillName),
+		)
+	}
+	if err := discovery.ValidateAgentSkillMetadata(meta); err != nil {
+		return registry.PushResult{}, clierrors.Wrap(err, "PUSH_VALIDATION_FAILED", clierrors.ExitValid,
+			clierrors.WithResource(skillName),
+		)
+	}
+	if meta.Name != skillName {
+		err := fmt.Errorf("SKILL.md name %q does not match requested skill %q", meta.Name, skillName)
+		return registry.PushResult{}, clierrors.Wrap(err, "PUSH_VALIDATION_FAILED", clierrors.ExitValid,
+			clierrors.WithResource(skillName),
+		)
+	}
+
+	return registry.PushSkill(ctx, pusher, skillName, skillDir, source)
+}
+
+func pushSource(installed state.InstalledSkill) (state.SkillSource, bool) {
+	for _, source := range installed.Sources {
+		if source.PushRegistry() != "" {
+			return source, true
+		}
+	}
+	return state.SkillSource{}, false
+}
+
+func authorMatches(ctx context.Context, author string, auth pushAuthClient, gitEmail func(context.Context) string) bool {
+	want := normalizeIdentity(author)
+	if want == "" {
+		return false
+	}
+	if gitEmail != nil && normalizeIdentity(gitEmail(ctx)) == want {
+		return true
+	}
+	user, err := auth.AuthenticatedUser(ctx)
+	if err == nil {
+		if normalizeIdentity(user.Login) == want {
+			return true
+		}
+		for _, email := range user.Emails {
+			if normalizeIdentity(email) == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func normalizeIdentity(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if strings.Contains(value, "<") && strings.Contains(value, ">") {
+		before, after, ok := strings.Cut(value, "<")
+		if ok {
+			_ = before
+			email, _, ok := strings.Cut(after, ">")
+			if ok {
+				return strings.TrimSpace(email)
+			}
+		}
+	}
+	return value
+}
+
+func gitConfigUserEmail(ctx context.Context) string {
+	out, err := exec.CommandContext(ctx, "git", "config", "user.email").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/cmd/push_schema.go
+++ b/cmd/push_schema.go
@@ -1,0 +1,20 @@
+package cmd
+
+import clischema "github.com/Naoray/scribe/internal/cli/schema"
+
+var pushOutputSchema = `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "skill": { "type": "string" },
+    "registry": { "type": "string" },
+    "commit_sha": { "type": "string" },
+    "commit_url": { "type": "string" }
+  },
+  "required": ["skill", "registry", "commit_sha", "commit_url"],
+  "additionalProperties": false
+}`
+
+func init() {
+	clischema.Register("scribe push", pushOutputSchema)
+}

--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/registry"
+	"github.com/Naoray/scribe/internal/state"
+)
+
+type fakePushAuth struct {
+	authed bool
+	user   gh.AuthenticatedUser
+}
+
+func (f fakePushAuth) IsAuthenticated() bool { return f.authed }
+
+func (f fakePushAuth) AuthenticatedUser(context.Context) (gh.AuthenticatedUser, error) {
+	return f.user, nil
+}
+
+type fakeRegistryPusher struct{}
+
+func (fakeRegistryPusher) GetTree(context.Context, string, string, string) ([]registry.TreeEntry, error) {
+	return []registry.TreeEntry{{Path: "deploy/SKILL.md", Type: "blob", SHA: "base-sha"}}, nil
+}
+
+func (fakeRegistryPusher) LatestCommitSHA(context.Context, string, string, string) (string, error) {
+	return "head-sha", nil
+}
+
+func (fakeRegistryPusher) PushFilesAtomic(context.Context, string, string, string, map[string][]byte, string, string) (registry.CommitResult, error) {
+	return registry.CommitResult{SHA: "abc123", URL: "https://github.com/acme/skills/commit/abc123"}, nil
+}
+
+func TestRunPushWithDepsEnforcesAuthor(t *testing.T) {
+	home := setupPushHome(t, "deploy", "---\nname: deploy\ndescription: Deploy things\n---\n")
+	t.Setenv("HOME", home)
+	st := pushState("deploy", "author@example.com")
+
+	_, err := runPushWithDeps(context.Background(), "deploy", st, fakePushAuth{
+		authed: true,
+		user:   gh.AuthenticatedUser{Login: "someone", Emails: []string{"other@example.com"}},
+	}, fakeRegistryPusher{}, func(context.Context) string { return "other@example.com" })
+
+	if clierrors.ExitCode(err) != clierrors.ExitPerm {
+		t.Fatalf("exit = %d, want perm; err=%v", clierrors.ExitCode(err), err)
+	}
+}
+
+func TestRunPushWithDepsRequiresAuth(t *testing.T) {
+	home := setupPushHome(t, "deploy", "---\nname: deploy\ndescription: Deploy things\n---\n")
+	t.Setenv("HOME", home)
+	st := pushState("deploy", "author@example.com")
+
+	_, err := runPushWithDeps(context.Background(), "deploy", st, fakePushAuth{}, fakeRegistryPusher{}, func(context.Context) string {
+		return "author@example.com"
+	})
+
+	if clierrors.ExitCode(err) != clierrors.ExitPerm {
+		t.Fatalf("exit = %d, want perm; err=%v", clierrors.ExitCode(err), err)
+	}
+}
+
+func TestRunPushWithDepsValidatesSkillMetadata(t *testing.T) {
+	home := setupPushHome(t, "deploy", "---\nname: Deploy\ndescription: Deploy things\n---\n")
+	t.Setenv("HOME", home)
+	st := pushState("deploy", "author@example.com")
+
+	_, err := runPushWithDeps(context.Background(), "deploy", st, fakePushAuth{
+		authed: true,
+		user:   gh.AuthenticatedUser{Emails: []string{"author@example.com"}},
+	}, fakeRegistryPusher{}, func(context.Context) string { return "" })
+
+	if clierrors.ExitCode(err) != clierrors.ExitValid {
+		t.Fatalf("exit = %d, want valid; err=%v", clierrors.ExitCode(err), err)
+	}
+}
+
+func TestRunPushWithDepsReturnsPushResult(t *testing.T) {
+	home := setupPushHome(t, "deploy", "---\nname: deploy\ndescription: Deploy things\n---\n")
+	t.Setenv("HOME", home)
+	st := pushState("deploy", "author@example.com")
+
+	result, err := runPushWithDeps(context.Background(), "deploy", st, fakePushAuth{
+		authed: true,
+		user:   gh.AuthenticatedUser{Login: "author", Emails: []string{"author@example.com"}},
+	}, fakeRegistryPusher{}, func(context.Context) string { return "" })
+	if err != nil {
+		t.Fatalf("runPushWithDeps() error = %v", err)
+	}
+	if result.CommitSHA != "abc123" || result.Registry != "acme/skills" || result.Skill != "deploy" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func setupPushHome(t *testing.T, name, skillMD string) string {
+	t.Helper()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".scribe", "skills", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMD), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	return home
+}
+
+func pushState(name, author string) *state.State {
+	return &state.State{Installed: map[string]state.InstalledSkill{
+		name: {
+			Revision:      1,
+			InstalledHash: "hash",
+			Sources: []state.SkillSource{{
+				Registry:   "acme/skills",
+				Path:       name,
+				Author:     author,
+				Ref:        "main",
+				LastSHA:    "base-sha",
+				LastSynced: time.Now().UTC(),
+			}},
+		},
+	}}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -227,6 +227,7 @@ func newRootCmd() *cobra.Command {
 		newBrowseCommand(),
 		newInstallCommand(),
 		newAddCommand(),
+		newPushCommand(),
 		newRemoveCommand(),
 		newSyncCommand(),
 		newAdoptCommand(),

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -19,6 +19,9 @@ import (
 // validSkillName matches safe skill names that work as catalog entry names and filesystem paths.
 var validSkillName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
+// validAgentSkillName matches the agentskills registry name convention.
+var validAgentSkillName = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+
 // SkillMeta holds metadata parsed from SKILL.md frontmatter.
 type SkillMeta struct {
 	Name           string
@@ -529,4 +532,71 @@ func truncateDescription(s string) string {
 		return s[:80] + "..."
 	}
 	return s
+}
+
+// ReadSkillMetadata extracts SKILL.md metadata from a skill directory.
+func ReadSkillMetadata(skillDir string) (SkillMeta, error) {
+	path := filepath.Join(skillDir, "SKILL.md")
+
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return SkillMeta{}, fmt.Errorf("resolve SKILL.md: %w", err)
+	}
+
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return SkillMeta{}, fmt.Errorf("read SKILL.md: %w", err)
+	}
+
+	return ParseSkillMetadata(data)
+}
+
+// ParseSkillMetadata extracts SKILL.md frontmatter from bytes.
+func ParseSkillMetadata(data []byte) (SkillMeta, error) {
+	fm := extractFrontmatter(data)
+	if fm == "" {
+		return SkillMeta{Description: extractFirstParagraph(data)}, nil
+	}
+
+	var raw rawFrontmatter
+	if err := yaml.Unmarshal([]byte(fm), &raw); err != nil {
+		return SkillMeta{}, fmt.Errorf("parse frontmatter: %w", err)
+	}
+
+	meta := SkillMeta{
+		Name:        raw.Name,
+		Description: truncateDescription(raw.Description),
+		Version:     raw.Version,
+		Author:      raw.Author,
+	}
+	if v, ok := raw.Metadata["version"]; ok {
+		meta.Version = fmt.Sprint(v)
+	}
+	if v, ok := raw.Metadata["author"]; ok {
+		meta.Author = fmt.Sprint(v)
+	}
+	if meta.Description == "" {
+		meta.Description = extractFirstParagraph(data)
+	}
+	return meta, nil
+}
+
+// ValidateAgentSkillMetadata checks the name and description fields required by
+// agentskills registries before publishing.
+func ValidateAgentSkillMetadata(meta SkillMeta) error {
+	name := strings.TrimSpace(meta.Name)
+	if name == "" {
+		return fmt.Errorf("SKILL.md frontmatter missing name")
+	}
+	if !validAgentSkillName.MatchString(name) {
+		return fmt.Errorf("skill name %q must use lowercase letters, digits, dot, underscore, or hyphen and start with a letter or digit", meta.Name)
+	}
+	if strings.Contains(name, "..") || strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("skill name %q must not contain path separators or parent-directory segments", meta.Name)
+	}
+	desc := strings.TrimSpace(meta.Description)
+	if desc == "" {
+		return fmt.Errorf("SKILL.md frontmatter missing description")
+	}
+	return nil
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -496,6 +496,12 @@ func wrapErr(err error, operation string) error {
 				clierrors.WithRemediation("run `gh auth login` or set GITHUB_TOKEN"),
 				clierrors.WithResource(operation),
 			)
+		case http.StatusConflict:
+			return githubConflict(err, operation)
+		case http.StatusUnprocessableEntity:
+			if isUpdateRefConflict(operation, ghErr) {
+				return githubConflict(err, operation)
+			}
 		}
 	}
 	return clierrors.Wrap(err, "GH_NETWORK_FAILED", clierrors.ExitNetwork,
@@ -503,6 +509,24 @@ func wrapErr(err error, operation string) error {
 		clierrors.WithRetryable(true),
 		clierrors.WithResource(operation),
 	)
+}
+
+func githubConflict(err error, operation string) error {
+	return clierrors.Wrap(err, "GH_CONFLICT", clierrors.ExitConflict,
+		clierrors.WithMessage(fmt.Sprintf("%s: remote changed while writing", operation)),
+		clierrors.WithRemediation("run `scribe sync` and retry"),
+		clierrors.WithResource(operation),
+	)
+}
+
+func isUpdateRefConflict(operation string, ghErr *github.ErrorResponse) bool {
+	if !strings.HasPrefix(operation, "set ref ") {
+		return false
+	}
+	msg := strings.ToLower(ghErr.Message)
+	return strings.Contains(msg, "fast forward") ||
+		strings.Contains(msg, "non-fast-forward") ||
+		strings.Contains(msg, "reference update failed")
 }
 
 func formatReset(unixTimestamp string) string {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -27,8 +27,49 @@ type Client struct {
 	authenticated bool
 }
 
+// AuthenticatedUser describes the token owner used for author checks.
+type AuthenticatedUser struct {
+	Login  string
+	Emails []string
+}
+
+// CommitResult describes a pushed GitHub commit.
+type CommitResult struct {
+	SHA string
+	URL string
+}
+
 // IsAuthenticated returns true if the client has a GitHub token.
 func (c *Client) IsAuthenticated() bool { return c.authenticated }
+
+// AuthenticatedUser returns the login and visible email addresses for the
+// current token. Private email addresses may be unavailable depending on token
+// scopes, so callers should also check local git config when enforcing author.
+func (c *Client) AuthenticatedUser(ctx context.Context) (AuthenticatedUser, error) {
+	if !c.authenticated {
+		return AuthenticatedUser{}, clierrors.Wrap(errors.New("GitHub authentication required"), "GH_AUTH_REQUIRED", clierrors.ExitPerm,
+			clierrors.WithRemediation("run `gh auth login` or set GITHUB_TOKEN"),
+		)
+	}
+	user, _, err := c.gh.Users.Get(ctx, "")
+	if err != nil {
+		return AuthenticatedUser{}, wrapErr(err, "get authenticated user")
+	}
+	out := AuthenticatedUser{Login: user.GetLogin()}
+	if email := strings.TrimSpace(user.GetEmail()); email != "" {
+		out.Emails = append(out.Emails, email)
+	}
+	emails, _, err := c.gh.Users.ListEmails(ctx, nil)
+	if err == nil {
+		for _, email := range emails {
+			addr := strings.TrimSpace(email.GetEmail())
+			if addr != "" {
+				out.Emails = append(out.Emails, addr)
+			}
+		}
+	}
+	return out, nil
+}
 
 // NewClient creates a GitHub client using the auth chain:
 //  1. gh auth token  (piggyback on gh CLI if installed)
@@ -274,6 +315,74 @@ func (c *Client) PushFiles(ctx context.Context, owner, repo string, files map[st
 	}
 
 	return nil
+}
+
+// PushFilesAtomic creates a single commit containing all file updates and moves
+// refs/heads/<branch> to it. If expectedHead is non-empty and the branch moved
+// since the caller checked it, the push is refused.
+func (c *Client) PushFilesAtomic(ctx context.Context, owner, repo, branch string, files map[string][]byte, message, expectedHead string) (CommitResult, error) {
+	if branch == "" {
+		branch = "main"
+	}
+	ref, _, err := c.gh.Git.GetRef(ctx, owner, repo, "refs/heads/"+branch)
+	if err != nil {
+		return CommitResult{}, wrapErr(err, fmt.Sprintf("%s/%s branch %s", owner, repo, branch))
+	}
+	parentSHA := ref.GetObject().GetSHA()
+	if expectedHead != "" && parentSHA != expectedHead {
+		return CommitResult{}, clierrors.Wrap(errors.New("remote branch changed while preparing push"), "GH_CONFLICT", clierrors.ExitConflict,
+			clierrors.WithRemediation("run `scribe sync` and retry"),
+			clierrors.WithResource(owner+"/"+repo),
+		)
+	}
+	parentCommit, _, err := c.gh.Git.GetCommit(ctx, owner, repo, parentSHA)
+	if err != nil {
+		return CommitResult{}, wrapErr(err, fmt.Sprintf("get commit %s/%s@%s", owner, repo, parentSHA))
+	}
+
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	entries := make([]*github.TreeEntry, 0, len(paths))
+	for _, path := range paths {
+		blob, _, err := c.gh.Git.CreateBlob(ctx, owner, repo, &github.Blob{
+			Content:  github.Ptr(string(files[path])),
+			Encoding: github.Ptr("utf-8"),
+		})
+		if err != nil {
+			return CommitResult{}, wrapErr(err, fmt.Sprintf("create blob %s", path))
+		}
+		entries = append(entries, &github.TreeEntry{
+			Path: github.Ptr(path),
+			Mode: github.Ptr("100644"),
+			Type: github.Ptr("blob"),
+			SHA:  blob.SHA,
+		})
+	}
+
+	tree, _, err := c.gh.Git.CreateTree(ctx, owner, repo, parentCommit.GetTree().GetSHA(), entries)
+	if err != nil {
+		return CommitResult{}, wrapErr(err, fmt.Sprintf("create tree %s/%s", owner, repo))
+	}
+	commit, _, err := c.gh.Git.CreateCommit(ctx, owner, repo, &github.Commit{
+		Message: github.Ptr(message),
+		Tree:    tree,
+		Parents: []*github.Commit{{SHA: github.Ptr(parentSHA)}},
+	}, nil)
+	if err != nil {
+		return CommitResult{}, wrapErr(err, fmt.Sprintf("create commit %s/%s", owner, repo))
+	}
+	_, _, err = c.gh.Git.UpdateRef(ctx, owner, repo, &github.Reference{
+		Ref:    github.Ptr("refs/heads/" + branch),
+		Object: &github.GitObject{SHA: commit.SHA},
+	}, false)
+	if err != nil {
+		return CommitResult{}, wrapErr(err, fmt.Sprintf("set ref %s/%s", owner, repo))
+	}
+	return CommitResult{SHA: commit.GetSHA(), URL: commit.GetHTMLURL()}, nil
 }
 
 // FileExists checks whether a file exists in a GitHub repo at the given ref.

--- a/internal/github/push_test.go
+++ b/internal/github/push_test.go
@@ -1,0 +1,77 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-github/v69/github"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+)
+
+func TestPushFilesAtomicClassifiesUpdateRefNonFastForwardAsConflict(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/skills/git/ref/heads/main", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("GetRef method = %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ref":"refs/heads/main","object":{"sha":"parent-sha","type":"commit"}}`))
+	})
+	mux.HandleFunc("/repos/acme/skills/git/commits/parent-sha", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("GetCommit method = %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"sha":"parent-sha","tree":{"sha":"base-tree"}}`))
+	})
+	mux.HandleFunc("/repos/acme/skills/git/blobs", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("CreateBlob method = %s", r.Method)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"sha":"blob-sha"}`))
+	})
+	mux.HandleFunc("/repos/acme/skills/git/trees", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("CreateTree method = %s", r.Method)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"sha":"tree-sha"}`))
+	})
+	mux.HandleFunc("/repos/acme/skills/git/commits", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("CreateCommit method = %s", r.Method)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"sha":"commit-sha","html_url":"https://github.com/acme/skills/commit/commit-sha"}`))
+	})
+	mux.HandleFunc("/repos/acme/skills/git/refs/heads/main", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("UpdateRef method = %s", r.Method)
+		}
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"Update is not a fast forward"}`))
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL + "/")
+	if err != nil {
+		t.Fatalf("parse test URL: %v", err)
+	}
+	ghClient := github.NewClient(server.Client())
+	ghClient.BaseURL = baseURL
+	client := &Client{gh: ghClient, authenticated: true}
+
+	_, err = client.PushFilesAtomic(context.Background(), "acme", "skills", "main", map[string][]byte{
+		"deploy/SKILL.md": []byte("# deploy\n"),
+	}, "Update deploy skill", "parent-sha")
+	if clierrors.ExitCode(err) != clierrors.ExitConflict {
+		t.Fatalf("exit = %d, want conflict; err=%v", clierrors.ExitCode(err), err)
+	}
+}

--- a/internal/registry/push.go
+++ b/internal/registry/push.go
@@ -1,0 +1,175 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/state"
+)
+
+// GitHubPusher is the GitHub API surface needed to push a skill.
+type GitHubPusher interface {
+	GetTree(ctx context.Context, owner, repo, ref string) ([]TreeEntry, error)
+	LatestCommitSHA(ctx context.Context, owner, repo, branch string) (string, error)
+	PushFilesAtomic(ctx context.Context, owner, repo, branch string, files map[string][]byte, message, expectedHead string) (CommitResult, error)
+}
+
+// TreeEntry is a Git tree entry used for conflict checks.
+type TreeEntry struct {
+	Path string
+	Type string
+	SHA  string
+}
+
+// CommitResult describes the commit created by a push.
+type CommitResult struct {
+	SHA string
+	URL string
+}
+
+type githubPusher struct {
+	client *gh.Client
+}
+
+// NewGitHubPusher adapts the shared GitHub client to the push interface.
+func NewGitHubPusher(client *gh.Client) GitHubPusher {
+	return githubPusher{client: client}
+}
+
+func (p githubPusher) GetTree(ctx context.Context, owner, repo, ref string) ([]TreeEntry, error) {
+	entries, err := p.client.GetTree(ctx, owner, repo, ref)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]TreeEntry, len(entries))
+	for i, entry := range entries {
+		out[i] = TreeEntry{Path: entry.Path, Type: entry.Type, SHA: entry.SHA}
+	}
+	return out, nil
+}
+
+func (p githubPusher) LatestCommitSHA(ctx context.Context, owner, repo, branch string) (string, error) {
+	return p.client.LatestCommitSHA(ctx, owner, repo, branch)
+}
+
+func (p githubPusher) PushFilesAtomic(ctx context.Context, owner, repo, branch string, files map[string][]byte, message, expectedHead string) (CommitResult, error) {
+	commit, err := p.client.PushFilesAtomic(ctx, owner, repo, branch, files, message, expectedHead)
+	if err != nil {
+		return CommitResult{}, err
+	}
+	return CommitResult{SHA: commit.SHA, URL: commit.URL}, nil
+}
+
+// PushResult is returned after a successful skill push.
+type PushResult struct {
+	Skill     string
+	Registry  string
+	CommitSHA string
+	CommitURL string
+}
+
+// PushSkill publishes all files in skillDir back to source in one commit.
+func PushSkill(ctx context.Context, client GitHubPusher, skillName, skillDir string, source state.SkillSource) (PushResult, error) {
+	registry := source.PushRegistry()
+	owner, repo, err := manifest.ParseOwnerRepo(registry)
+	if err != nil {
+		return PushResult{}, clierrors.Wrap(err, "PUSH_INVALID_REGISTRY", clierrors.ExitConflict,
+			clierrors.WithRemediation("reinstall the skill from a valid registry source"),
+		)
+	}
+	branch := source.Ref
+	if branch == "" {
+		branch = "main"
+	}
+	remoteDir := strings.Trim(strings.TrimSpace(source.Path), "/")
+	if remoteDir == "" {
+		remoteDir = skillName
+	}
+
+	tree, err := client.GetTree(ctx, owner, repo, branch)
+	if err != nil {
+		return PushResult{}, err
+	}
+	headSHA, err := client.LatestCommitSHA(ctx, owner, repo, branch)
+	if err != nil {
+		return PushResult{}, err
+	}
+	if source.LastSHA == "" {
+		return PushResult{}, clierrors.Wrap(errors.New("skill has no recorded remote baseline"), "PUSH_CONFLICT", clierrors.ExitConflict,
+			clierrors.WithRemediation("run `scribe sync` before pushing this skill"),
+			clierrors.WithResource(skillName),
+		)
+	}
+	if remoteSHA, found := skillBlobSHA(tree, remoteDir); !found || remoteSHA != source.LastSHA {
+		return PushResult{}, clierrors.Wrap(errors.New("remote skill has changed since it was installed"), "PUSH_CONFLICT", clierrors.ExitConflict,
+			clierrors.WithRemediation("run `scribe sync` and reapply your local edits before pushing"),
+			clierrors.WithResource(skillName),
+		)
+	}
+
+	files, err := collectSkillFiles(skillDir, remoteDir)
+	if err != nil {
+		return PushResult{}, err
+	}
+	commit, err := client.PushFilesAtomic(ctx, owner, repo, branch, files, fmt.Sprintf("Update %s skill", skillName), headSHA)
+	if err != nil {
+		return PushResult{}, err
+	}
+	return PushResult{Skill: skillName, Registry: registry, CommitSHA: commit.SHA, CommitURL: commit.URL}, nil
+}
+
+func collectSkillFiles(skillDir, remoteDir string) (map[string][]byte, error) {
+	files := map[string][]byte{}
+	err := filepath.WalkDir(skillDir, func(localPath string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		name := d.Name()
+		if d.IsDir() {
+			switch name {
+			case ".git", "versions":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(skillDir, localPath)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(localPath)
+		if err != nil {
+			return err
+		}
+		files[path.Join(remoteDir, filepath.ToSlash(rel))] = data
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("collect skill files: %w", err)
+	}
+	if len(files) == 0 {
+		return nil, clierrors.Wrap(errors.New("skill directory has no files"), "PUSH_EMPTY_SKILL", clierrors.ExitConflict)
+	}
+	return files, nil
+}
+
+func skillBlobSHA(tree []TreeEntry, remoteDir string) (string, bool) {
+	target := path.Join(remoteDir, "SKILL.md")
+	if remoteDir == "." || remoteDir == "" {
+		target = "SKILL.md"
+	}
+	for _, entry := range tree {
+		if entry.Type == "blob" && entry.Path == target {
+			return entry.SHA, true
+		}
+	}
+	return "", false
+}

--- a/internal/registry/push.go
+++ b/internal/registry/push.go
@@ -109,15 +109,12 @@ func PushSkill(ctx context.Context, client GitHubPusher, skillName, skillDir str
 			clierrors.WithResource(skillName),
 		)
 	}
-	if remoteSHA, found := skillBlobSHA(tree, remoteDir); !found || remoteSHA != source.LastSHA {
-		return PushResult{}, clierrors.Wrap(errors.New("remote skill has changed since it was installed"), "PUSH_CONFLICT", clierrors.ExitConflict,
-			clierrors.WithRemediation("run `scribe sync` and reapply your local edits before pushing"),
-			clierrors.WithResource(skillName),
-		)
-	}
 
 	files, err := collectSkillFiles(skillDir, remoteDir)
 	if err != nil {
+		return PushResult{}, err
+	}
+	if err := verifyRemoteBaseline(skillName, tree, files, source, remoteDir); err != nil {
 		return PushResult{}, err
 	}
 	commit, err := client.PushFilesAtomic(ctx, owner, repo, branch, files, fmt.Sprintf("Update %s skill", skillName), headSHA)
@@ -172,4 +169,42 @@ func skillBlobSHA(tree []TreeEntry, remoteDir string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func verifyRemoteBaseline(skillName string, tree []TreeEntry, files map[string][]byte, source state.SkillSource, remoteDir string) error {
+	current := blobSHAsByPath(tree)
+	if len(source.BlobSHAs) == 0 {
+		if remoteSHA, found := skillBlobSHA(tree, remoteDir); !found || remoteSHA != source.LastSHA {
+			return pushConflict(skillName)
+		}
+		return nil
+	}
+	for filePath := range files {
+		expectedSHA, hadBaseline := source.BlobSHAs[filePath]
+		currentSHA, exists := current[filePath]
+		switch {
+		case hadBaseline && (!exists || currentSHA != expectedSHA):
+			return pushConflict(skillName)
+		case !hadBaseline && exists:
+			return pushConflict(skillName)
+		}
+	}
+	return nil
+}
+
+func blobSHAsByPath(tree []TreeEntry) map[string]string {
+	blobs := make(map[string]string, len(tree))
+	for _, entry := range tree {
+		if entry.Type == "blob" {
+			blobs[entry.Path] = entry.SHA
+		}
+	}
+	return blobs
+}
+
+func pushConflict(skillName string) error {
+	return clierrors.Wrap(errors.New("remote skill has changed since it was installed"), "PUSH_CONFLICT", clierrors.ExitConflict,
+		clierrors.WithRemediation("run `scribe sync` and reapply your local edits before pushing"),
+		clierrors.WithResource(skillName),
+	)
 }

--- a/internal/registry/push_test.go
+++ b/internal/registry/push_test.go
@@ -93,6 +93,37 @@ func TestPushSkillRefusesRemoteDivergence(t *testing.T) {
 	}
 }
 
+func TestPushSkillRefusesPartialRemoteDivergence(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "---\nname: deploy\ndescription: Deploy things\n---\n")
+	writeFile(t, filepath.Join(dir, "scripts", "foo.sh"), "echo local\n")
+
+	client := &fakePusher{
+		tree: []TreeEntry{
+			{Path: "deploy/SKILL.md", Type: "blob", SHA: "base-sha"},
+			{Path: "deploy/scripts/foo.sh", Type: "blob", SHA: "remote-script-sha"},
+		},
+		head: "head-sha",
+	}
+
+	_, err := PushSkill(context.Background(), client, "deploy", dir, state.SkillSource{
+		Registry: "acme/skills",
+		Path:     "deploy",
+		Ref:      "main",
+		LastSHA:  "base-sha",
+		BlobSHAs: map[string]string{
+			"deploy/SKILL.md":       "base-sha",
+			"deploy/scripts/foo.sh": "base-script-sha",
+		},
+	})
+	if clierrors.ExitCode(err) != clierrors.ExitConflict {
+		t.Fatalf("exit = %d, want conflict; err=%v", clierrors.ExitCode(err), err)
+	}
+	if client.pushCalled {
+		t.Fatal("push should not be called on partial divergence")
+	}
+}
+
 func TestPushSkillPropagatesNetworkFailure(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "SKILL.md"), "---\nname: deploy\ndescription: Deploy things\n---\n")

--- a/internal/registry/push_test.go
+++ b/internal/registry/push_test.go
@@ -1,0 +1,121 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/Naoray/scribe/internal/state"
+)
+
+type fakePusher struct {
+	tree       []TreeEntry
+	head       string
+	err        error
+	files      map[string][]byte
+	expected   string
+	pushCalled bool
+}
+
+func (f *fakePusher) GetTree(context.Context, string, string, string) ([]TreeEntry, error) {
+	return f.tree, f.err
+}
+
+func (f *fakePusher) LatestCommitSHA(context.Context, string, string, string) (string, error) {
+	return f.head, f.err
+}
+
+func (f *fakePusher) PushFilesAtomic(_ context.Context, _, _, _ string, files map[string][]byte, _ string, expectedHead string) (CommitResult, error) {
+	f.pushCalled = true
+	f.files = files
+	f.expected = expectedHead
+	return CommitResult{SHA: "abc123", URL: "https://github.com/acme/skills/commit/abc123"}, f.err
+}
+
+func TestPushSkillPushesDirectoryInSingleCommit(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "---\nname: deploy\ndescription: Deploy things\n---\n")
+	writeFile(t, filepath.Join(dir, "scripts", "deploy.sh"), "echo deploy\n")
+	writeFile(t, filepath.Join(dir, "versions", "rev-1.md"), "old\n")
+
+	client := &fakePusher{
+		tree: []TreeEntry{{Path: "skills/deploy/SKILL.md", Type: "blob", SHA: "base-sha"}},
+		head: "head-sha",
+	}
+	result, err := PushSkill(context.Background(), client, "deploy", dir, state.SkillSource{
+		SourceRepo: "acme/skills",
+		Path:       "skills/deploy",
+		Ref:        "main",
+		LastSHA:    "base-sha",
+	})
+	if err != nil {
+		t.Fatalf("PushSkill() error = %v", err)
+	}
+	if result.CommitSHA != "abc123" || result.Registry != "acme/skills" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if client.expected != "head-sha" {
+		t.Fatalf("expected head = %q", client.expected)
+	}
+	if _, ok := client.files["skills/deploy/SKILL.md"]; !ok {
+		t.Fatalf("SKILL.md not pushed: %#v", client.files)
+	}
+	if _, ok := client.files["skills/deploy/scripts/deploy.sh"]; !ok {
+		t.Fatalf("adjacent file not pushed: %#v", client.files)
+	}
+	if _, ok := client.files["skills/deploy/versions/rev-1.md"]; ok {
+		t.Fatalf("versions snapshot should not be pushed: %#v", client.files)
+	}
+}
+
+func TestPushSkillRefusesRemoteDivergence(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "---\nname: deploy\ndescription: Deploy things\n---\n")
+	client := &fakePusher{
+		tree: []TreeEntry{{Path: "deploy/SKILL.md", Type: "blob", SHA: "remote-sha"}},
+		head: "head-sha",
+	}
+
+	_, err := PushSkill(context.Background(), client, "deploy", dir, state.SkillSource{
+		Registry: "acme/skills",
+		Path:     "deploy",
+		Ref:      "main",
+		LastSHA:  "base-sha",
+	})
+	if clierrors.ExitCode(err) != clierrors.ExitConflict {
+		t.Fatalf("exit = %d, want conflict; err=%v", clierrors.ExitCode(err), err)
+	}
+	if client.pushCalled {
+		t.Fatal("push should not be called on conflict")
+	}
+}
+
+func TestPushSkillPropagatesNetworkFailure(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "---\nname: deploy\ndescription: Deploy things\n---\n")
+	networkErr := clierrors.Wrap(errors.New("offline"), "GH_NETWORK_FAILED", clierrors.ExitNetwork)
+	client := &fakePusher{err: networkErr}
+
+	_, err := PushSkill(context.Background(), client, "deploy", dir, state.SkillSource{
+		Registry: "acme/skills",
+		Path:     "deploy",
+		Ref:      "main",
+		LastSHA:  "base-sha",
+	})
+	if clierrors.ExitCode(err) != clierrors.ExitNetwork {
+		t.Fatalf("exit = %d, want network; err=%v", clierrors.ExitCode(err), err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -153,13 +153,14 @@ func (i InstalledSkill) IsPackage() bool {
 
 // SkillSource records a registry that provides this skill.
 type SkillSource struct {
-	Registry   string    `json:"registry"`
-	SourceRepo string    `json:"source_repo,omitempty"`
-	Path       string    `json:"path,omitempty"`
-	Author     string    `json:"author,omitempty"`
-	Ref        string    `json:"ref"`
-	LastSHA    string    `json:"last_sha"`
-	LastSynced time.Time `json:"last_synced"`
+	Registry   string            `json:"registry"`
+	SourceRepo string            `json:"source_repo,omitempty"`
+	Path       string            `json:"path,omitempty"`
+	Author     string            `json:"author,omitempty"`
+	Ref        string            `json:"ref"`
+	LastSHA    string            `json:"last_sha"`
+	BlobSHAs   map[string]string `json:"blob_shas,omitempty"`
+	LastSynced time.Time         `json:"last_synced"`
 }
 
 // PushRegistry returns the repository that should receive local edits.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -154,9 +154,20 @@ func (i InstalledSkill) IsPackage() bool {
 // SkillSource records a registry that provides this skill.
 type SkillSource struct {
 	Registry   string    `json:"registry"`
+	SourceRepo string    `json:"source_repo,omitempty"`
+	Path       string    `json:"path,omitempty"`
+	Author     string    `json:"author,omitempty"`
 	Ref        string    `json:"ref"`
 	LastSHA    string    `json:"last_sha"`
 	LastSynced time.Time `json:"last_synced"`
+}
+
+// PushRegistry returns the repository that should receive local edits.
+func (s SkillSource) PushRegistry() string {
+	if s.SourceRepo != "" {
+		return s.SourceRepo
+	}
+	return s.Registry
 }
 
 // ProjectionConflict records a divergent tool-facing projection that Scribe

--- a/internal/sync/blobsha.go
+++ b/internal/sync/blobsha.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"path"
 	"strings"
 
 	"github.com/Naoray/scribe/internal/manifest"
@@ -17,19 +18,46 @@ const missingSkillBlobSHA = "__missing_skill_blob__"
 // content actually changes. The boolean reports whether the skill file was
 // found in the tree; a missing file is distinct from an API failure.
 func resolveSkillBlobSHA(tree []provider.TreeEntry, entry manifest.Entry) (string, bool) {
+	blobs := resolveSkillBlobSHAs(tree, entry)
+	sha, found := blobs[skillBlobTarget(entry)]
+	return sha, found
+}
+
+func resolveSkillBlobSHAs(tree []provider.TreeEntry, entry manifest.Entry) map[string]string {
+	base := skillTreeBase(entry)
+	blobs := map[string]string{}
+	for _, e := range tree {
+		if e.Type != "blob" || !isUnderSkillBase(e.Path, base) {
+			continue
+		}
+		blobs[e.Path] = e.SHA
+	}
+	return blobs
+}
+
+func skillBlobTarget(entry manifest.Entry) string {
+	base := skillTreeBase(entry)
+	if base == "" || base == "." {
+		return "SKILL.md"
+	}
+	return path.Join(base, "SKILL.md")
+}
+
+func skillTreeBase(entry manifest.Entry) string {
 	skillPath := entry.Path
 	if skillPath == "" {
 		skillPath = entry.Name
 	}
 	skillPath = strings.TrimSuffix(skillPath, "/")
-	target := "SKILL.md"
-	if skillPath != "" && skillPath != "." && skillPath != "SKILL.md" {
-		target = skillPath + "/SKILL.md"
+	if skillPath == "SKILL.md" {
+		return "."
 	}
-	for _, e := range tree {
-		if e.Type == "blob" && e.Path == target {
-			return e.SHA, true
-		}
+	return skillPath
+}
+
+func isUnderSkillBase(filePath, base string) bool {
+	if base == "" || base == "." {
+		return true
 	}
-	return "", false
+	return filePath == base || strings.HasPrefix(filePath, base+"/")
 }

--- a/internal/sync/blobsha_test.go
+++ b/internal/sync/blobsha_test.go
@@ -77,3 +77,23 @@ func TestResolveSkillBlobSHA(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveSkillBlobSHAs(t *testing.T) {
+	tree := []provider.TreeEntry{
+		{Path: "skills/deploy/SKILL.md", Type: "blob", SHA: "skillblob"},
+		{Path: "skills/deploy/scripts/foo.sh", Type: "blob", SHA: "scriptblob"},
+		{Path: "skills/deploy", Type: "tree", SHA: "treeblob"},
+		{Path: "skills/other/SKILL.md", Type: "blob", SHA: "otherblob"},
+	}
+
+	got := resolveSkillBlobSHAs(tree, manifest.Entry{Name: "deploy", Path: "skills/deploy"})
+	if got["skills/deploy/SKILL.md"] != "skillblob" {
+		t.Fatalf("SKILL.md SHA = %q", got["skills/deploy/SKILL.md"])
+	}
+	if got["skills/deploy/scripts/foo.sh"] != "scriptblob" {
+		t.Fatalf("script SHA = %q", got["skills/deploy/scripts/foo.sh"])
+	}
+	if _, ok := got["skills/other/SKILL.md"]; ok {
+		t.Fatalf("included blob outside skill subtree: %#v", got)
+	}
+}

--- a/internal/sync/events.go
+++ b/internal/sync/events.go
@@ -49,6 +49,7 @@ type SkillStatus struct {
 	Maintainer string
 	IsPackage  bool
 	LatestSHA  string // resolved SHA for branch-pinned skills; empty if unavailable
+	BlobSHAs   map[string]string
 }
 
 // DisplayVersion returns the best human-readable version for this skill.

--- a/internal/sync/source_test.go
+++ b/internal/sync/source_test.go
@@ -1,0 +1,32 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/Naoray/scribe/internal/manifest"
+)
+
+func TestSkillSourceFromEntryPersistsBlobSHAs(t *testing.T) {
+	blobs := map[string]string{
+		"skills/deploy/SKILL.md":       "skillblob",
+		"skills/deploy/scripts/foo.sh": "scriptblob",
+	}
+
+	source := skillSourceFromEntry("acme/team", &manifest.Entry{
+		Name:   "deploy",
+		Path:   "skills/deploy",
+		Source: "github:acme/skills@main",
+	}, "main", "skillblob", blobs)
+
+	if source.BlobSHAs["skills/deploy/SKILL.md"] != "skillblob" {
+		t.Fatalf("SKILL.md SHA = %q", source.BlobSHAs["skills/deploy/SKILL.md"])
+	}
+	if source.BlobSHAs["skills/deploy/scripts/foo.sh"] != "scriptblob" {
+		t.Fatalf("script SHA = %q", source.BlobSHAs["skills/deploy/scripts/foo.sh"])
+	}
+
+	blobs["skills/deploy/SKILL.md"] = "mutated"
+	if source.BlobSHAs["skills/deploy/SKILL.md"] != "skillblob" {
+		t.Fatal("source BlobSHAs should not alias caller map")
+	}
+}

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -497,12 +497,7 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 			}
 
 			// Build sources: merge with existing sources from other registries.
-			newSource := state.SkillSource{
-				Registry:   teamRepo,
-				Ref:        ref,
-				LastSHA:    sk.LatestSHA,
-				LastSynced: time.Now().UTC(),
-			}
+			newSource := skillSourceFromEntry(teamRepo, sk.Entry, ref, sk.LatestSHA)
 			sources := mergeSources(installed, newSource)
 
 			// Preserve pinned ToolsMode across re-syncs. New skills default to
@@ -840,12 +835,7 @@ func (s *Syncer) applyPackage(ctx context.Context, sk SkillStatus, teamRepo stri
 		}
 
 		installed := lookupInstalled(st, stateName)
-		newSource := state.SkillSource{
-			Registry:   teamRepo,
-			Ref:        ref,
-			LastSHA:    sk.LatestSHA,
-			LastSynced: time.Now().UTC(),
-		}
+		newSource := skillSourceFromEntry(teamRepo, sk.Entry, ref, sk.LatestSHA)
 
 		st.RecordInstall(stateName, state.InstalledSkill{
 			Revision:   nextRevision(installed),
@@ -1016,6 +1006,30 @@ func mergeSources(installed *state.InstalledSkill, newSource state.SkillSource) 
 	return sources
 }
 
+func skillSourceFromEntry(teamRepo string, entry *manifest.Entry, ref, lastSHA string) state.SkillSource {
+	source := state.SkillSource{
+		Registry:   teamRepo,
+		Ref:        ref,
+		LastSHA:    lastSHA,
+		LastSynced: time.Now().UTC(),
+	}
+	if entry == nil {
+		return source
+	}
+	source.Path = entry.Path
+	source.Author = entry.Author
+	if source.Path == "" {
+		source.Path = entry.Name
+	}
+	if src, err := manifest.ParseSource(entry.Source); err == nil {
+		source.SourceRepo = src.Owner + "/" + src.Repo
+		if source.Ref == "" {
+			source.Ref = src.Ref
+		}
+	}
+	return source
+}
+
 // updateSourceEntry updates the source entry for a registry in the installed skill state.
 // Used after merge operations where we don't want to fully overwrite the install record.
 func (s *Syncer) updateSourceEntry(st *state.State, skillName, teamRepo string, sk SkillStatus, installed *state.InstalledSkill) {
@@ -1024,12 +1038,7 @@ func (s *Syncer) updateSourceEntry(st *state.State, skillName, teamRepo string, 
 	if parseErr == nil {
 		ref = src.Ref
 	}
-	newSource := state.SkillSource{
-		Registry:   teamRepo,
-		Ref:        ref,
-		LastSHA:    sk.LatestSHA,
-		LastSynced: time.Now().UTC(),
-	}
+	newSource := skillSourceFromEntry(teamRepo, sk.Entry, ref, sk.LatestSHA)
 
 	existing := st.Installed[skillName]
 	existing.Sources = mergeSources(installed, newSource)
@@ -1099,12 +1108,7 @@ func (s *Syncer) applyTreePackage(ctx context.Context, sk SkillStatus, teamRepo 
 	// projects them into tool skill dirs — the package ran its own install
 	// and anything it needs now lives wherever that script decided.
 	src, _ := manifest.ParseSource(entrySource(sk.Entry))
-	newSource := state.SkillSource{
-		Registry:   teamRepo,
-		Ref:        src.Ref,
-		LastSHA:    sk.LatestSHA,
-		LastSynced: time.Now().UTC(),
-	}
+	newSource := skillSourceFromEntry(teamRepo, sk.Entry, src.Ref, sk.LatestSHA)
 
 	st.RecordInstall(sk.Name, state.InstalledSkill{
 		Revision:   nextRevision(installed),

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -152,6 +152,7 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 		// still compare commit SHAs via LatestCommitSHA (tree-based identity is a
 		// follow-up PR). If the API is unavailable, latestSHA stays "" and
 		// compareEntry handles that gracefully.
+		var blobSHAs map[string]string
 		if err == nil {
 			switch {
 			case entry.IsPackage():
@@ -176,8 +177,8 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 					}
 				}
 				if len(tree) > 0 {
-					resolvedSHA, found := resolveSkillBlobSHA(tree, *entry)
-					if found {
+					blobSHAs = resolveSkillBlobSHAs(tree, *entry)
+					if resolvedSHA, found := blobSHAs[skillBlobTarget(*entry)]; found {
 						latestSHA = resolvedSHA
 					} else {
 						latestSHA = missingSkillBlobSHA
@@ -196,6 +197,7 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 			Maintainer: entry.Maintainer(),
 			IsPackage:  entry.IsPackage(),
 			LatestSHA:  latestSHA,
+			BlobSHAs:   blobSHAs,
 		})
 	}
 
@@ -497,7 +499,7 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 			}
 
 			// Build sources: merge with existing sources from other registries.
-			newSource := skillSourceFromEntry(teamRepo, sk.Entry, ref, sk.LatestSHA)
+			newSource := skillSourceFromEntry(teamRepo, sk.Entry, ref, sk.LatestSHA, sk.BlobSHAs)
 			sources := mergeSources(installed, newSource)
 
 			// Preserve pinned ToolsMode across re-syncs. New skills default to
@@ -835,7 +837,7 @@ func (s *Syncer) applyPackage(ctx context.Context, sk SkillStatus, teamRepo stri
 		}
 
 		installed := lookupInstalled(st, stateName)
-		newSource := skillSourceFromEntry(teamRepo, sk.Entry, ref, sk.LatestSHA)
+		newSource := skillSourceFromEntry(teamRepo, sk.Entry, ref, sk.LatestSHA, sk.BlobSHAs)
 
 		st.RecordInstall(stateName, state.InstalledSkill{
 			Revision:   nextRevision(installed),
@@ -1006,11 +1008,12 @@ func mergeSources(installed *state.InstalledSkill, newSource state.SkillSource) 
 	return sources
 }
 
-func skillSourceFromEntry(teamRepo string, entry *manifest.Entry, ref, lastSHA string) state.SkillSource {
+func skillSourceFromEntry(teamRepo string, entry *manifest.Entry, ref, lastSHA string, blobSHAs map[string]string) state.SkillSource {
 	source := state.SkillSource{
 		Registry:   teamRepo,
 		Ref:        ref,
 		LastSHA:    lastSHA,
+		BlobSHAs:   cloneBlobSHAs(blobSHAs),
 		LastSynced: time.Now().UTC(),
 	}
 	if entry == nil {
@@ -1030,6 +1033,17 @@ func skillSourceFromEntry(teamRepo string, entry *manifest.Entry, ref, lastSHA s
 	return source
 }
 
+func cloneBlobSHAs(blobSHAs map[string]string) map[string]string {
+	if len(blobSHAs) == 0 {
+		return nil
+	}
+	clone := make(map[string]string, len(blobSHAs))
+	for path, sha := range blobSHAs {
+		clone[path] = sha
+	}
+	return clone
+}
+
 // updateSourceEntry updates the source entry for a registry in the installed skill state.
 // Used after merge operations where we don't want to fully overwrite the install record.
 func (s *Syncer) updateSourceEntry(st *state.State, skillName, teamRepo string, sk SkillStatus, installed *state.InstalledSkill) {
@@ -1038,7 +1052,7 @@ func (s *Syncer) updateSourceEntry(st *state.State, skillName, teamRepo string, 
 	if parseErr == nil {
 		ref = src.Ref
 	}
-	newSource := skillSourceFromEntry(teamRepo, sk.Entry, ref, sk.LatestSHA)
+	newSource := skillSourceFromEntry(teamRepo, sk.Entry, ref, sk.LatestSHA, sk.BlobSHAs)
 
 	existing := st.Installed[skillName]
 	existing.Sources = mergeSources(installed, newSource)
@@ -1108,7 +1122,7 @@ func (s *Syncer) applyTreePackage(ctx context.Context, sk SkillStatus, teamRepo 
 	// projects them into tool skill dirs — the package ran its own install
 	// and anything it needs now lives wherever that script decided.
 	src, _ := manifest.ParseSource(entrySource(sk.Entry))
-	newSource := skillSourceFromEntry(teamRepo, sk.Entry, src.Ref, sk.LatestSHA)
+	newSource := skillSourceFromEntry(teamRepo, sk.Entry, src.Ref, sk.LatestSHA, sk.BlobSHAs)
 
 	st.RecordInstall(sk.Name, state.InstalledSkill{
 		Revision:   nextRevision(installed),

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "1e1db7da",
+      "content_hash": "f1287504",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe-agent",

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "0e97a648",
+      "content_hash": "1e1db7da",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe-agent",


### PR DESCRIPTION
Pushes local skill changes back to originating registry via GitHub Contents API.\n\n## Summary\n- New cobra command `scribe push <name>`\n- Atomic single-commit push via PUT contents API\n- Author enforcement (state metadata + auth token)\n- Validates name/description before push\n- Conflict refusal when remote diverged\n\nCloses #45\n\n## Test plan\n- [x] go test ./...\n- [ ] scribe push <skill> --json (happy path)\n- [x] scribe push (non-author) → exit 4\n- [x] scribe push (diverged) → exit 5\n- [x] scribe schema push --json