### PR TITLE
feat(init): scribe init for package authors (todo #391, GH #7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe doctor` | --fix, --json, --skill | yes |
 | `scribe explain` | --json, --raw | yes |
 | `scribe guide` | --json | yes |
+| `scribe init` | --force, --json | yes |
 | `scribe install` | --alias, --all, --force, --json, --registry | no |
 | `scribe list` | --fields, --json, --registry, --remote | yes |
 | `scribe migrate global-to-projects` | --dry-run, --json, --project | no |

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,15 +1,138 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	"charm.land/huh/v2"
+	"github.com/spf13/cobra"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/discovery"
 	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/workflow"
 )
+
+type initResult struct {
+	Package    manifest.PackageMeta `json:"package"`
+	Skills     []manifest.Skill     `json:"skills"`
+	ScribeFile string               `json:"scribe_file"`
+}
+
+func newInitCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Scaffold a skill package manifest",
+		Long: `Scaffold a package manifest for publishing your own skills.
+
+The command discovers SKILL.md files under the current directory and writes a
+top-level scribe.yaml package manifest.`,
+		Args: cobra.NoArgs,
+		RunE: runInit,
+	}
+	cmd.Flags().Bool("force", false, "Overwrite an existing scribe manifest")
+	return markJSONSupported(cmd)
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get working directory: %w", err)
+	}
+	force, _ := cmd.Flags().GetBool("force")
+	jsonFlag := jsonFlagPassed(cmd)
+	useJSON := workflow.UseJSONOutputForProcess(jsonFlag)
+
+	result, err := buildInitResult(wd, useJSON)
+	if err != nil {
+		return err
+	}
+
+	if err := ensureInitManifestWritable(wd, force); err != nil {
+		return err
+	}
+	data, err := manifest.ScaffoldPackageManifest(result.Package, result.Skills)
+	if err != nil {
+		return clierrors.Wrap(err, "PACKAGE_NAME_INVALID", clierrors.ExitValid,
+			clierrors.WithMessage(err.Error()),
+			clierrors.WithRemediation("Use letters, numbers, dots, underscores, or dashes."),
+		)
+	}
+	if err := os.WriteFile(filepath.Join(wd, result.ScribeFile), data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", result.ScribeFile, err)
+	}
+
+	if useJSON {
+		r := jsonRendererForCommand(cmd, jsonFlag)
+		if err := r.Result(result); err != nil {
+			return err
+		}
+		return r.Flush()
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Found skills: %s\n", formatInitSkillList(result.Skills))
+	fmt.Fprintf(cmd.OutOrStdout(), "Created %s\n", result.ScribeFile)
+	return nil
+}
+
+func buildInitResult(wd string, skipPrompt bool) (initResult, error) {
+	skills, err := discoverPackageSkills(wd)
+	if err != nil {
+		return initResult{}, err
+	}
+	meta := defaultInitPackageMeta(wd)
+	if !skipPrompt {
+		if err := promptInitPackageMeta(&meta); err != nil {
+			if errors.Is(err, huh.ErrUserAborted) {
+				return initResult{}, clierrors.Wrap(err, "USER_CANCELED", clierrors.ExitCanceled,
+					clierrors.WithMessage("user canceled init"),
+				)
+			}
+			return initResult{}, err
+		}
+	}
+	return initResult{Package: meta, Skills: skills, ScribeFile: manifest.ManifestFilename}, nil
+}
+
+func defaultInitPackageMeta(wd string) manifest.PackageMeta {
+	return manifest.PackageMeta{
+		Name:   filepath.Base(wd),
+		Author: gitConfigValue(wd, "user.name"),
+	}
+}
+
+func promptInitPackageMeta(meta *manifest.PackageMeta) error {
+	return huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Package name").
+				Value(&meta.Name).
+				Validate(manifest.ValidatePackageName),
+			huh.NewInput().
+				Title("Description").
+				Value(&meta.Description),
+			huh.NewInput().
+				Title("Author").
+				Value(&meta.Author),
+		),
+	).Run()
+}
+
+func gitConfigValue(wd, key string) string {
+	cmd := exec.Command("git", "config", key)
+	cmd.Dir = wd
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
 
 func discoverPackageSkills(root string) ([]manifest.Skill, error) {
 	var skills []manifest.Skill
@@ -61,4 +184,31 @@ func discoverPackageSkills(root string) ([]manifest.Skill, error) {
 
 func shouldSkipInitDiscoveryDir(name string) bool {
 	return name == ".git" || name == "node_modules" || name == ".scribe" || name == "versions"
+}
+
+func ensureInitManifestWritable(wd string, force bool) error {
+	for _, name := range []string{manifest.ManifestFilename, manifest.LegacyManifestFilename} {
+		path := filepath.Join(wd, name)
+		if _, err := os.Stat(path); err == nil && !force {
+			return clierrors.Wrap(fmt.Errorf("%s already exists", name), "MANIFEST_EXISTS", clierrors.ExitConflict,
+				clierrors.WithMessage(fmt.Sprintf("%s already exists", name)),
+				clierrors.WithRemediation("Pass --force to overwrite the existing manifest."),
+				clierrors.WithResource(name),
+			)
+		} else if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("stat %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func formatInitSkillList(skills []manifest.Skill) string {
+	if len(skills) == 0 {
+		return "(none)"
+	}
+	paths := make([]string, len(skills))
+	for i, skill := range skills {
+		paths[i] = filepath.ToSlash(filepath.Join(skill.Path, "SKILL.md"))
+	}
+	return strings.Join(paths, ", ")
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -135,7 +135,7 @@ func gitConfigValue(wd, key string) string {
 }
 
 func discoverPackageSkills(root string) ([]manifest.Skill, error) {
-	var skills []manifest.Skill
+	skills := []manifest.Skill{}
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Naoray/scribe/internal/discovery"
+	"github.com/Naoray/scribe/internal/manifest"
+)
+
+func discoverPackageSkills(root string) ([]manifest.Skill, error) {
+	var skills []manifest.Skill
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if path != root && shouldSkipInitDiscoveryDir(d.Name()) {
+			return filepath.SkipDir
+		}
+		if path == root {
+			return nil
+		}
+
+		skillFile := filepath.Join(path, "SKILL.md")
+		info, err := os.Stat(skillFile)
+		if err != nil || info.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		name := filepath.Base(path)
+		if meta, err := discovery.ReadSkillMetadata(path); err == nil && strings.TrimSpace(meta.Name) != "" {
+			name = strings.TrimSpace(meta.Name)
+		}
+		skills = append(skills, manifest.Skill{Name: name, Path: rel})
+		return filepath.SkipDir
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(skills, func(i, j int) bool {
+		if skills[i].Name != skills[j].Name {
+			return skills[i].Name < skills[j].Name
+		}
+		return skills[i].Path < skills[j].Path
+	})
+	return skills, nil
+}
+
+func shouldSkipInitDiscoveryDir(name string) bool {
+	return name == ".git" || name == "node_modules" || name == ".scribe" || name == "versions"
+}

--- a/cmd/init_schema.go
+++ b/cmd/init_schema.go
@@ -1,0 +1,39 @@
+package cmd
+
+import clischema "github.com/Naoray/scribe/internal/cli/schema"
+
+var initOutputSchema = `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "package": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "author": { "type": "string" }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    "skills": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "path": { "type": "string" }
+        },
+        "required": ["name", "path"],
+        "additionalProperties": false
+      }
+    },
+    "scribe_file": { "type": "string" }
+  },
+  "required": ["package", "skills", "scribe_file"],
+  "additionalProperties": false
+}`
+
+func init() {
+	clischema.Register("scribe init", initOutputSchema)
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -7,6 +7,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	clischema "github.com/Naoray/scribe/internal/cli/schema"
 )
 
 func TestDiscoverPackageSkillsFindsNestedSkillFiles(t *testing.T) {
@@ -68,6 +71,19 @@ func TestNewInitCommandHasForceFlag(t *testing.T) {
 	}
 }
 
+func TestRootIncludesInitCommand(t *testing.T) {
+	root := newRootCmd()
+	if got, _, err := root.Find([]string{"init"}); err != nil || got == nil || got.Name() != "init" {
+		t.Fatalf("root.Find(init) = %v, %v", got, err)
+	}
+}
+
+func TestInitOutputSchemaRegistered(t *testing.T) {
+	if _, ok := clischema.Get("scribe init"); !ok {
+		t.Fatal("missing output schema for scribe init")
+	}
+}
+
 func TestRunInitNonTTYWritesJSONEnvelope(t *testing.T) {
 	dir := t.TempDir()
 	writeInitSkill(t, dir, "review", "---\nname: review\n---\n# Review\n")
@@ -105,6 +121,25 @@ func TestRunInitNonTTYWritesJSONEnvelope(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "scribe.yaml")); err != nil {
 		t.Fatalf("scribe.yaml not written: %v", err)
+	}
+}
+
+func TestRunInitRefusesExistingLegacyManifestWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "scribe.toml"), []byte("[package]\nname = \"old\"\n"), 0o644); err != nil {
+		t.Fatalf("write scribe.toml: %v", err)
+	}
+	withInitWorkingDir(t, dir)
+
+	cmd := newInitCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil error for existing scribe.toml")
+	}
+	if got := clierrors.ExitCode(err); got != 5 {
+		t.Fatalf("exit code = %d, want 5; err=%v", got, err)
 	}
 }
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -66,6 +68,46 @@ func TestNewInitCommandHasForceFlag(t *testing.T) {
 	}
 }
 
