### PR TITLE
feat(sync): alias support for name conflicts (todo #388, GH #99)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 
 | Command | Flags | Output schema |
 |---|---|---|
-| `scribe add` | --force, --json, --registry, --yes | yes |
+| `scribe add` | --alias, --force, --json, --registry, --yes | yes |
 | `scribe adopt` | --dry-run, --json, --verbose, --yes | yes |
 | `scribe browse` | --install, --json, --query, --registry, --yes | no |
 | `scribe config adoption` | --add-path, --json, --mode, --remove-path | no |
@@ -67,7 +67,7 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe doctor` | --fix, --json, --skill | yes |
 | `scribe explain` | --json, --raw | yes |
 | `scribe guide` | --json | yes |
-| `scribe install` | --all, --force, --json, --registry | no |
+| `scribe install` | --alias, --all, --force, --json, --registry | no |
 | `scribe list` | --fields, --json, --registry, --remote | yes |
 | `scribe migrate global-to-projects` | --dry-run, --json, --project | no |
 | `scribe migrate` | --json | no |
@@ -92,7 +92,7 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe skill tools` | --disable, --enable, --json, --reset | no |
 | `scribe skill` | --json | no |
 | `scribe status` | --json | yes |
-| `scribe sync` | --all, --force, --json, --registry, --trust-all | yes |
+| `scribe sync` | --alias, --all, --force, --json, --registry, --trust-all | yes |
 | `scribe tools add` | --detect, --install, --json, --path, --uninstall | no |
 | `scribe tools disable` | --json | no |
 | `scribe tools enable` | --json | no |

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -38,6 +38,11 @@ type installResult struct {
 	Error    string `json:"error,omitempty"`
 }
 
+type installRunResults struct {
+	Installed  []installResult
+	Resolution *nameConflictResolutionPayload
+}
+
 // browseEntry pairs a SkillStatus with the registry it came from.
 type browseEntry struct {
 	Status   sync.SkillStatus
@@ -120,7 +125,10 @@ func runAdd(cmd *cobra.Command, args []string) error {
 				clierrors.WithRemediation("run `gh auth login` or set GITHUB_TOKEN"),
 			)
 		}
-		return runAddDirectInstallForCommand(cmd, ctx, registryRepo, skillName, cfg, st, newInstallSyncerWithOptions(client, targets, forceBudget, aliasName), true, useJSON, skipConfirm)
+		if err := runAddDirectInstallForCommand(cmd, ctx, registryRepo, skillName, cfg, st, newInstallSyncerWithOptions(client, targets, forceBudget, aliasName), true, useJSON, skipConfirm); err != nil {
+			return handleNameConflictError(cmd, err)
+		}
+		return nil
 	}
 
 	// Need at least one connected registry to search/browse.
@@ -192,7 +200,10 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	return installSelected(ctx, selected, cfg, st, client, targets, skipConfirm, forceBudget, aliasName)
+	if err := installSelected(ctx, selected, cfg, st, client, targets, skipConfirm, forceBudget, aliasName); err != nil {
+		return handleNameConflictError(cmd, err)
+	}
+	return nil
 }
 
 // parseSkillRef parses "owner/repo:skillname" into its parts.
@@ -282,7 +293,7 @@ func runAddDirectInstallForCommand(
 		if useJSON {
 			return emitInstallJSON([]installResult{{
 				Name: target.Name, Registry: registryRepo, Status: "already-installed",
-			}}, cmd)
+			}}, nil, cmd)
 		}
 		fmt.Printf("%s is already installed (current).\n", skillName)
 		return nil
@@ -309,7 +320,7 @@ func runAddDirectInstallForCommand(
 	}
 
 	if useJSON {
-		return emitInstallJSON(*results, cmd)
+		return emitInstallJSON(results.Installed, results.Resolution, cmd)
 	}
 	return nil
 }