+func TestRunInitNonTTYWritesJSONEnvelope(t *testing.T) {
+	dir := t.TempDir()
+	writeInitSkill(t, dir, "review", "---\nname: review\n---\n# Review\n")
+	withInitWorkingDir(t, dir)
+
+	cmd := newInitCommand()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute init: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	var env testEnvelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout is not JSON envelope: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if env.Status != "ok" {
+		t.Fatalf("status = %q, want ok", env.Status)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	pkg, ok := data["package"].(map[string]any)
+	if !ok {
+		t.Fatalf("data.package missing: %#v", data)
+	}
+	if pkg["name"] != filepath.Base(dir) {
+		t.Fatalf("package.name = %v, want %s", pkg["name"], filepath.Base(dir))
+	}
+	if data["scribe_file"] != "scribe.yaml" {
+		t.Fatalf("scribe_file = %v, want scribe.yaml", data["scribe_file"])
+	}
+	if _, err := os.Stat(filepath.Join(dir, "scribe.yaml")); err != nil {
+		t.Fatalf("scribe.yaml not written: %v", err)
+	}
+}
+
 func writeInitSkill(t *testing.T, root, name, content string) {
 	t.Helper()
 	dir := filepath.Join(root, name)
@@ -84,4 +126,20 @@ func runGitForInitTest(t *testing.T, dir string, args ...string) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, string(out))
 	}
+}
+
+func withInitWorkingDir(t *testing.T, dir string) {
+	t.Helper()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -37,6 +38,34 @@ func TestDiscoverPackageSkillsEmptyDirectory(t *testing.T) {
 	}
 }
 
+func TestDefaultInitPackageMetaUsesCwdNameAndGitAuthor(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "my-skills-repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	runGitForInitTest(t, dir, "init")
+	runGitForInitTest(t, dir, "config", "user.name", "Test Author")
+
+	meta := defaultInitPackageMeta(dir)
+
+	if meta.Name != "my-skills-repo" {
+		t.Fatalf("Name = %q, want my-skills-repo", meta.Name)
+	}
+	if meta.Author != "Test Author" {
+		t.Fatalf("Author = %q, want Test Author", meta.Author)
+	}
+}
+
+func TestNewInitCommandHasForceFlag(t *testing.T) {
+	cmd := newInitCommand()
+	if cmd.Use != "init" {
+		t.Fatalf("Use = %q, want init", cmd.Use)
+	}
+	if cmd.Flags().Lookup("force") == nil {
+		t.Fatal("init command missing --force flag")
+	}
+}
+
 func writeInitSkill(t *testing.T, root, name, content string) {
 	t.Helper()
 	dir := filepath.Join(root, name)
@@ -45,5 +74,14 @@ func writeInitSkill(t *testing.T, root, name, content string) {
 	}
 	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
 		t.Fatalf("write SKILL.md: %v", err)
+	}
+}
+
+func runGitForInitTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, string(out))
 	}
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverPackageSkillsFindsNestedSkillFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeInitSkill(t, dir, "review", "---\nname: code-review\n---\n# Review\n")
+	writeInitSkill(t, dir, "deploy", "# Deploy\n")
+
+	skills, err := discoverPackageSkills(dir)
+	if err != nil {
+		t.Fatalf("discoverPackageSkills: %v", err)
+	}
+
+	if len(skills) != 2 {
+		t.Fatalf("skills count = %d, want 2: %#v", len(skills), skills)
+	}
+	if skills[0].Name != "code-review" || skills[0].Path != "review" {
+		t.Fatalf("skills[0] = %#v, want code-review/review", skills[0])
+	}
+	if skills[1].Name != "deploy" || skills[1].Path != "deploy" {
+		t.Fatalf("skills[1] = %#v, want deploy/deploy", skills[1])
+	}
+}
+
+func TestDiscoverPackageSkillsEmptyDirectory(t *testing.T) {
+	skills, err := discoverPackageSkills(t.TempDir())
+	if err != nil {
+		t.Fatalf("discoverPackageSkills: %v", err)
+	}
+	if len(skills) != 0 {
+		t.Fatalf("skills count = %d, want 0: %#v", len(skills), skills)
+	}
+}
+
+func writeInitSkill(t *testing.T, root, name, content string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -124,6 +124,38 @@ func TestRunInitNonTTYWritesJSONEnvelope(t *testing.T) {
 	}
 }
 