@@ -430,8 +441,8 @@ func resolveCurrentProjectRoot() string {
 
 // wireInstallSyncer attaches an Emit callback that prints progress (or
 // collects results for JSON output) and returns the result slice pointer.
-func wireInstallSyncer(syncer *sync.Syncer, registryRepo string, useJSON bool) *[]installResult {
-	results := &[]installResult{}
+func wireInstallSyncer(syncer *sync.Syncer, registryRepo string, useJSON bool) *installRunResults {
+	results := &installRunResults{}
 	syncer.Emit = func(msg any) {
 		switch m := msg.(type) {
 		case sync.SkillInstalledMsg:
@@ -440,7 +451,7 @@ func wireInstallSyncer(syncer *sync.Syncer, registryRepo string, useJSON bool) *
 				if m.Updated {
 					status = "updated"
 				}
-				*results = append(*results, installResult{
+				results.Installed = append(results.Installed, installResult{
 					Name: m.Name, Registry: registryRepo, Status: status,
 				})
 			} else {
@@ -452,7 +463,7 @@ func wireInstallSyncer(syncer *sync.Syncer, registryRepo string, useJSON bool) *
 			}
 		case sync.SkillErrorMsg:
 			if useJSON {
-				*results = append(*results, installResult{
+				results.Installed = append(results.Installed, installResult{
 					Name: m.Name, Registry: registryRepo, Status: "error", Error: m.Err.Error(),
 				})
 			} else {
@@ -462,6 +473,9 @@ func wireInstallSyncer(syncer *sync.Syncer, registryRepo string, useJSON bool) *
 			if !useJSON {
 				fmt.Fprintf(os.Stderr, "warning: %s\n", m.Message)
 			}
+		case sync.NameConflictResolvedMsg:
+			payload := conflictResolutionPayload(m.Conflict, m.Resolution)
+			results.Resolution = &payload
 		}
 	}
 	return results
@@ -566,8 +580,11 @@ func emitBrowseJSONForCommand(cmd *cobra.Command, entries []browseEntry) error {
 }
 
 // emitInstallJSON emits per-skill install results as JSON.
-func emitInstallJSON(results []installResult, cmd *cobra.Command) error {
+func emitInstallJSON(results []installResult, resolution *nameConflictResolutionPayload, cmd *cobra.Command) error {
 	payload := map[string]any{"installed": results}
+	if resolution != nil {
+		payload["resolution"] = resolution
+	}
 	if cmd == nil {
 		return json.NewEncoder(os.Stdout).Encode(payload)
 	}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
+	"github.com/Naoray/scribe/internal/workflow"
 )
 
 // skillRefPattern matches "owner/repo:skillname" — direct install reference.
@@ -85,7 +86,8 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	aliasName, _ := cmd.Flags().GetString("alias")
 
 	isTTY := isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
-	useJSON := jsonFlag || !isatty.IsTerminal(os.Stdout.Fd())
+	conflictMode := workflow.ConflictModeForProcess(jsonFlag)
+	useJSON := workflow.UseJSONOutputForProcess(jsonFlag)
 	factory := newCommandFactory()
 
 	cfg, err := factory.Config()
@@ -125,7 +127,9 @@ func runAdd(cmd *cobra.Command, args []string) error {
 				clierrors.WithRemediation("run `gh auth login` or set GITHUB_TOKEN"),
 			)
 		}
-		if err := runAddDirectInstallForCommand(cmd, ctx, registryRepo, skillName, cfg, st, newInstallSyncerWithOptions(client, targets, forceBudget, aliasName), true, useJSON, skipConfirm); err != nil {
+		syncer := newInstallSyncerWithOptions(client, targets, forceBudget, aliasName)
+		configureInstallNameConflictResolver(syncer, conflictMode, aliasName)
+		if err := runAddDirectInstallForCommand(cmd, ctx, registryRepo, skillName, cfg, st, syncer, true, useJSON, skipConfirm); err != nil {
 			return handleNameConflictError(cmd, err)
 		}
 		return nil
@@ -200,7 +204,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if err := installSelected(ctx, selected, cfg, st, client, targets, skipConfirm, forceBudget, aliasName); err != nil {
+	if err := installSelected(ctx, selected, cfg, st, client, targets, skipConfirm, forceBudget, aliasName, conflictMode); err != nil {
 		return handleNameConflictError(cmd, err)
 	}
 	return nil
@@ -337,6 +341,7 @@ func installSelected(
 	skipConfirm bool,
 	forceBudget bool,
 	aliasName string,
+	conflictMode workflow.ConflictMode,
 ) error {
 	// Group by registry.
 	byRegistry := map[string][]sync.SkillStatus{}
@@ -371,6 +376,7 @@ func installSelected(
 	}
 
 	syncer := newInstallSyncerWithOptions(client, targets, forceBudget, aliasName)
+	configureInstallNameConflictResolver(syncer, conflictMode, aliasName)
 
 	var installErr error
 	for _, registryRepo := range order {
@@ -424,6 +430,12 @@ func newInstallSyncerWithOptions(client *gh.Client, targets []tools.Tool, forceB
 		ProjectRoot: resolveCurrentProjectRoot(),
 		ForceBudget: forceBudget,
 		AliasName:   aliasName,
+	}
+}
+
+func configureInstallNameConflictResolver(syncer *sync.Syncer, conflictMode workflow.ConflictMode, aliasName string) {
+	if syncer != nil && conflictMode == workflow.ConflictModeInteractive && aliasName == "" {
+		syncer.NameConflictResolver = workflow.PromptNameConflictResolution
 	}
 }
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -68,6 +68,7 @@ Examples:
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.Flags().String("registry", "", "Limit search to a specific registry (owner/repo)")
 	cmd.Flags().Bool("force", false, "Project skills even when an agent budget is exceeded")
+	cmd.Flags().String("alias", "", "Install incoming skill under this name when a local directory conflicts")
 	return markJSONSupported(cmd)
 }
 
@@ -76,6 +77,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	jsonFlag := jsonFlagPassed(cmd)
 	registryFilter, _ := cmd.Flags().GetString("registry")
 	forceBudget, _ := cmd.Flags().GetBool("force")
+	aliasName, _ := cmd.Flags().GetString("alias")
 
 	isTTY := isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
 	useJSON := jsonFlag || !isatty.IsTerminal(os.Stdout.Fd())
@@ -118,7 +120,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 				clierrors.WithRemediation("run `gh auth login` or set GITHUB_TOKEN"),
 			)
 		}
-		return runAddDirectInstallForCommand(cmd, ctx, registryRepo, skillName, cfg, st, newInstallSyncer(client, targets, forceBudget), true, useJSON, skipConfirm)
+		return runAddDirectInstallForCommand(cmd, ctx, registryRepo, skillName, cfg, st, newInstallSyncerWithOptions(client, targets, forceBudget, aliasName), true, useJSON, skipConfirm)
 	}
 
 	// Need at least one connected registry to search/browse.
@@ -190,7 +192,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	return installSelected(ctx, selected, cfg, st, client, targets, skipConfirm, forceBudget)
+	return installSelected(ctx, selected, cfg, st, client, targets, skipConfirm, forceBudget, aliasName)
 }
 
 // parseSkillRef parses "owner/repo:skillname" into its parts.
@@ -323,6 +325,7 @@ func installSelected(
 	targets []tools.Tool,
 	skipConfirm bool,
 	forceBudget bool,
+	aliasName string,
 ) error {
 	// Group by registry.
 	byRegistry := map[string][]sync.SkillStatus{}
@@ -356,7 +359,7 @@ func installSelected(
 		}
 	}
 
-	syncer := newInstallSyncer(client, targets, forceBudget)
+	syncer := newInstallSyncerWithOptions(client, targets, forceBudget, aliasName)
 
 	var installErr error
 	for _, registryRepo := range order {
@@ -398,6 +401,10 @@ func newInstallSyncer(client *gh.Client, targets []tools.Tool, forceBudgetOpt ..
 	if len(forceBudgetOpt) > 0 {
 		forceBudget = forceBudgetOpt[0]
 	}
+	return newInstallSyncerWithOptions(client, targets, forceBudget, "")
+}
+
+func newInstallSyncerWithOptions(client *gh.Client, targets []tools.Tool, forceBudget bool, aliasName string) *sync.Syncer {
 	return &sync.Syncer{
 		Client:      sync.WrapGitHubClient(client),
 		Provider:    provider.NewGitHubProvider(provider.WrapGitHubClient(client)),
@@ -405,6 +412,7 @@ func newInstallSyncer(client *gh.Client, targets []tools.Tool, forceBudgetOpt ..
 		Executor:    &sync.ShellExecutor{},
 		ProjectRoot: resolveCurrentProjectRoot(),
 		ForceBudget: forceBudget,
+		AliasName:   aliasName,
 	}
 }
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -54,7 +54,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		FilterRegistries: filterRegistries,
 	}
 	if err := workflow.Run(cmd.Context(), workflow.InstallSteps(), bag); err != nil {
-		return err
+		return handleNameConflictError(cmd, err)
 	}
 	return saveWorkflowState(bag)
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -23,6 +23,7 @@ Pass skill names to install specific skills, or use --all to install everything.
 	cmd.Flags().Bool("all", false, "Install all available skills without prompting")
 	cmd.Flags().String("registry", "", "Limit to a specific registry (owner/repo)")
 	cmd.Flags().Bool("force", false, "Project skills even when an agent budget is exceeded")
+	cmd.Flags().String("alias", "", "Install incoming skill under this name when a local directory conflicts")
 	return cmd
 }
 
@@ -30,6 +31,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	allFlag, _ := cmd.Flags().GetBool("all")
 	repoFlag, _ := cmd.Flags().GetString("registry")
 	forceBudget, _ := cmd.Flags().GetBool("force")
+	aliasName, _ := cmd.Flags().GetString("alias")
 	factory := newCommandFactory()
 
 	if err := enforceCurrentBudget(factory, forceBudget); err != nil {
@@ -47,6 +49,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		InstallAllFlag:   allFlag,
 		RepoFlag:         repoFlag,
 		ForceBudget:      forceBudget,
+		AliasName:        aliasName,
 		Factory:          factory,
 		FilterRegistries: filterRegistries,
 	}

--- a/cmd/name_conflict.go
+++ b/cmd/name_conflict.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"time"
+
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/cli/envelope"
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/Naoray/scribe/internal/sync"
+)
+
+type nameConflictResolutionPayload struct {
+	Skill  string                  `json:"skill"`
+	Tool   string                  `json:"tool,omitempty"`
+	Path   string                  `json:"path,omitempty"`
+	Action sync.NameConflictAction `json:"action"`
+	Alias  string                  `json:"alias,omitempty"`
+}
+
+func handleNameConflictError(cmd *cobra.Command, err error) error {
+	var conflict *sync.NameConflictError
+	if !errors.As(err, &conflict) {
+		return err
+	}
+
+	wrapped := clierrors.Wrap(
+		err,
+		"SYNC_NAME_CONFLICT",
+		clierrors.ExitConflict,
+		clierrors.WithRemediation("run `scribe adopt "+conflict.Conflict.Name+"`, retry with `--alias <name>`, or skip from an interactive terminal"),
+	)
+
+	if !jsonFlagPassed(cmd) && isatty.IsTerminal(os.Stdout.Fd()) {
+		return wrapped
+	}
+
+	resolution := conflictResolutionPayload(conflict.Conflict, conflict.Resolution)
+	payload := map[string]any{"resolution": resolution}
+	env := envelope.Envelope{
+		Status:        envelope.StatusError,
+		FormatVersion: envelope.FormatVersion,
+		Data:          payload,
+		Error:         conflictCLIError(wrapped),
+		Meta:          envelopeMetaForCommand(cmd),
+	}
+	if encodeErr := json.NewEncoder(os.Stdout).Encode(env); encodeErr != nil {
+		return encodeErr
+	}
+	return clierrors.Wrap(err, "SYNC_NAME_CONFLICT", clierrors.ExitConflict, clierrors.WithRendered(true))
+}
+
+func conflictResolutionPayload(conflict sync.NameConflict, resolution sync.NameConflictResolution) nameConflictResolutionPayload {
+	return nameConflictResolutionPayload{
+		Skill:  conflict.Name,
+		Tool:   conflict.Tool,
+		Path:   conflict.Path,
+		Action: resolution.Action,
+		Alias:  resolution.Alias,
+	}
+}
+
+func conflictCLIError(err error) *clierrors.Error {
+	var ce *clierrors.Error
+	if errors.As(err, &ce) {
+		return ce
+	}
+	return &clierrors.Error{Code: "SYNC_NAME_CONFLICT", Message: err.Error(), Exit: clierrors.ExitConflict}
+}
+
+func envelopeMetaForCommand(cmd *cobra.Command) envelope.Meta {
+	meta := envelope.Meta{}
+	if cmd == nil {
+		return meta
+	}
+	if version, ok := cmd.Context().Value(envelope.ScribeVersionKey).(string); ok {
+		meta.ScribeVersion = version
+	}
+	if command, ok := cmd.Context().Value(envelope.CommandPathKey).(string); ok {
+		meta.Command = command
+	}
+	if start, ok := cmd.Context().Value(envelope.RunEStartKey).(time.Time); ok {
+		meta.DurationMS = positiveDuration(time.Since(start).Milliseconds())
+	}
+	if bootstrap, ok := cmd.Context().Value(envelope.BootstrapMSKey).(int64); ok {
+		meta.BootstrapMS = positiveDuration(bootstrap)
+	}
+	return meta
+}

--- a/cmd/name_conflict.go
+++ b/cmd/name_conflict.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
 	"github.com/Naoray/scribe/internal/cli/envelope"
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/sync"
+	"github.com/Naoray/scribe/internal/workflow"
 )
 
 type nameConflictResolutionPayload struct {
@@ -35,7 +35,7 @@ func handleNameConflictError(cmd *cobra.Command, err error) error {
 		clierrors.WithRemediation("run `scribe adopt "+conflict.Conflict.Name+"`, retry with `--alias <name>`, or skip from an interactive terminal"),
 	)
 
-	if !jsonFlagPassed(cmd) && isatty.IsTerminal(os.Stdout.Fd()) {
+	if workflow.ConflictModeForProcess(jsonFlagPassed(cmd)) == workflow.ConflictModeInteractive {
 		return wrapped
 	}
 

--- a/cmd/name_conflict_test.go
+++ b/cmd/name_conflict_test.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallNameConflictJSONEnvelope(t *testing.T) {
+	home := setupNameConflictHome(t)
+	realSkillPath := filepath.Join(home, ".claude", "skills", "good-skill")
+	if err := os.MkdirAll(realSkillPath, 0o755); err != nil {
+		t.Fatalf("mkdir conflict dir: %v", err)
+	}
+	writeNameConflictState(t, home)
+
+	stdout, stderr, code := runScribeHelperWithHome(t, home, []string{"sync", "--json", "--registry", "acme/team"})
+	if code != 5 {
+		t.Fatalf("exit = %d, want 5\nstdout=%s\nstderr=%s", code, stdout, stderr)
+	}
+
+	var env struct {
+		Status string `json:"status"`
+		Data   struct {
+			Resolution nameConflictResolutionPayload `json:"resolution"`
+		} `json:"data"`
+		Error struct {
+			Code string `json:"code"`
+			Exit int    `json:"exit_code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("stdout is not JSON envelope: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if env.Status != "error" || env.Error.Code != "SYNC_NAME_CONFLICT" || env.Error.Exit != 5 {
+		t.Fatalf("unexpected envelope: %+v\nstdout=%s", env, stdout)
+	}
+	if env.Data.Resolution.Skill != "good-skill" ||
+		env.Data.Resolution.Action != "unresolved" ||
+		env.Data.Resolution.Path != realSkillPath {
+		t.Fatalf("resolution = %+v, want unresolved good-skill at %s", env.Data.Resolution, realSkillPath)
+	}
+}
+
+func writeNameConflictState(t *testing.T, home string) {
+	t.Helper()
+	raw := []byte(`{
+  "schema_version": 5,
+  "installed": {
+    "good-skill": {
+      "revision": 1,
+      "sources": [
+        {
+          "registry": "acme/team",
+          "ref": "v0.9.0"
+        }
+      ],
+      "tools": [
+        "claude"
+      ],
+      "tools_mode": "inherit"
+    }
+  },
+  "migrations": {
+    "store-v2-flat-skills": true
+  }
+}`)
+	if err := os.WriteFile(filepath.Join(home, ".scribe", "state.json"), raw, 0o644); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+}
+
+func setupNameConflictHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	scribeDir := filepath.Join(home, ".scribe")
+	if err := os.MkdirAll(scribeDir, 0o755); err != nil {
+		t.Fatalf("mkdir .scribe: %v", err)
+	}
+	cfg := `registries:
+  - repo: acme/team
+    enabled: true
+    type: team
+adoption:
+  mode: off
+tools:
+  - name: claude
+    enabled: true
+  - name: codex
+    enabled: false
+  - name: cursor
+    enabled: false
+  - name: gemini
+    enabled: false
+scribe_agent:
+  enabled: false
+`
+	if err := os.WriteFile(filepath.Join(scribeDir, "config.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return home
+}

--- a/cmd/name_conflict_test.go
+++ b/cmd/name_conflict_test.go
@@ -2,9 +2,14 @@ package cmd
 
 import (
 	"encoding/json"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/creack/pty"
 )
 
 func TestInstallNameConflictJSONEnvelope(t *testing.T) {
@@ -41,6 +46,141 @@ func TestInstallNameConflictJSONEnvelope(t *testing.T) {
 		env.Data.Resolution.Path != realSkillPath {
 		t.Fatalf("resolution = %+v, want unresolved good-skill at %s", env.Data.Resolution, realSkillPath)
 	}
+}
+
+func TestSyncNameConflictEnvelopeWhenStdoutNonTTYAndStdinTTY(t *testing.T) {
+	home := setupNameConflictHome(t)
+	realSkillPath := filepath.Join(home, ".claude", "skills", "good-skill")
+	if err := os.MkdirAll(realSkillPath, 0o755); err != nil {
+		t.Fatalf("mkdir conflict dir: %v", err)
+	}
+	writeNameConflictState(t, home)
+
+	stdout, stderr, code := runScribeHelperWithTTYStdin(t, home, []string{"sync", "--registry", "acme/team"})
+	assertNameConflictEnvelope(t, stdout, stderr, code, realSkillPath)
+}
+
+func TestSyncNameConflictEnvelopeWhenStdinNonTTYAndStdoutTTY(t *testing.T) {
+	home := setupNameConflictHome(t)
+	realSkillPath := filepath.Join(home, ".claude", "skills", "good-skill")
+	if err := os.MkdirAll(realSkillPath, 0o755); err != nil {
+		t.Fatalf("mkdir conflict dir: %v", err)
+	}
+	writeNameConflictState(t, home)
+
+	stdout, stderr, code := runScribeHelperWithTTYStdout(t, home, []string{"sync", "--registry", "acme/team"})
+	assertNameConflictEnvelope(t, stdout, stderr, code, realSkillPath)
+}
+
+func TestSyncNameConflictEnvelopeWhenBothNonTTY(t *testing.T) {
+	home := setupNameConflictHome(t)
+	realSkillPath := filepath.Join(home, ".claude", "skills", "good-skill")
+	if err := os.MkdirAll(realSkillPath, 0o755); err != nil {
+		t.Fatalf("mkdir conflict dir: %v", err)
+	}
+	writeNameConflictState(t, home)
+
+	stdout, stderr, code := runScribeHelperWithHome(t, home, []string{"sync", "--registry", "acme/team"})
+	assertNameConflictEnvelope(t, stdout, stderr, code, realSkillPath)
+}
+
+func assertNameConflictEnvelope(t *testing.T, stdout, stderr string, code int, realSkillPath string) {
+	t.Helper()
+	if code != 5 {
+		t.Fatalf("exit = %d, want 5\nstdout=%s\nstderr=%s", code, stdout, stderr)
+	}
+
+	var env struct {
+		Status string `json:"status"`
+		Data   struct {
+			Resolution nameConflictResolutionPayload `json:"resolution"`
+		} `json:"data"`
+		Error struct {
+			Code string `json:"code"`
+			Exit int    `json:"exit_code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("stdout is not JSON envelope: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if env.Status != "error" || env.Error.Code != "SYNC_NAME_CONFLICT" || env.Error.Exit != 5 {
+		t.Fatalf("unexpected envelope: %+v\nstdout=%s", env, stdout)
+	}
+	if env.Data.Resolution.Skill != "good-skill" ||
+		env.Data.Resolution.Action != "unresolved" ||
+		env.Data.Resolution.Path != realSkillPath {
+		t.Fatalf("resolution = %+v, want unresolved good-skill at %s", env.Data.Resolution, realSkillPath)
+	}
+}
+
+func runScribeHelperWithTTYStdin(t *testing.T, home string, args []string) (string, string, int) {
+	t.Helper()
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Fatalf("open pty: %v", err)
+	}
+	t.Cleanup(func() { _ = ptmx.Close() })
+
+	cmd := scribeHelperCommand(t, home, args)
+	cmd.Stdin = tty
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Start()
+	_ = tty.Close()
+	if err != nil {
+		t.Fatalf("helper start: %v", err)
+	}
+	code := waitExitCode(t, cmd)
+	return stdout.String(), stderr.String(), code
+}
+
+func runScribeHelperWithTTYStdout(t *testing.T, home string, args []string) (string, string, int) {
+	t.Helper()
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Fatalf("open pty: %v", err)
+	}
+	t.Cleanup(func() { _ = ptmx.Close() })
+
+	cmd := scribeHelperCommand(t, home, args)
+	cmd.Stdin = strings.NewReader("piped input\n")
+	cmd.Stdout = tty
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+
+	err = cmd.Start()
+	_ = tty.Close()
+	if err != nil {
+		t.Fatalf("helper start: %v", err)
+	}
+	out, readErr := io.ReadAll(ptmx)
+	if readErr != nil && !strings.Contains(readErr.Error(), "input/output error") {
+		t.Fatalf("read pty: %v", readErr)
+	}
+	code := waitExitCode(t, cmd)
+	return strings.ReplaceAll(string(out), "\r\n", "\n"), stderr.String(), code
+}
+
+func scribeHelperCommand(t *testing.T, home string, args []string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], append([]string{"-test.run=TestScribeHelperProcess", "--"}, args...)...)
+	cmd.Env = append(os.Environ(), "GO_WANT_SCRIBE_HELPER_PROCESS=1", "HOME="+home, partialFixtureEnv+"=1")
+	return cmd
+}
+
+func waitExitCode(t *testing.T, cmd *exec.Cmd) int {
+	t.Helper()
+	err := cmd.Wait()
+	if err == nil {
+		return 0
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("helper wait: %v", err)
+	}
+	return exitErr.ExitCode()
 }
 
 func writeNameConflictState(t *testing.T, home string) {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -46,7 +46,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		FilterRegistries: filterRegistries,
 	}
 	if err := workflow.Run(cmd.Context(), workflow.SyncSteps(), bag); err != nil {
-		return err
+		return handleNameConflictError(cmd, err)
 	}
 	if bag.Partial {
 		if err := saveWorkflowState(bag); err != nil {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -18,6 +18,7 @@ func newSyncCommand() *cobra.Command {
 	cmd.Flags().Bool("trust-all", false, "Approve all package install commands without prompting")
 	cmd.Flags().Bool("all", false, "Sync all registries (default behavior)")
 	cmd.Flags().Bool("force", false, "Project skills even when an agent budget is exceeded")
+	cmd.Flags().String("alias", "", "Install incoming skill under this name when a local directory conflicts")
 	cmd.Flags().MarkHidden("all")
 	return markJSONSupported(cmd)
 }
@@ -27,6 +28,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 	repoFlag, _ := cmd.Flags().GetString("registry")
 	trustAllFlag, _ := cmd.Flags().GetBool("trust-all")
 	forceBudget, _ := cmd.Flags().GetBool("force")
+	aliasName, _ := cmd.Flags().GetString("alias")
 	factory := commandFactory()
 
 	if err := enforceCurrentBudget(factory, forceBudget); err != nil {
@@ -39,6 +41,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		RepoFlag:         repoFlag,
 		TrustAllFlag:     trustAllFlag,
 		ForceBudget:      forceBudget,
+		AliasName:        aliasName,
 		Factory:          factory,
 		FilterRegistries: filterRegistries,
 	}

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/internal/sync/events.go
+++ b/internal/sync/events.go
@@ -176,6 +176,62 @@ type SkillAdoptionNeededMsg struct {
 	Path string
 }
 
+type NameConflictAction string
+
+const (
+	NameConflictActionUnresolved NameConflictAction = "unresolved"
+	NameConflictActionAdopt      NameConflictAction = "adopt"
+	NameConflictActionAlias      NameConflictAction = "alias"
+	NameConflictActionSkip       NameConflictAction = "skip"
+)
+
+type NameConflict struct {
+	Name string
+	Tool string
+	Path string
+}
+
+type NameConflictResolution struct {
+	Action NameConflictAction `json:"action"`
+	Alias  string             `json:"alias,omitempty"`
+}
+
+type NameConflictResolvedMsg struct {
+	Conflict   NameConflict
+	Resolution NameConflictResolution
+}
+
+type NameConflictError struct {
+	Conflict   NameConflict
+	Resolution NameConflictResolution
+	Err        error
+}
+
+func (e *NameConflictError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	switch e.Resolution.Action {
+	case NameConflictActionAdopt:
+		return "name conflict for " + e.Conflict.Name + ": run `scribe adopt " + e.Conflict.Name + "` first, then retry sync"
+	case NameConflictActionAlias:
+		if e.Resolution.Alias != "" {
+			return "name conflict for " + e.Conflict.Name + ": alias " + e.Resolution.Alias + " already exists"
+		}
+	}
+	return "name conflict for " + e.Conflict.Name + ": real directory at " + e.Conflict.Path
+}
+
+func (e *NameConflictError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
 // MergeConflictMsg is sent when a 3-way merge produces conflict markers.
 type MergeConflictMsg struct {
 	Name string

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -69,6 +69,14 @@ type Syncer struct {
 	// Returns true if approved, false if denied.
 	// If nil and TrustAll is false, packages needing approval are skipped.
 	ApprovalFunc func(name, command, source string) bool
+
+	// AliasName installs an incoming skill under this alternate name when a
+	// real directory already exists at the original tool projection path.
+	AliasName string
+
+	// NameConflictResolver is called when a real directory already exists at
+	// the incoming skill name. Nil means non-interactive conflict.
+	NameConflictResolver func(NameConflict) (NameConflictResolution, error)
 }
 
 // ModifiedStrategy controls how sync treats outdated skills with local edits.
@@ -432,14 +440,6 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 				}
 			}
 
-			// Write files to canonical store once, then symlink per target.
-			canonicalDir, err := tools.WriteToStore(sk.Name, tFiles)
-			if err != nil {
-				s.emit(SkillErrorMsg{Name: sk.Name, Err: fmt.Errorf("write store: %w", err)})
-				summary.Failed++
-				continue
-			}
-
 			// Filter to the skill's effective tools (pinned mode respects user
 			// selection; inherit mode uses every globally-enabled tool).
 			effectiveTools := selectEffectiveTools(s.Tools, installed)
@@ -452,24 +452,58 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 				}
 			}
 
+			installName := sk.Name
+			if conflict, ok := s.firstRealDirectoryConflict(sk.Name, effectiveTools); ok {
+				resolution, err := s.resolveNameConflict(conflict, st, effectiveTools)
+				if err != nil {
+					return err
+				}
+				s.emit(NameConflictResolvedMsg{Conflict: conflict, Resolution: resolution})
+				switch resolution.Action {
+				case NameConflictActionSkip:
+					s.emit(SkillSkippedMsg{Name: sk.Name})
+					summary.Skipped++
+					continue
+				case NameConflictActionAlias:
+					installName = resolution.Alias
+				case NameConflictActionAdopt:
+					return &NameConflictError{Conflict: conflict, Resolution: resolution}
+				default:
+					return &NameConflictError{Conflict: conflict, Resolution: resolution}
+				}
+			}
+
+			// Write files to canonical store once, then symlink per target.
+			canonicalDir, err := tools.WriteToStore(installName, tFiles)
+			if err != nil {
+				s.emit(SkillErrorMsg{Name: installName, Err: fmt.Errorf("write store: %w", err)})
+				summary.Failed++
+				continue
+			}
+
 			var paths []string
 			var toolNames []string
 			toolFailed := false
 			for _, t := range effectiveTools {
-				links, err := t.Install(sk.Name, canonicalDir, s.ProjectRoot)
+				links, err := t.Install(installName, canonicalDir, s.ProjectRoot)
 				if err != nil {
 					if errors.Is(err, tools.ErrRealDirectoryExists) {
-						existing, pathErr := t.SkillPath(sk.Name)
+						existing, pathErr := t.SkillPath(installName)
 						if pathErr != nil {
-							s.emit(SkillErrorMsg{Name: sk.Name, Err: fmt.Errorf("link to %s: %w", t.Name(), err)})
+							return &NameConflictError{
+								Conflict:   NameConflict{Name: installName, Tool: t.Name()},
+								Resolution: NameConflictResolution{Action: NameConflictActionUnresolved},
+								Err:        fmt.Errorf("link to %s: %w", t.Name(), err),
+							}
 						} else {
-							s.emit(SkillErrorMsg{
-								Name: sk.Name,
-								Err:  fmt.Errorf("link to %s: real directory at %s: run `scribe adopt %s` first", t.Name(), existing, sk.Name),
-							})
+							return &NameConflictError{
+								Conflict:   NameConflict{Name: installName, Tool: t.Name(), Path: existing},
+								Resolution: NameConflictResolution{Action: NameConflictActionUnresolved},
+								Err:        fmt.Errorf("link to %s: real directory at %s: run `scribe adopt %s` first", t.Name(), existing, installName),
+							}
 						}
 					} else {
-						s.emit(SkillErrorMsg{Name: sk.Name, Err: fmt.Errorf("link to %s: %w", t.Name(), err)})
+						s.emit(SkillErrorMsg{Name: installName, Err: fmt.Errorf("link to %s: %w", t.Name(), err)})
 					}
 					summary.Failed++
 					toolFailed = true
@@ -512,7 +546,7 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 			}
 
 			managedPaths := mergeManagedPaths(installed, paths)
-			st.RecordInstall(sk.Name, state.InstalledSkill{
+			st.RecordInstall(installName, state.InstalledSkill{
 				Revision:      nextRevision(installed),
 				InstalledHash: installedHash,
 				Sources:       sources,
@@ -524,7 +558,7 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 			})
 			// Save after each successful install — partial sync is safe.
 			if err := st.Save(); err != nil {
-				s.emit(SkillErrorMsg{Name: sk.Name, Err: fmt.Errorf("save state after %s: %w", sk.Name, err)})
+				s.emit(SkillErrorMsg{Name: installName, Err: fmt.Errorf("save state after %s: %w", installName, err)})
 			}
 
 			// Enforce version retention after successful write.
@@ -533,7 +567,7 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 			}
 
 			s.emit(SkillInstalledMsg{
-				Name:    sk.Name,
+				Name:    installName,
 				Updated: sk.Status == StatusOutdated,
 			})
 			if sk.Status == StatusOutdated {
@@ -557,6 +591,80 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 func (s *Syncer) emit(msg any) {
 	if s.Emit != nil {
 		s.Emit(msg)
+	}
+}
+
+func (s *Syncer) firstRealDirectoryConflict(name string, targetTools []tools.Tool) (NameConflict, bool) {
+	for _, t := range targetTools {
+		if _, ok := t.CanonicalTarget(""); !ok {
+			continue
+		}
+		path, err := t.SkillPath(name)
+		if err != nil {
+			continue
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
+			return NameConflict{Name: name, Tool: t.Name(), Path: path}, true
+		}
+	}
+	return NameConflict{}, false
+}
+
+func (s *Syncer) resolveNameConflict(conflict NameConflict, st *state.State, targetTools []tools.Tool) (NameConflictResolution, error) {
+	resolution := NameConflictResolution{Action: NameConflictActionUnresolved}
+	if strings.TrimSpace(s.AliasName) != "" {
+		resolution = NameConflictResolution{
+			Action: NameConflictActionAlias,
+			Alias:  strings.TrimSpace(s.AliasName),
+		}
+	} else if s.NameConflictResolver != nil {
+		var err error
+		resolution, err = s.NameConflictResolver(conflict)
+		if err != nil {
+			return resolution, err
+		}
+		resolution.Alias = strings.TrimSpace(resolution.Alias)
+	}
+
+	switch resolution.Action {
+	case NameConflictActionAlias:
+		if resolution.Alias == "" {
+			return resolution, &NameConflictError{
+				Conflict:   conflict,
+				Resolution: resolution,
+				Err:        fmt.Errorf("name conflict for %s: alias cannot be empty", conflict.Name),
+			}
+		}
+		if resolution.Alias == conflict.Name {
+			return resolution, &NameConflictError{
+				Conflict:   conflict,
+				Resolution: resolution,
+				Err:        fmt.Errorf("name conflict for %s: alias must be different from the conflicting name", conflict.Name),
+			}
+		}
+		if lookupInstalled(st, resolution.Alias) != nil {
+			return resolution, &NameConflictError{
+				Conflict:   conflict,
+				Resolution: resolution,
+				Err:        fmt.Errorf("name conflict for %s: alias %q is already installed", conflict.Name, resolution.Alias),
+			}
+		}
+		if aliasConflict, ok := s.firstRealDirectoryConflict(resolution.Alias, targetTools); ok {
+			return resolution, &NameConflictError{
+				Conflict:   aliasConflict,
+				Resolution: resolution,
+				Err:        fmt.Errorf("name conflict for %s: alias %q also conflicts with a real directory at %s", conflict.Name, resolution.Alias, aliasConflict.Path),
+			}
+		}
+		return resolution, nil
+	case NameConflictActionSkip, NameConflictActionAdopt:
+		return resolution, nil
+	default:
+		return resolution, &NameConflictError{Conflict: conflict, Resolution: resolution}
 	}
 }
 

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -2,6 +2,7 @@ package sync_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -673,7 +674,6 @@ func TestApply_RealDirectoryAtProjectionPath(t *testing.T) {
 		t.Fatalf("write existing SKILL.md: %v", err)
 	}
 
-	var events []any
 	syncer := &sync.Syncer{
 		Client: &syncTestFetcher{
 			files: []tools.SkillFile{
@@ -681,7 +681,6 @@ func TestApply_RealDirectoryAtProjectionPath(t *testing.T) {
 			},
 		},
 		Tools: []tools.Tool{tools.ClaudeTool{}},
-		Emit:  func(msg any) { events = append(events, msg) },
 	}
 
 	st := &state.State{Installed: make(map[string]state.InstalledSkill)}
@@ -694,26 +693,16 @@ func TestApply_RealDirectoryAtProjectionPath(t *testing.T) {
 		},
 	}}
 
-	if err := syncer.RunWithDiff(context.Background(), "acme/skills", statuses, st); err != nil {
-		t.Fatalf("RunWithDiff: %v", err)
+	err := syncer.RunWithDiff(context.Background(), "acme/skills", statuses, st)
+	if err == nil {
+		t.Fatal("expected conflict error")
 	}
-
-	// Expect a SkillErrorMsg with adoption guidance.
-	var errMsg *sync.SkillErrorMsg
-	for _, ev := range events {
-		if e, ok := ev.(sync.SkillErrorMsg); ok {
-			errMsg = &e
-			break
-		}
+	var conflict *sync.NameConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("error = %T %v, want NameConflictError", err, err)
 	}
-	if errMsg == nil {
-		t.Fatal("expected SkillErrorMsg, none emitted")
-	}
-	if !strings.Contains(errMsg.Err.Error(), "real directory") {
-		t.Errorf("error should mention 'real directory', got: %v", errMsg.Err)
-	}
-	if !strings.Contains(errMsg.Err.Error(), "scribe adopt qa") {
-		t.Errorf("error should mention 'scribe adopt qa', got: %v", errMsg.Err)
+	if !strings.Contains(err.Error(), "real directory") {
+		t.Errorf("error should mention 'real directory', got: %v", err)
 	}
 
 	// Real directory must be preserved.
@@ -725,6 +714,252 @@ func TestApply_RealDirectoryAtProjectionPath(t *testing.T) {
 	if _, ok := st.Installed["qa"]; ok {
 		t.Error("skill should not be in state when install failed")
 	}
+}
+
+func TestRunWithDiff_NameConflictWithoutResolverReturnsConflict(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	realSkillPath := filepath.Join(home, ".test-tool", "qa")
+	if err := os.MkdirAll(realSkillPath, 0o755); err != nil {
+		t.Fatalf("mkdir real skill dir: %v", err)
+	}
+
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{files: []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# qa\n")}}},
+		Tools:  []tools.Tool{testProjectionTool{root: filepath.Join(home, ".test-tool")}},
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{}}
+
+	err := syncer.RunWithDiff(context.Background(), "acme/skills", []sync.SkillStatus{{
+		Name:   "qa",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "qa", Source: "github:acme/skills@main"},
+	}}, st)
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	var conflict *sync.NameConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("error = %T %v, want NameConflictError", err, err)
+	}
+	if conflict.Resolution.Action != sync.NameConflictActionUnresolved {
+		t.Fatalf("resolution action = %q, want unresolved", conflict.Resolution.Action)
+	}
+	if _, ok := st.Installed["qa"]; ok {
+		t.Fatal("qa should not be installed on unresolved conflict")
+	}
+}
+
+func TestRunWithDiff_NameConflictAliasInstallsIncomingUnderAlias(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	realSkillPath := filepath.Join(home, ".test-tool", "qa")
+	if err := os.MkdirAll(realSkillPath, 0o755); err != nil {
+		t.Fatalf("mkdir real skill dir: %v", err)
+	}
+
+	var events []any
+	syncer := &sync.Syncer{
+		Client:    &syncTestFetcher{files: []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# qa\n")}}},
+		Tools:     []tools.Tool{testProjectionTool{root: filepath.Join(home, ".test-tool")}},
+		AliasName: "qa-registry",
+		Emit:      func(msg any) { events = append(events, msg) },
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{}}
+
+	if err := syncer.RunWithDiff(context.Background(), "acme/skills", []sync.SkillStatus{{
+		Name:   "qa",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "qa", Source: "github:acme/skills@main"},
+	}}, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+
+	if _, ok := st.Installed["qa"]; ok {
+		t.Fatal("original name should not be installed")
+	}
+	if _, ok := st.Installed["qa-registry"]; !ok {
+		t.Fatal("alias should be installed")
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".test-tool", "qa-registry")); err != nil {
+		t.Fatalf("alias projection missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(realSkillPath)); err != nil {
+		t.Fatalf("original real directory was touched: %v", err)
+	}
+	assertConflictResolutionEvent(t, events, sync.NameConflictActionAlias, "qa-registry")
+}
+
+func TestRunWithDiff_NameConflictAliasCollisionReturnsConflict(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".test-tool", "qa"), 0o755); err != nil {
+		t.Fatalf("mkdir real skill dir: %v", err)
+	}
+
+	syncer := &sync.Syncer{
+		Client:    &syncTestFetcher{files: []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# qa\n")}}},
+		Tools:     []tools.Tool{testProjectionTool{root: filepath.Join(home, ".test-tool")}},
+		AliasName: "existing",
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"existing": {Revision: 1},
+	}}
+
+	err := syncer.RunWithDiff(context.Background(), "acme/skills", []sync.SkillStatus{{
+		Name:   "qa",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "qa", Source: "github:acme/skills@main"},
+	}}, st)
+	if err == nil {
+		t.Fatal("expected alias collision conflict")
+	}
+	var conflict *sync.NameConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("error = %T %v, want NameConflictError", err, err)
+	}
+	if conflict.Resolution.Action != sync.NameConflictActionAlias || conflict.Resolution.Alias != "existing" {
+		t.Fatalf("resolution = %+v, want alias existing", conflict.Resolution)
+	}
+}
+
+func TestRunWithDiff_NameConflictResolverSkipLeavesExistingUntouched(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	realSkillPath := filepath.Join(home, ".test-tool", "qa")
+	if err := os.MkdirAll(realSkillPath, 0o755); err != nil {
+		t.Fatalf("mkdir real skill dir: %v", err)
+	}
+	marker := filepath.Join(realSkillPath, "SKILL.md")
+	if err := os.WriteFile(marker, []byte("# manual\n"), 0o644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	var events []any
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{files: []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# qa\n")}}},
+		Tools:  []tools.Tool{testProjectionTool{root: filepath.Join(home, ".test-tool")}},
+		NameConflictResolver: func(sync.NameConflict) (sync.NameConflictResolution, error) {
+			return sync.NameConflictResolution{Action: sync.NameConflictActionSkip}, nil
+		},
+		Emit: func(msg any) { events = append(events, msg) },
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{}}
+
+	if err := syncer.RunWithDiff(context.Background(), "acme/skills", []sync.SkillStatus{{
+		Name:   "qa",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "qa", Source: "github:acme/skills@main"},
+	}}, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+	if got, err := os.ReadFile(marker); err != nil || string(got) != "# manual\n" {
+		t.Fatalf("existing marker = %q, %v; want untouched", got, err)
+	}
+	if len(st.Installed) != 0 {
+		t.Fatalf("state installed = %v, want empty", st.Installed)
+	}
+	assertConflictResolutionEvent(t, events, sync.NameConflictActionSkip, "")
+}
+
+func TestRunWithDiff_NameConflictResolverAdoptReturnsGuidance(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".test-tool", "qa"), 0o755); err != nil {
+		t.Fatalf("mkdir real skill dir: %v", err)
+	}
+
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{files: []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# qa\n")}}},
+		Tools:  []tools.Tool{testProjectionTool{root: filepath.Join(home, ".test-tool")}},
+		NameConflictResolver: func(sync.NameConflict) (sync.NameConflictResolution, error) {
+			return sync.NameConflictResolution{Action: sync.NameConflictActionAdopt}, nil
+		},
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{}}
+
+	err := syncer.RunWithDiff(context.Background(), "acme/skills", []sync.SkillStatus{{
+		Name:   "qa",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "qa", Source: "github:acme/skills@main"},
+	}}, st)
+	if err == nil {
+		t.Fatal("expected adopt guidance conflict")
+	}
+	if !strings.Contains(err.Error(), "scribe adopt qa") {
+		t.Fatalf("error = %v, want adopt guidance", err)
+	}
+	var conflict *sync.NameConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("error = %T %v, want NameConflictError", err, err)
+	}
+	if conflict.Resolution.Action != sync.NameConflictActionAdopt {
+		t.Fatalf("resolution action = %q, want adopt", conflict.Resolution.Action)
+	}
+}
+
+type testProjectionTool struct {
+	root string
+}
+
+func (t testProjectionTool) Name() string { return "test-tool" }
+
+func (t testProjectionTool) Install(skillName, canonicalDir, _ string) ([]string, error) {
+	path, err := t.SkillPath(skillName)
+	if err != nil {
+		return nil, err
+	}
+	if info, statErr := os.Lstat(path); statErr == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
+		return nil, fmt.Errorf("%w: %s", tools.ErrRealDirectoryExists, path)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if err := os.Symlink(canonicalDir, path); err != nil {
+		return nil, err
+	}
+	return []string{path}, nil
+}
+
+func (t testProjectionTool) Uninstall(skillName string) error {
+	path, err := t.SkillPath(skillName)
+	if err != nil {
+		return err
+	}
+	return os.Remove(path)
+}
+
+func (t testProjectionTool) Detect() bool { return true }
+
+func (t testProjectionTool) SkillPath(skillName string) (string, error) {
+	return filepath.Join(t.root, skillName), nil
+}
+
+func (t testProjectionTool) CanonicalTarget(canonicalDir string) (string, bool) {
+	return canonicalDir, true
+}
+
+func assertConflictResolutionEvent(t *testing.T, events []any, action sync.NameConflictAction, alias string) {
+	t.Helper()
+	for _, ev := range events {
+		msg, ok := ev.(sync.NameConflictResolvedMsg)
+		if !ok {
+			continue
+		}
+		if msg.Resolution.Action != action || msg.Resolution.Alias != alias {
+			t.Fatalf("resolution event = %+v, want action=%q alias=%q", msg.Resolution, action, alias)
+		}
+		return
+	}
+	t.Fatal("expected NameConflictResolvedMsg")
 }
 
 func writeStoredSkill(t *testing.T, storeDir, name, description string) {

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -25,6 +25,7 @@ type Bag struct {
 	TrustAllFlag   bool   // --trust-all: approve all package commands without prompting
 	InstallAllFlag bool   // --all: install all available skills without prompting
 	ForceBudget    bool   // --force: allow projection over agent description-byte budgets
+	AliasName      string // --alias: install incoming skill under another name on projection conflict
 	LazyGitHub     bool   // skip eager GitHub client/provider setup for local-only flows
 	Factory        *app.Factory
 

--- a/internal/workflow/conflict_mode.go
+++ b/internal/workflow/conflict_mode.go
@@ -1,0 +1,41 @@
+package workflow
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+// ConflictMode describes how name conflicts may be resolved for the current IO
+// shape and output format.
+type ConflictMode int
+
+const (
+	ConflictModeInteractive ConflictMode = iota
+	ConflictModeJSONEnvelope
+)
+
+var conflictModeIsTerminal = isatty.IsTerminal
+
+// ResolveConflictMode centralizes the prompt-vs-envelope decision for name
+// conflict handling across sync, install, and add.
+func ResolveConflictMode(stdin, stdout *os.File, jsonForced bool) ConflictMode {
+	stdinTTY := stdin != nil && conflictModeIsTerminal(stdin.Fd())
+	stdoutTTY := stdout != nil && conflictModeIsTerminal(stdout.Fd())
+	if stdinTTY && stdoutTTY && !jsonForced {
+		return ConflictModeInteractive
+	}
+	return ConflictModeJSONEnvelope
+}
+
+func ConflictModeForProcess(jsonForced bool) ConflictMode {
+	return ResolveConflictMode(os.Stdin, os.Stdout, jsonForced)
+}
+
+func UseJSONOutput(stdin, stdout *os.File, jsonForced bool) bool {
+	return ResolveConflictMode(stdin, stdout, jsonForced) == ConflictModeJSONEnvelope
+}
+
+func UseJSONOutputForProcess(jsonForced bool) bool {
+	return UseJSONOutput(os.Stdin, os.Stdout, jsonForced)
+}

--- a/internal/workflow/conflict_mode_test.go
+++ b/internal/workflow/conflict_mode_test.go
@@ -1,0 +1,87 @@
+package workflow
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveConflictModeMatrix(t *testing.T) {
+	oldIsTerminal := conflictModeIsTerminal
+	t.Cleanup(func() { conflictModeIsTerminal = oldIsTerminal })
+
+	stdin := os.NewFile(1, "stdin")
+	stdout := os.NewFile(2, "stdout")
+
+	tests := []struct {
+		name       string
+		stdinTTY   bool
+		stdoutTTY  bool
+		jsonForced bool
+		want       ConflictMode
+	}{
+		{name: "both tty text", stdinTTY: true, stdoutTTY: true, want: ConflictModeInteractive},
+		{name: "tty stdin non tty stdout", stdinTTY: true, want: ConflictModeJSONEnvelope},
+		{name: "non tty stdin tty stdout", stdoutTTY: true, want: ConflictModeJSONEnvelope},
+		{name: "both non tty", want: ConflictModeJSONEnvelope},
+		{name: "json forced", stdinTTY: true, stdoutTTY: true, jsonForced: true, want: ConflictModeJSONEnvelope},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conflictModeIsTerminal = func(fd uintptr) bool {
+				switch fd {
+				case stdin.Fd():
+					return tt.stdinTTY
+				case stdout.Fd():
+					return tt.stdoutTTY
+				default:
+					return false
+				}
+			}
+
+			if got := ResolveConflictMode(stdin, stdout, tt.jsonForced); got != tt.want {
+				t.Fatalf("mode = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUseJSONOutputUsesConflictModeMatrix(t *testing.T) {
+	oldIsTerminal := conflictModeIsTerminal
+	t.Cleanup(func() { conflictModeIsTerminal = oldIsTerminal })
+
+	stdin := os.NewFile(3, "stdin")
+	stdout := os.NewFile(4, "stdout")
+
+	tests := []struct {
+		name       string
+		stdinTTY   bool
+		stdoutTTY  bool
+		jsonForced bool
+		want       bool
+	}{
+		{name: "both tty text", stdinTTY: true, stdoutTTY: true, want: false},
+		{name: "both tty json forced", stdinTTY: true, stdoutTTY: true, jsonForced: true, want: true},
+		{name: "non tty stdout", stdinTTY: true, want: true},
+		{name: "non tty stdin", stdoutTTY: true, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conflictModeIsTerminal = func(fd uintptr) bool {
+				switch fd {
+				case stdin.Fd():
+					return tt.stdinTTY
+				case stdout.Fd():
+					return tt.stdoutTTY
+				default:
+					return false
+				}
+			}
+
+			if got := UseJSONOutput(stdin, stdout, tt.jsonForced); got != tt.want {
+				t.Fatalf("useJSON = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/workflow/formatter.go
+++ b/internal/workflow/formatter.go
@@ -23,6 +23,7 @@ type Formatter interface {
 	OnSkillSkippedByDenyList(name, registry string)
 	OnSkillError(name string, err error)
 	OnBudgetWarning(agent, message string)
+	OnNameConflictResolved(conflict sync.NameConflict, resolution sync.NameConflictResolution)
 	OnSyncComplete(summary sync.SyncCompleteMsg)
 	OnReconcileConflict(name string, conflict state.ProjectionConflict)
 	OnReconcileComplete(summary sync.ReconcileCompleteMsg)

--- a/internal/workflow/formatter_json.go
+++ b/internal/workflow/formatter_json.go
@@ -17,6 +17,7 @@ type jsonFormatter struct {
 	summary    sync.SyncCompleteMsg
 	denied     []denyListSkip
 	adoption   adoptionResult
+	resolution *nameConflictResolutionResult
 	reconcile  *reconcileResult
 	meta       func() envelope.Meta
 	renderer   output.Renderer
@@ -55,6 +56,14 @@ type skillResult struct {
 type denyListSkip struct {
 	Name     string `json:"name"`
 	Registry string `json:"registry"`
+}
+
+type nameConflictResolutionResult struct {
+	Skill  string                  `json:"skill"`
+	Tool   string                  `json:"tool,omitempty"`
+	Path   string                  `json:"path,omitempty"`
+	Action sync.NameConflictAction `json:"action"`
+	Alias  string                  `json:"alias,omitempty"`
 }
 
 type registryResult struct {
@@ -136,6 +145,16 @@ func (f *jsonFormatter) OnSkillError(name string, err error) {
 }
 
 func (f *jsonFormatter) OnBudgetWarning(_, _ string) {}
+
+func (f *jsonFormatter) OnNameConflictResolved(conflict sync.NameConflict, resolution sync.NameConflictResolution) {
+	f.resolution = &nameConflictResolutionResult{
+		Skill:  conflict.Name,
+		Tool:   conflict.Tool,
+		Path:   conflict.Path,
+		Action: resolution.Action,
+		Alias:  resolution.Alias,
+	}
+}
 
 func (f *jsonFormatter) OnSyncComplete(summary sync.SyncCompleteMsg) {
 	f.summary.Installed += summary.Installed
@@ -293,6 +312,9 @@ func (f *jsonFormatter) Flush() error {
 	}
 	if f.reconcile != nil {
 		out["reconcile"] = f.reconcile
+	}
+	if f.resolution != nil {
+		out["resolution"] = f.resolution
 	}
 	if len(f.denied) > 0 {
 		out["skipped_by_deny_list"] = f.denied

--- a/internal/workflow/formatter_text.go
+++ b/internal/workflow/formatter_text.go
@@ -68,6 +68,15 @@ func (f *textFormatter) OnBudgetWarning(_, message string) {
 	fmt.Fprintf(f.errOut, "warning: %s\n", message)
 }
 
+func (f *textFormatter) OnNameConflictResolved(conflict sync.NameConflict, resolution sync.NameConflictResolution) {
+	switch resolution.Action {
+	case sync.NameConflictActionAlias:
+		fmt.Fprintf(f.out, "  %-20s installed as %s\n", conflict.Name, resolution.Alias)
+	case sync.NameConflictActionSkip:
+		fmt.Fprintf(f.out, "  %-20s skipped (name conflict)\n", conflict.Name)
+	}
+}
+
 func (f *textFormatter) OnSyncComplete(summary sync.SyncCompleteMsg) {
 	f.totalSummary.Installed += summary.Installed
 	f.totalSummary.Updated += summary.Updated

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -289,6 +289,7 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 		Executor:    &sync.ShellExecutor{},
 		TrustAll:    b.TrustAllFlag,
 		ForceBudget: b.ForceBudget,
+		AliasName:   b.AliasName,
 		SkillFilter: b.SkillFilter,
 		ProjectRoot: b.ProjectRoot,
 		// Skip missing skills when no explicit filter/--all: scribe sync only updates

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -206,7 +206,7 @@ func StepResolveFormatter(ctx context.Context, b *Bag) error {
 	if b.Formatter != nil {
 		return nil
 	}
-	useJSON := b.JSONFlag || !isatty.IsTerminal(os.Stdout.Fd())
+	useJSON := UseJSONOutputForProcess(b.JSONFlag)
 	multiRegistry := len(b.Repos) > 1
 	b.Formatter = NewFormatterForContext(ctx, useJSON, multiRegistry)
 	return nil
@@ -369,8 +369,8 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 			return approved
 		}
 	}
-	if isTTY && !b.JSONFlag && b.AliasName == "" {
-		syncer.NameConflictResolver = promptNameConflictResolution
+	if ConflictModeForProcess(b.JSONFlag) == ConflictModeInteractive && b.AliasName == "" {
+		syncer.NameConflictResolver = PromptNameConflictResolution
 	}
 
 	for _, teamRepo := range b.Repos {
@@ -398,7 +398,7 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 	return nil
 }
 
-func promptNameConflictResolution(conflict sync.NameConflict) (sync.NameConflictResolution, error) {
+func PromptNameConflictResolution(conflict sync.NameConflict) (sync.NameConflictResolution, error) {
 	const (
 		adopt = "adopt"
 		alias = "alias"

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -313,6 +313,8 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 				b.Formatter.OnSkillError(m.Name, m.Err)
 			case sync.BudgetWarningMsg:
 				b.Formatter.OnBudgetWarning(m.Agent, m.Message)
+			case sync.NameConflictResolvedMsg:
+				b.Formatter.OnNameConflictResolved(m.Conflict, m.Resolution)
 			case sync.SkillAdoptionNeededMsg:
 				// Handled implicitly by the SkillErrorMsg that follows it.
 			case sync.LegacyFormatMsg:

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -367,6 +367,9 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 			return approved
 		}
 	}
+	if isTTY && !b.JSONFlag && b.AliasName == "" {
+		syncer.NameConflictResolver = promptNameConflictResolution
+	}
 
 	for _, teamRepo := range b.Repos {
 		if b.State.RegistryFailure(teamRepo).Muted {
@@ -391,4 +394,48 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 	}
 
 	return nil
+}
+
+func promptNameConflictResolution(conflict sync.NameConflict) (sync.NameConflictResolution, error) {
+	const (
+		adopt = "adopt"
+		alias = "alias"
+		skip  = "skip"
+	)
+	choice := adopt
+	err := huh.NewSelect[string]().
+		Title(fmt.Sprintf("Skill %q conflicts with an existing local directory", conflict.Name)).
+		Description(fmt.Sprintf("%s already exists at %s.", conflict.Tool, conflict.Path)).
+		Options(
+			huh.NewOption("Adopt existing first", adopt),
+			huh.NewOption("Install incoming under a different name", alias),
+			huh.NewOption("Skip incoming skill", skip),
+		).
+		Value(&choice).
+		Run()
+	if err != nil {
+		return sync.NameConflictResolution{}, err
+	}
+
+	switch choice {
+	case adopt:
+		return sync.NameConflictResolution{Action: sync.NameConflictActionAdopt}, nil
+	case skip:
+		return sync.NameConflictResolution{Action: sync.NameConflictActionSkip}, nil
+	case alias:
+		aliasName := ""
+		if err := huh.NewInput().
+			Title("Install incoming skill as").
+			Placeholder(conflict.Name + "-registry").
+			Value(&aliasName).
+			Run(); err != nil {
+			return sync.NameConflictResolution{}, err
+		}
+		return sync.NameConflictResolution{
+			Action: sync.NameConflictActionAlias,
+			Alias:  aliasName,
+		}, nil
+	default:
+		return sync.NameConflictResolution{Action: sync.NameConflictActionUnresolved}, nil
+	}
 }

--- a/internal/workflow/sync_adopt_test.go
+++ b/internal/workflow/sync_adopt_test.go
@@ -42,14 +42,16 @@ type adoptCompleteCall struct {
 }
 
 // No-ops for non-adoption Formatter methods.
-func (r *adoptRecorder) OnRegistryStart(_ string)                                 {}
-func (r *adoptRecorder) OnSkillResolved(_ string, _ isync.SkillStatus)            {}
-func (r *adoptRecorder) OnSkillDownloading(_ string)                              {}
-func (r *adoptRecorder) OnSkillInstalled(_ string, _ bool)                        {}
-func (r *adoptRecorder) OnSkillSkipped(_ string, _ isync.SkillStatus)             {}
-func (r *adoptRecorder) OnSkillSkippedByDenyList(_, _ string)                     {}
-func (r *adoptRecorder) OnSkillError(_ string, _ error)                           {}
-func (r *adoptRecorder) OnBudgetWarning(_, _ string)                              {}
+func (r *adoptRecorder) OnRegistryStart(_ string)                      {}
+func (r *adoptRecorder) OnSkillResolved(_ string, _ isync.SkillStatus) {}
+func (r *adoptRecorder) OnSkillDownloading(_ string)                   {}
+func (r *adoptRecorder) OnSkillInstalled(_ string, _ bool)             {}
+func (r *adoptRecorder) OnSkillSkipped(_ string, _ isync.SkillStatus)  {}
+func (r *adoptRecorder) OnSkillSkippedByDenyList(_, _ string)          {}
+func (r *adoptRecorder) OnSkillError(_ string, _ error)                {}
+func (r *adoptRecorder) OnBudgetWarning(_, _ string)                   {}
+func (r *adoptRecorder) OnNameConflictResolved(_ isync.NameConflict, _ isync.NameConflictResolution) {
+}
 func (r *adoptRecorder) OnSyncComplete(_ isync.SyncCompleteMsg)                   {}
 func (r *adoptRecorder) OnReconcileConflict(_ string, _ state.ProjectionConflict) {}
 func (r *adoptRecorder) OnReconcileComplete(_ isync.ReconcileCompleteMsg)         {}

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "f1287504",
+      "content_hash": "dfad4ae2",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe-agent",


### PR DESCRIPTION
Resolves ErrRealDirectoryExists with 3 choices: Adopt / Alias / Skip.\n\n## Summary\n- --alias flag on sync, install, add\n- Interactive 3-choice prompt in TTY\n- Non-TTY exits 5 with structured conflict envelope\n- Alias collision returns conflict\n\nCloses #99\n\n## Test plan\n- [x] go test ./...\n- [ ] scribe sync --alias mything (with conflict)\n- [ ] scribe sync (TTY, with conflict) — interactive choice\n- [ ] scribe sync --json (non-tty, no flag) — exit 5