+func TestRunInitJSONEnvelopeEmptyDirectorySerializesSkillsArray(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	withInitWorkingDir(t, dir)
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"init", "--json"})
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute init --json: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	var env testEnvelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout is not JSON envelope: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if env.Status != "ok" {
+		t.Fatalf("status = %q, want ok", env.Status)
+	}
+
+	var data map[string]json.RawMessage
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if string(data["skills"]) != "[]" {
+		t.Fatalf("data.skills = %s, want []", data["skills"])
+	}
+}
+
 func TestRunInitRefusesExistingLegacyManifestWithoutForce(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "scribe.toml"), []byte("[package]\nname = \"old\"\n"), 0o644); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -232,6 +232,7 @@ func newRootCmd() *cobra.Command {
 		newSyncCommand(),
 		newAdoptCommand(),
 		newStatusCommand(),
+		newInitCommand(),
 		newShowCommand(),
 		newSchemaCommand(cmd),
 		newResolveCommand(),

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -249,12 +249,59 @@ func TestManifestEncode(t *testing.T) {
 	}
 }
 
+func TestScaffoldPackageManifestProducesParseablePackage(t *testing.T) {
+	data, err := manifest.ScaffoldPackageManifest(
+		manifest.PackageMeta{
+			Name:        "my-skills",
+			Description: "Reusable development skills",
+			Author:      "Krishan",
+		},
+		[]manifest.Skill{
+			{Name: "review", Path: "review"},
+			{Name: "deploy", Path: "deploy"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("ScaffoldPackageManifest: %v", err)
+	}
+
+	m, err := manifest.Parse(data)
+	if err != nil {
+		t.Fatalf("Parse scaffolded manifest: %v\n%s", err, string(data))
+	}
+	if !m.IsPackage() {
+		t.Fatal("scaffolded manifest is not a package")
+	}
+	if m.Package.Name != "my-skills" {
+		t.Fatalf("package name = %q, want my-skills", m.Package.Name)
+	}
+	if m.Package.Description != "Reusable development skills" {
+		t.Fatalf("description = %q", m.Package.Description)
+	}
+	if len(m.Package.Authors) != 1 || m.Package.Authors[0] != "Krishan" {
+		t.Fatalf("authors = %#v, want [Krishan]", m.Package.Authors)
+	}
+	if got := m.FindByName("review"); got == nil || got.Path != "review" {
+		t.Fatalf("review entry = %#v, want path review", got)
+	}
+	if got := m.FindByName("deploy"); got == nil || got.Path != "deploy" {
+		t.Fatalf("deploy entry = %#v, want path deploy", got)
+	}
+}
+
+func TestScaffoldPackageManifestRejectsInvalidPackageName(t *testing.T) {
+	_, err := manifest.ScaffoldPackageManifest(manifest.PackageMeta{Name: "bad name"}, nil)
+	if err == nil {
+		t.Fatal("ScaffoldPackageManifest returned nil error for invalid package name")
+	}
+}
+
 func TestParseSourceErrors(t *testing.T) {
 	cases := []string{
-		"garrytan/gstack@v1.0.0",  // missing host
-		"github:garrytan/gstack",  // missing @ref
-		"github:gstack@v1.0.0",    // missing slash in repo
-		"npm:garrytan/gstack@v1",  // unsupported host
+		"garrytan/gstack@v1.0.0", // missing host
+		"github:garrytan/gstack", // missing @ref
+		"github:gstack@v1.0.0",   // missing slash in repo
+		"npm:garrytan/gstack@v1", // unsupported host
 	}
 	for _, raw := range cases {
 		if _, err := manifest.ParseSource(raw); err == nil {

--- a/internal/manifest/scaffold.go
+++ b/internal/manifest/scaffold.go
@@ -10,9 +10,9 @@ var packageNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 
 // PackageMeta contains the package-level fields collected by scribe init.
 type PackageMeta struct {
-	Name        string
-	Description string
-	Author      string
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Author      string `json:"author"`
 }
 
 // Skill describes a local skill directory to include in a package manifest.

--- a/internal/manifest/scaffold.go
+++ b/internal/manifest/scaffold.go
@@ -1,0 +1,75 @@
+package manifest
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var packageNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+// PackageMeta contains the package-level fields collected by scribe init.
+type PackageMeta struct {
+	Name        string
+	Description string
+	Author      string
+}
+
+// Skill describes a local skill directory to include in a package manifest.
+type Skill struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+// ScaffoldPackageManifest builds a parseable package manifest for a new skill package.
+func ScaffoldPackageManifest(meta PackageMeta, skills []Skill) ([]byte, error) {
+	meta.Name = strings.TrimSpace(meta.Name)
+	if err := ValidatePackageName(meta.Name); err != nil {
+		return nil, err
+	}
+
+	pkg := &Package{
+		Name:        meta.Name,
+		Version:     "0.1.0",
+		Description: strings.TrimSpace(meta.Description),
+	}
+	if author := strings.TrimSpace(meta.Author); author != "" {
+		pkg.Authors = []string{author}
+	}
+
+	catalog := make([]Entry, 0, len(skills))
+	for _, skill := range skills {
+		name := strings.TrimSpace(skill.Name)
+		path := strings.TrimSpace(skill.Path)
+		if name == "" {
+			return nil, fmt.Errorf("skill has empty name for path %q", path)
+		}
+		if path == "" {
+			return nil, fmt.Errorf("skill %q has empty path", name)
+		}
+		catalog = append(catalog, Entry{Name: name, Path: path})
+	}
+
+	m := &Manifest{
+		APIVersion: "scribe/v1",
+		Kind:       "Package",
+		Package:    pkg,
+		Catalog:    catalog,
+	}
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	return m.Encode()
+}
+
+// ValidatePackageName checks whether name is suitable for a package manifest.
+func ValidatePackageName(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("package name is required")
+	}
+	if !packageNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid package name %q: use letters, numbers, dots, underscores, or dashes", name)
+	}
+	return nil
+}

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "dfad4ae2",
+      "content_hash": "6d654842",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe-agent",


### PR DESCRIPTION
Scaffolds scribe.toml for users publishing their own skills.\n\n## Summary\n- Auto-discovers SKILL.md files in cwd\n- Prompts for package metadata (huh)\n- Non-TTY/--json mode skips prompts, uses defaults\n- Refuses on existing scribe.toml without --force (exit 5)\n- Distinct from scribe connect (which is for consumers)\n\nCloses #7\n\n## Test plan\n- [x] go test ./...\n- [ ] scribe init (TTY, fresh dir)\n- [x] scribe init --json (CI mode)\n- [x] scribe init in dir with scribe.toml (exit 5)\n- [x] scribe init --force overwrites\n- [x] scribe schema init --json