### PR TITLE
feat(lockfile): scribe.lock for reproducible syncs (todo #390, GH #44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe add` | --alias, --force, --json, --registry, --yes | yes |
 | `scribe adopt` | --dry-run, --json, --verbose, --yes | yes |
 | `scribe browse` | --install, --json, --query, --registry, --yes | no |
+| `scribe check` | --json | yes |
 | `scribe config adoption` | --add-path, --json, --mode, --remove-path | no |
 | `scribe config set editor` | --json | no |
 | `scribe config set` | --json | no |
@@ -100,6 +101,7 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe tools` | --json | no |
 | `scribe upgrade-agent` | --json | no |
 | `scribe upgrade` | --check, --json | no |
+| `scribe update` | --apply, --json | yes |
 | `scribe` |  | no |
 
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -18,7 +18,7 @@ func newCheckCommand() *cobra.Command {
 		RunE:  runCheck,
 	}
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
-	return markJSONSupported(cmd)
+	return markReadOnly(markJSONSupported(cmd))
 }
 
 func runCheck(cmd *cobra.Command, args []string) error {
@@ -36,12 +36,8 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	st, err := factory.State()
-	if err != nil {
-		return err
-	}
 	repos := cfg.TeamRepos()
-	out, _, err := buildLockPlan(cmd.Context(), repos, isync.WrapGitHubClient(client), provider, st)
+	out, _, err := buildLockPlan(cmd.Context(), repos, isync.WrapGitHubClient(client), provider)
 	if err != nil {
 		return err
 	}

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/cli/envelope"
+	isync "github.com/Naoray/scribe/internal/sync"
+)
+
+func newCheckCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Check registries for lockfile updates without modifying anything",
+		Args:  cobra.NoArgs,
+		RunE:  runCheck,
+	}
+	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	return markJSONSupported(cmd)
+}
+
+func runCheck(cmd *cobra.Command, args []string) error {
+	jsonFlag := jsonFlagPassed(cmd)
+	factory := commandFactory()
+	cfg, err := factory.Config()
+	if err != nil {
+		return err
+	}
+	client, err := factory.Client()
+	if err != nil {
+		return err
+	}
+	provider, err := factory.Provider()
+	if err != nil {
+		return err
+	}
+	st, err := factory.State()
+	if err != nil {
+		return err
+	}
+	repos := cfg.TeamRepos()
+	out, _, err := buildLockPlan(cmd.Context(), repos, isync.WrapGitHubClient(client), provider, st)
+	if err != nil {
+		return err
+	}
+	if jsonFlag {
+		return renderMutatorEnvelope(cmd, out, envelope.StatusOK)
+	}
+	if len(out.Updates) == 0 {
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile updates available.")
+		return err
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}

--- a/cmd/check_schema.go
+++ b/cmd/check_schema.go
@@ -1,0 +1,50 @@
+package cmd
+
+import clischema "github.com/Naoray/scribe/internal/cli/schema"
+
+var checkOutputSchema = `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "registries": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/registry_plan" }
+    },
+    "updates": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/update" }
+    }
+  },
+  "required": ["registries", "updates"],
+  "additionalProperties": false,
+  "$defs": {
+    "registry_plan": {
+      "type": "object",
+      "properties": {
+        "registry": { "type": "string" },
+        "updates": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/update" }
+        }
+      },
+      "required": ["registry", "updates"],
+      "additionalProperties": false
+    },
+    "update": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "current_sha": { "type": "string" },
+        "latest_sha": { "type": "string" },
+        "current_hash": { "type": "string" },
+        "latest_hash": { "type": "string" }
+      },
+      "required": ["name", "current_sha", "latest_sha", "current_hash", "latest_hash"],
+      "additionalProperties": false
+    }
+  }
+}`
+
+func init() {
+	clischema.Register("scribe check", checkOutputSchema)
+}

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -60,12 +60,12 @@ func (p lockPlanProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]pr
 }
 
 func TestBuildLockPlanReportsAvailableUpdates(t *testing.T) {
-	current := []byte(`version: 1
+	current := []byte(`format_version: 1
 registry: acme/registry
 entries:
   - name: deploy
     source_registry: acme/source
-    registry_commit_sha: old-sha
+    commit_sha: old-sha
     content_hash: old-hash
 `)
 	fetcher := lockPlanFetcher{lock: current}
@@ -79,7 +79,7 @@ entries:
 	if out.Updates[0].CurrentSHA != "old-sha" || out.Updates[0].LatestSHA != "new-sha" {
 		t.Fatalf("unexpected update: %+v", out.Updates[0])
 	}
-	if latest["acme/registry"].Entries[0].RegistryCommitSHA != "new-sha" {
+	if latest["acme/registry"].Entries[0].CommitSHA != "new-sha" {
 		t.Fatalf("latest lock not pinned to new-sha: %+v", latest["acme/registry"])
 	}
 }

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Naoray/scribe/internal/lockfile"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
-	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/tools"
 )
 
@@ -69,7 +68,7 @@ entries:
     content_hash: old-hash
 `)
 	fetcher := lockPlanFetcher{lock: current}
-	out, latest, err := buildLockPlan(context.Background(), []string{"acme/registry"}, fetcher, lockPlanProvider{fetcher: fetcher}, &state.State{})
+	out, latest, err := buildLockPlan(context.Background(), []string{"acme/registry"}, fetcher, lockPlanProvider{fetcher: fetcher})
 	if err != nil {
 		t.Fatalf("buildLockPlan() error = %v", err)
 	}

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/lockfile"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+type lockPlanFetcher struct {
+	lock []byte
+}
+
+func (f lockPlanFetcher) FetchFile(ctx context.Context, owner, repo, path, ref string) ([]byte, error) {
+	if path == lockfile.Filename {
+		return f.lock, nil
+	}
+	if path == manifest.ManifestFilename {
+		return []byte(`apiVersion: scribe/v1
+kind: Registry
+team:
+  name: acme/registry
+catalog:
+  - name: deploy
+    source: github:acme/source@main
+`), nil
+	}
+	return nil, nil
+}
+
+func (f lockPlanFetcher) FetchDirectory(context.Context, string, string, string, string) ([]tools.SkillFile, error) {
+	return []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# deploy\n")}}, nil
+}
+
+func (f lockPlanFetcher) LatestCommitSHA(context.Context, string, string, string) (string, error) {
+	return "new-sha", nil
+}
+
+func (f lockPlanFetcher) GetTree(context.Context, string, string, string) ([]provider.TreeEntry, error) {
+	return nil, nil
+}
+
+type lockPlanProvider struct {
+	fetcher lockPlanFetcher
+}
+
+func (p lockPlanProvider) Discover(ctx context.Context, repo string) (*provider.DiscoverResult, error) {
+	return &provider.DiscoverResult{IsTeam: true, Entries: []manifest.Entry{{
+		Name:   "deploy",
+		Source: "github:acme/source@main",
+	}}}, nil
+}
+
+func (p lockPlanProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]provider.File, error) {
+	return []provider.File{{Path: "SKILL.md", Content: []byte("# deploy\n")}}, nil
+}
+
+func TestBuildLockPlanReportsAvailableUpdates(t *testing.T) {
+	current := []byte(`version: 1
+registry: acme/registry
+entries:
+  - name: deploy
+    source_registry: acme/source
+    registry_commit_sha: old-sha
+    content_hash: old-hash
+`)
+	fetcher := lockPlanFetcher{lock: current}
+	out, latest, err := buildLockPlan(context.Background(), []string{"acme/registry"}, fetcher, lockPlanProvider{fetcher: fetcher}, &state.State{})
+	if err != nil {
+		t.Fatalf("buildLockPlan() error = %v", err)
+	}
+	if len(out.Updates) != 1 {
+		t.Fatalf("len(updates) = %d, want 1: %+v", len(out.Updates), out)
+	}
+	if out.Updates[0].CurrentSHA != "old-sha" || out.Updates[0].LatestSHA != "new-sha" {
+		t.Fatalf("unexpected update: %+v", out.Updates[0])
+	}
+	if latest["acme/registry"].Entries[0].RegistryCommitSHA != "new-sha" {
+		t.Fatalf("latest lock not pinned to new-sha: %+v", latest["acme/registry"])
+	}
+}

--- a/cmd/lock_plan.go
+++ b/cmd/lock_plan.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/Naoray/scribe/internal/lockfile"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/state"
+	isync "github.com/Naoray/scribe/internal/sync"
+)
+
+type lockPlanOutput struct {
+	Registries []registryLockPlan `json:"registries"`
+	Updates    []lockfile.Update  `json:"updates"`
+}
+
+type registryLockPlan struct {
+	Registry string            `json:"registry"`
+	Updates  []lockfile.Update `json:"updates"`
+}
+
+func buildLockPlan(ctx context.Context, repos []string, fetcher isync.GitHubFetcher, p provider.Provider, st *state.State) (lockPlanOutput, map[string]*lockfile.Lockfile, error) {
+	out := lockPlanOutput{Registries: []registryLockPlan{}, Updates: []lockfile.Update{}}
+	next := map[string]*lockfile.Lockfile{}
+	syncer := &isync.Syncer{Client: fetcher, Provider: p}
+	for _, repo := range repos {
+		current, err := syncer.FetchLockfile(ctx, repo)
+		if err != nil {
+			return out, nil, err
+		}
+		latest, err := buildLatestLockfile(ctx, repo, fetcher, p)
+		if err != nil {
+			return out, nil, err
+		}
+		next[repo] = latest
+		updates := lockfile.Diff(current, latest)
+		out.Registries = append(out.Registries, registryLockPlan{Registry: repo, Updates: updates})
+		out.Updates = append(out.Updates, updates...)
+		_ = st
+	}
+	return out, next, nil
+}
+
+func buildLatestLockfile(ctx context.Context, repo string, fetcher isync.GitHubFetcher, p provider.Provider) (*lockfile.Lockfile, error) {
+	owner, repoName, err := manifest.ParseOwnerRepo(repo)
+	if err != nil {
+		return nil, err
+	}
+	syncer := &isync.Syncer{Client: fetcher, Provider: p}
+	m, err := syncer.FetchManifest(ctx, owner, repoName)
+	if err != nil {
+		return nil, fmt.Errorf("fetch manifest for %s: %w", repo, err)
+	}
+	lf := &lockfile.Lockfile{Version: lockfile.SchemaVersion, Registry: repo, Entries: []lockfile.Entry{}}
+	for _, entry := range m.Catalog {
+		pin, err := buildLatestLockEntry(ctx, entry, fetcher, p)
+		if err != nil {
+			return nil, err
+		}
+		lf.Entries = append(lf.Entries, pin)
+	}
+	sort.Slice(lf.Entries, func(i, j int) bool { return lf.Entries[i].Name < lf.Entries[j].Name })
+	return lf, nil
+}
+
+func buildLatestLockEntry(ctx context.Context, entry manifest.Entry, fetcher isync.GitHubFetcher, p provider.Provider) (lockfile.Entry, error) {
+	src, err := manifest.ParseSource(entry.Source)
+	if err != nil {
+		return lockfile.Entry{}, err
+	}
+	commit := src.Ref
+	if src.IsBranch() {
+		commit, err = fetcher.LatestCommitSHA(ctx, src.Owner, src.Repo, src.Ref)
+		if err != nil {
+			return lockfile.Entry{}, err
+		}
+	}
+	pinned := entry
+	src.Ref = commit
+	pinned.Source = src.String()
+	files, err := p.Fetch(ctx, pinned)
+	if err != nil {
+		return lockfile.Entry{}, err
+	}
+	hash, err := isync.HashInstallableFiles(files)
+	if err != nil {
+		return lockfile.Entry{}, err
+	}
+	return lockfile.Entry{
+		Name:               entry.Name,
+		SourceRegistry:     src.Owner + "/" + src.Repo,
+		RegistryCommitSHA:  commit,
+		ContentHash:        hash,
+		InstallCommandHash: installCommandHash(entry),
+	}, nil
+}
+
+func installCommandHash(entry manifest.Entry) string {
+	parts := []string{entry.Install, entry.Update}
+	for _, key := range sortedMapKeys(entry.Installs) {
+		parts = append(parts, key, entry.Installs[key])
+	}
+	for _, key := range sortedMapKeys(entry.Updates) {
+		parts = append(parts, key, entry.Updates[key])
+	}
+	return lockfile.CommandHash(parts...)
+}
+
+func sortedMapKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cmd/lock_plan.go
+++ b/cmd/lock_plan.go
@@ -54,7 +54,7 @@ func buildLatestLockfile(ctx context.Context, repo string, fetcher isync.GitHubF
 	if err != nil {
 		return nil, fmt.Errorf("fetch manifest for %s: %w", repo, err)
 	}
-	lf := &lockfile.Lockfile{Version: lockfile.SchemaVersion, Registry: repo, Entries: []lockfile.Entry{}}
+	lf := &lockfile.Lockfile{FormatVersion: lockfile.SchemaVersion, Registry: repo, Entries: []lockfile.Entry{}}
 	for _, entry := range m.Catalog {
 		pin, err := buildLatestLockEntry(ctx, entry, fetcher, p)
 		if err != nil {
@@ -92,7 +92,7 @@ func buildLatestLockEntry(ctx context.Context, entry manifest.Entry, fetcher isy
 	return lockfile.Entry{
 		Name:               entry.Name,
 		SourceRegistry:     src.Owner + "/" + src.Repo,
-		RegistryCommitSHA:  commit,
+		CommitSHA:          commit,
 		ContentHash:        hash,
 		InstallCommandHash: installCommandHash(entry),
 	}, nil

--- a/cmd/lock_plan.go
+++ b/cmd/lock_plan.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Naoray/scribe/internal/lockfile"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
-	"github.com/Naoray/scribe/internal/state"
 	isync "github.com/Naoray/scribe/internal/sync"
 )
 
@@ -22,7 +21,7 @@ type registryLockPlan struct {
 	Updates  []lockfile.Update `json:"updates"`
 }
 
-func buildLockPlan(ctx context.Context, repos []string, fetcher isync.GitHubFetcher, p provider.Provider, st *state.State) (lockPlanOutput, map[string]*lockfile.Lockfile, error) {
+func buildLockPlan(ctx context.Context, repos []string, fetcher isync.GitHubFetcher, p provider.Provider) (lockPlanOutput, map[string]*lockfile.Lockfile, error) {
 	out := lockPlanOutput{Registries: []registryLockPlan{}, Updates: []lockfile.Update{}}
 	next := map[string]*lockfile.Lockfile{}
 	syncer := &isync.Syncer{Client: fetcher, Provider: p}
@@ -39,7 +38,6 @@ func buildLockPlan(ctx context.Context, repos []string, fetcher isync.GitHubFetc
 		updates := lockfile.Diff(current, latest)
 		out.Registries = append(out.Registries, registryLockPlan{Registry: repo, Updates: updates})
 		out.Updates = append(out.Updates, updates...)
-		_ = st
 	}
 	return out, next, nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -231,6 +231,7 @@ func newRootCmd() *cobra.Command {
 		newRemoveCommand(),
 		newSyncCommand(),
 		newCheckCommand(),
+		newUpdateCommand(),
 		newAdoptCommand(),
 		newStatusCommand(),
 		newInitCommand(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,12 @@ var commandFactory = newCommandFactory
 
 var rootCmd = newRootCmd()
 
-const jsonSupportedAnnotation = "json_supported"
+const (
+	jsonSupportedAnnotation = "json_supported"
+	commandModeAnnotation   = "mode"
+	commandModeReadOnly     = "read-only"
+	commandModeApplyWrites  = "read-only-without-apply"
+)
 
 type legacyGlobalProjectionCompatKey struct{}
 
@@ -109,6 +114,9 @@ func newRootCmd() *cobra.Command {
 			}
 
 			factory := commandFactory()
+			if commandReadOnly(c) {
+				return nil
+			}
 			if err := runStoreMigration(factory); err != nil {
 				return err
 			}
@@ -299,6 +307,34 @@ func markJSONSupported(cmd *cobra.Command) *cobra.Command {
 	}
 	cmd.Annotations[jsonSupportedAnnotation] = "true"
 	return cmd
+}
+
+func markReadOnly(cmd *cobra.Command) *cobra.Command {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[commandModeAnnotation] = commandModeReadOnly
+	return cmd
+}
+
+func markReadOnlyWithoutApply(cmd *cobra.Command) *cobra.Command {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[commandModeAnnotation] = commandModeApplyWrites
+	return cmd
+}
+
+func commandReadOnly(cmd *cobra.Command) bool {
+	switch cmd.Annotations[commandModeAnnotation] {
+	case commandModeReadOnly:
+		return true
+	case commandModeApplyWrites:
+		apply, err := cmd.Flags().GetBool("apply")
+		return err == nil && !apply
+	default:
+		return false
+	}
 }
 
 func jsonFlagPassed(cmd *cobra.Command) bool {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -230,6 +230,7 @@ func newRootCmd() *cobra.Command {
 		newPushCommand(),
 		newRemoveCommand(),
 		newSyncCommand(),
+		newCheckCommand(),
 		newAdoptCommand(),
 		newStatusCommand(),
 		newInitCommand(),

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -174,6 +174,50 @@ builtins_version: 1
 	}
 }
 
+func TestRoot_ReadOnlyCommandsDoNotWriteHome(t *testing.T) {
+	for _, args := range [][]string{
+		{"check", "--json"},
+		{"update", "--json"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+
+			root := newRootCmd()
+			var stdout, stderr bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(&stderr)
+			root.SetArgs(args)
+
+			if err := root.Execute(); err != nil {
+				t.Fatalf("execute: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+			}
+
+			var files []string
+			err := filepath.WalkDir(home, func(path string, d os.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if d.IsDir() {
+					return nil
+				}
+				rel, err := filepath.Rel(home, path)
+				if err != nil {
+					return err
+				}
+				files = append(files, rel)
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("walk home: %v", err)
+			}
+			if len(files) > 0 {
+				t.Fatalf("read-only command wrote files in HOME: %v\nstdout=%s\nstderr=%s", files, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
 func TestRoot_JSONFlag_LegacyAnthropicBuiltinIsSilentlyRenamed(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
+	"github.com/Naoray/scribe/internal/cli/envelope"
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	isync "github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/workflow"
 )
 
@@ -46,6 +51,21 @@ func runSync(cmd *cobra.Command, args []string) error {
 		FilterRegistries: filterRegistries,
 	}
 	if err := workflow.Run(cmd.Context(), workflow.SyncSteps(), bag); err != nil {
+		var lockErr *isync.LockMismatchError
+		if errors.As(err, &lockErr) {
+			if jsonFlag {
+				_ = renderMutatorEnvelope(cmd, map[string]any{
+					"refused":  lockErr.Refused,
+					"registry": lockErr.Registry,
+				}, envelope.StatusError)
+			} else {
+				fmt.Fprintf(cmd.ErrOrStderr(), "refused by scribe.lock for %s\n", lockErr.Registry)
+				for _, item := range lockErr.Refused {
+					fmt.Fprintf(cmd.ErrOrStderr(), "- %s: %s\n", item.Name, item.Reason)
+				}
+			}
+			return clierrors.Wrap(err, "LOCKFILE_MISMATCH", clierrors.ExitConflict, clierrors.WithRendered(jsonFlag))
+		}
 		return handleNameConflictError(cmd, err)
 	}
 	if bag.Partial {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/cli/envelope"
+	"github.com/Naoray/scribe/internal/lockfile"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/registry"
+	isync "github.com/Naoray/scribe/internal/sync"
+)
+
+type updateOutput struct {
+	lockPlanOutput
+	Applied bool           `json:"applied"`
+	Commits []updateCommit `json:"commits,omitempty"`
+}
+
+type updateCommit struct {
+	Registry string `json:"registry"`
+	SHA      string `json:"sha"`
+	URL      string `json:"url"`
+}
+
+func newUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Refresh registry lockfiles after review",
+		Args:  cobra.NoArgs,
+		RunE:  runUpdate,
+	}
+	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	cmd.Flags().Bool("apply", false, "Write refreshed lockfiles to registries")
+	return markJSONSupported(cmd)
+}
+
+func runUpdate(cmd *cobra.Command, args []string) error {
+	jsonFlag := jsonFlagPassed(cmd)
+	apply, _ := cmd.Flags().GetBool("apply")
+	factory := commandFactory()
+	cfg, err := factory.Config()
+	if err != nil {
+		return err
+	}
+	client, err := factory.Client()
+	if err != nil {
+		return err
+	}
+	provider, err := factory.Provider()
+	if err != nil {
+		return err
+	}
+	st, err := factory.State()
+	if err != nil {
+		return err
+	}
+	repos := cfg.TeamRepos()
+	plan, latest, err := buildLockPlan(cmd.Context(), repos, isync.WrapGitHubClient(client), provider, st)
+	if err != nil {
+		return err
+	}
+	out := updateOutput{lockPlanOutput: plan, Applied: false}
+	if apply {
+		pusher := registry.NewGitHubPusher(client)
+		for _, repo := range repos {
+			lf := latest[repo]
+			if lf == nil {
+				continue
+			}
+			commit, err := pushLockfile(cmd.Context(), pusher, repo, lf)
+			if err != nil {
+				return err
+			}
+			out.Commits = append(out.Commits, commit)
+		}
+		out.Applied = true
+	}
+	if jsonFlag {
+		return renderMutatorEnvelope(cmd, out, envelope.StatusOK)
+	}
+	if !apply {
+		if len(out.Updates) == 0 {
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile updates available.")
+			return err
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(out.lockPlanOutput)
+	}
+	for _, commit := range out.Commits {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n", commit.Registry, commit.URL)
+	}
+	return nil
+}
+
+type lockfilePusher interface {
+	LatestCommitSHA(ctx context.Context, owner, repo, branch string) (string, error)
+	PushFilesAtomic(ctx context.Context, owner, repo, branch string, files map[string][]byte, message, expectedHead string) (registry.CommitResult, error)
+}
+
+func pushLockfile(ctx context.Context, pusher lockfilePusher, repo string, lf *lockfile.Lockfile) (updateCommit, error) {
+	owner, repoName, err := manifest.ParseOwnerRepo(repo)
+	if err != nil {
+		return updateCommit{}, err
+	}
+	data, err := lf.Encode()
+	if err != nil {
+		return updateCommit{}, err
+	}
+	head, err := pusher.LatestCommitSHA(ctx, owner, repoName, "main")
+	if err != nil {
+		return updateCommit{}, err
+	}
+	commit, err := pusher.PushFilesAtomic(ctx, owner, repoName, "main", map[string][]byte{
+		lockfile.Filename: data,
+	}, "Update scribe.lock", head)
+	if err != nil {
+		return updateCommit{}, err
+	}
+	return updateCommit{Registry: repo, SHA: commit.SHA, URL: commit.URL}, nil
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -35,7 +35,7 @@ func newUpdateCommand() *cobra.Command {
 	}
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.Flags().Bool("apply", false, "Write refreshed lockfiles to registries")
-	return markJSONSupported(cmd)
+	return markReadOnlyWithoutApply(markJSONSupported(cmd))
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
@@ -54,12 +54,8 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	st, err := factory.State()
-	if err != nil {
-		return err
-	}
 	repos := cfg.TeamRepos()
-	plan, latest, err := buildLockPlan(cmd.Context(), repos, isync.WrapGitHubClient(client), provider, st)
+	plan, latest, err := buildLockPlan(cmd.Context(), repos, isync.WrapGitHubClient(client), provider)
 	if err != nil {
 		return err
 	}

--- a/cmd/update_schema.go
+++ b/cmd/update_schema.go
@@ -1,0 +1,64 @@
+package cmd
+
+import clischema "github.com/Naoray/scribe/internal/cli/schema"
+
+var updateOutputSchema = `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "registries": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/registry_plan" }
+    },
+    "updates": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/update" }
+    },
+    "applied": { "type": "boolean" },
+    "commits": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "registry": { "type": "string" },
+          "sha": { "type": "string" },
+          "url": { "type": "string" }
+        },
+        "required": ["registry", "sha", "url"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["registries", "updates", "applied"],
+  "additionalProperties": false,
+  "$defs": {
+    "registry_plan": {
+      "type": "object",
+      "properties": {
+        "registry": { "type": "string" },
+        "updates": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/update" }
+        }
+      },
+      "required": ["registry", "updates"],
+      "additionalProperties": false
+    },
+    "update": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "current_sha": { "type": "string" },
+        "latest_sha": { "type": "string" },
+        "current_hash": { "type": "string" },
+        "latest_hash": { "type": "string" }
+      },
+      "required": ["name", "current_sha", "latest_sha", "current_hash", "latest_hash"],
+      "additionalProperties": false
+    }
+  }
+}`
+
+func init() {
+	clischema.Register("scribe update", updateOutputSchema)
+}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/lockfile"
+	"github.com/Naoray/scribe/internal/registry"
+)
+
+type fakeLockfilePusher struct {
+	expectedHead string
+	files        map[string][]byte
+}
+
+func (f *fakeLockfilePusher) LatestCommitSHA(context.Context, string, string, string) (string, error) {
+	return "head-sha", nil
+}
+
+func (f *fakeLockfilePusher) PushFilesAtomic(_ context.Context, _, _, _ string, files map[string][]byte, _ string, expectedHead string) (registry.CommitResult, error) {
+	f.expectedHead = expectedHead
+	f.files = files
+	return registry.CommitResult{SHA: "commit-sha", URL: "https://github.com/acme/registry/commit/commit-sha"}, nil
+}
+
+func TestPushLockfileWritesScribeLockAtomically(t *testing.T) {
+	pusher := &fakeLockfilePusher{}
+	result, err := pushLockfile(context.Background(), pusher, "acme/registry", &lockfile.Lockfile{
+		Version:  lockfile.SchemaVersion,
+		Registry: "acme/registry",
+		Entries: []lockfile.Entry{{
+			Name:              "deploy",
+			SourceRegistry:    "acme/source",
+			RegistryCommitSHA: "sha",
+			ContentHash:       "hash",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("pushLockfile() error = %v", err)
+	}
+	if result.SHA != "commit-sha" || pusher.expectedHead != "head-sha" {
+		t.Fatalf("unexpected result=%+v expectedHead=%q", result, pusher.expectedHead)
+	}
+	if string(pusher.files[lockfile.Filename]) == "" {
+		t.Fatalf("scribe.lock was not pushed: %#v", pusher.files)
+	}
+}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -26,13 +26,13 @@ func (f *fakeLockfilePusher) PushFilesAtomic(_ context.Context, _, _, _ string, 
 func TestPushLockfileWritesScribeLockAtomically(t *testing.T) {
 	pusher := &fakeLockfilePusher{}
 	result, err := pushLockfile(context.Background(), pusher, "acme/registry", &lockfile.Lockfile{
-		Version:  lockfile.SchemaVersion,
-		Registry: "acme/registry",
+		FormatVersion: lockfile.SchemaVersion,
+		Registry:      "acme/registry",
 		Entries: []lockfile.Entry{{
-			Name:              "deploy",
-			SourceRegistry:    "acme/source",
-			RegistryCommitSHA: "sha",
-			ContentHash:       "hash",
+			Name:           "deploy",
+			SourceRegistry: "acme/source",
+			CommitSHA:      "sha",
+			ContentHash:    "hash",
 		}},
 	})
 	if err != nil {

--- a/internal/lockfile/hash.go
+++ b/internal/lockfile/hash.go
@@ -1,0 +1,90 @@
+package lockfile
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type File struct {
+	Path    string
+	Content []byte
+}
+
+func HashFiles(files []File) (string, error) {
+	if len(files) == 0 {
+		return "", errors.New("cannot hash empty file tree")
+	}
+	clean := make([]File, 0, len(files))
+	seen := map[string]bool{}
+	for _, file := range files {
+		p := filepath.ToSlash(filepath.Clean(file.Path))
+		if p == "." || p == "" || strings.HasPrefix(p, "../") || filepath.IsAbs(p) {
+			return "", fmt.Errorf("invalid file path %q", file.Path)
+		}
+		if seen[p] {
+			return "", fmt.Errorf("duplicate file path %q", p)
+		}
+		seen[p] = true
+		clean = append(clean, File{Path: p, Content: file.Content})
+	}
+	sort.Slice(clean, func(i, j int) bool { return clean[i].Path < clean[j].Path })
+
+	h := sha256.New()
+	for _, file := range clean {
+		_, _ = h.Write([]byte(file.Path))
+		_, _ = h.Write([]byte{0})
+		sum := sha256.Sum256(file.Content)
+		_, _ = h.Write([]byte(hex.EncodeToString(sum[:])))
+		_, _ = h.Write([]byte{'\n'})
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func HashDir(root string) (string, error) {
+	var files []File
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "versions":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files = append(files, File{Path: rel, Content: data})
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("hash directory %s: %w", root, err)
+	}
+	return HashFiles(files)
+}
+
+func CommandHash(parts ...string) string {
+	h := sha256.New()
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		_, _ = h.Write([]byte(part))
+		_, _ = h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/lockfile/hash_test.go
+++ b/internal/lockfile/hash_test.go
@@ -1,0 +1,68 @@
+package lockfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHashFilesCanonicalizesOrder(t *testing.T) {
+	a, err := HashFiles([]File{
+		{Path: "b.txt", Content: []byte("b")},
+		{Path: "a.txt", Content: []byte("a")},
+	})
+	if err != nil {
+		t.Fatalf("HashFiles() error = %v", err)
+	}
+	b, err := HashFiles([]File{
+		{Path: "a.txt", Content: []byte("a")},
+		{Path: "b.txt", Content: []byte("b")},
+	})
+	if err != nil {
+		t.Fatalf("HashFiles() error = %v", err)
+	}
+	if a != b {
+		t.Fatalf("hashes differ: %s != %s", a, b)
+	}
+}
+
+func TestHashDirSkipsVersionSnapshots(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "SKILL.md"), "# deploy\n")
+	mustWrite(t, filepath.Join(dir, "versions", "rev-1.md"), "old\n")
+
+	withSnapshot, err := HashDir(dir)
+	if err != nil {
+		t.Fatalf("HashDir() error = %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(dir, "versions")); err != nil {
+		t.Fatalf("remove versions: %v", err)
+	}
+	withoutSnapshot, err := HashDir(dir)
+	if err != nil {
+		t.Fatalf("HashDir() error = %v", err)
+	}
+	if withSnapshot != withoutSnapshot {
+		t.Fatalf("versions directory should not affect hash: %s != %s", withSnapshot, withoutSnapshot)
+	}
+}
+
+func TestHashFilesRejectsDuplicatePaths(t *testing.T) {
+	_, err := HashFiles([]File{
+		{Path: "SKILL.md", Content: []byte("a")},
+		{Path: "./SKILL.md", Content: []byte("b")},
+	})
+	if err == nil {
+		t.Fatal("HashFiles() should reject duplicate canonical paths")
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -16,15 +16,15 @@ const (
 )
 
 type Lockfile struct {
-	Version  int     `yaml:"version"`
-	Registry string  `yaml:"registry"`
-	Entries  []Entry `yaml:"entries"`
+	FormatVersion int     `yaml:"format_version"`
+	Registry      string  `yaml:"registry"`
+	Entries       []Entry `yaml:"entries"`
 }
 
 type Entry struct {
 	Name               string `yaml:"name" json:"name"`
 	SourceRegistry     string `yaml:"source_registry" json:"source_registry"`
-	RegistryCommitSHA  string `yaml:"registry_commit_sha" json:"registry_commit_sha"`
+	CommitSHA          string `yaml:"commit_sha" json:"commit_sha"`
 	ContentHash        string `yaml:"content_hash" json:"content_hash"`
 	InstallCommandHash string `yaml:"install_command_hash,omitempty" json:"install_command_hash,omitempty"`
 }
@@ -65,8 +65,8 @@ func (lf *Lockfile) Validate() error {
 	if lf == nil {
 		return errors.New("lockfile is nil")
 	}
-	if lf.Version != SchemaVersion {
-		return fmt.Errorf("unsupported lockfile version %d (expected %d)", lf.Version, SchemaVersion)
+	if lf.FormatVersion != SchemaVersion {
+		return fmt.Errorf("unsupported lockfile format_version %d (expected %d)", lf.FormatVersion, SchemaVersion)
 	}
 	if strings.TrimSpace(lf.Registry) == "" {
 		return errors.New("lockfile registry is required")
@@ -83,8 +83,8 @@ func (lf *Lockfile) Validate() error {
 		if strings.TrimSpace(entry.SourceRegistry) == "" {
 			return fmt.Errorf("lockfile entry %q missing source_registry", entry.Name)
 		}
-		if strings.TrimSpace(entry.RegistryCommitSHA) == "" {
-			return fmt.Errorf("lockfile entry %q missing registry_commit_sha", entry.Name)
+		if strings.TrimSpace(entry.CommitSHA) == "" {
+			return fmt.Errorf("lockfile entry %q missing commit_sha", entry.Name)
 		}
 		if strings.TrimSpace(entry.ContentHash) == "" {
 			return fmt.Errorf("lockfile entry %q has invalid content_hash", entry.Name)
@@ -133,15 +133,15 @@ func Diff(current, latest *Lockfile) []Update {
 	for _, name := range names {
 		next := latestByName[name]
 		prev := currentByName[name]
-		if prev.RegistryCommitSHA == next.RegistryCommitSHA &&
+		if prev.CommitSHA == next.CommitSHA &&
 			prev.ContentHash == next.ContentHash &&
 			prev.InstallCommandHash == next.InstallCommandHash {
 			continue
 		}
 		updates = append(updates, Update{
 			Name:        name,
-			CurrentSHA:  prev.RegistryCommitSHA,
-			LatestSHA:   next.RegistryCommitSHA,
+			CurrentSHA:  prev.CommitSHA,
+			LatestSHA:   next.CommitSHA,
 			CurrentHash: prev.ContentHash,
 			LatestHash:  next.ContentHash,
 		})

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -1,0 +1,150 @@
+package lockfile
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	Filename      = "scribe.lock"
+	SchemaVersion = 1
+)
+
+type Lockfile struct {
+	Version  int     `yaml:"version"`
+	Registry string  `yaml:"registry"`
+	Entries  []Entry `yaml:"entries"`
+}
+
+type Entry struct {
+	Name               string `yaml:"name" json:"name"`
+	SourceRegistry     string `yaml:"source_registry" json:"source_registry"`
+	RegistryCommitSHA  string `yaml:"registry_commit_sha" json:"registry_commit_sha"`
+	ContentHash        string `yaml:"content_hash" json:"content_hash"`
+	InstallCommandHash string `yaml:"install_command_hash,omitempty" json:"install_command_hash,omitempty"`
+}
+
+type Update struct {
+	Name        string `json:"name"`
+	CurrentSHA  string `json:"current_sha"`
+	LatestSHA   string `json:"latest_sha"`
+	CurrentHash string `json:"current_hash"`
+	LatestHash  string `json:"latest_hash"`
+}
+
+func Parse(data []byte) (*Lockfile, error) {
+	var lf Lockfile
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&lf); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", Filename, err)
+	}
+	if err := lf.Validate(); err != nil {
+		return nil, err
+	}
+	return &lf, nil
+}
+
+func (lf *Lockfile) Encode() ([]byte, error) {
+	if err := lf.Validate(); err != nil {
+		return nil, err
+	}
+	data, err := yaml.Marshal(lf)
+	if err != nil {
+		return nil, fmt.Errorf("encode %s: %w", Filename, err)
+	}
+	return data, nil
+}
+
+func (lf *Lockfile) Validate() error {
+	if lf == nil {
+		return errors.New("lockfile is nil")
+	}
+	if lf.Version != SchemaVersion {
+		return fmt.Errorf("unsupported lockfile version %d (expected %d)", lf.Version, SchemaVersion)
+	}
+	if strings.TrimSpace(lf.Registry) == "" {
+		return errors.New("lockfile registry is required")
+	}
+	seen := make(map[string]bool, len(lf.Entries))
+	for _, entry := range lf.Entries {
+		if strings.TrimSpace(entry.Name) == "" {
+			return errors.New("lockfile entry has empty name")
+		}
+		if seen[entry.Name] {
+			return fmt.Errorf("duplicate lockfile entry %q", entry.Name)
+		}
+		seen[entry.Name] = true
+		if strings.TrimSpace(entry.SourceRegistry) == "" {
+			return fmt.Errorf("lockfile entry %q missing source_registry", entry.Name)
+		}
+		if strings.TrimSpace(entry.RegistryCommitSHA) == "" {
+			return fmt.Errorf("lockfile entry %q missing registry_commit_sha", entry.Name)
+		}
+		if strings.TrimSpace(entry.ContentHash) == "" {
+			return fmt.Errorf("lockfile entry %q has invalid content_hash", entry.Name)
+		}
+		if entry.InstallCommandHash != "" && strings.TrimSpace(entry.InstallCommandHash) == "" {
+			return fmt.Errorf("lockfile entry %q has invalid install_command_hash", entry.Name)
+		}
+	}
+	return nil
+}
+
+func (lf *Lockfile) Entry(name string) (Entry, bool) {
+	if lf == nil {
+		return Entry{}, false
+	}
+	for _, entry := range lf.Entries {
+		if entry.Name == name {
+			return entry, true
+		}
+	}
+	return Entry{}, false
+}
+
+func Diff(current, latest *Lockfile) []Update {
+	latestByName := map[string]Entry{}
+	if latest != nil {
+		for _, entry := range latest.Entries {
+			latestByName[entry.Name] = entry
+		}
+	}
+
+	currentByName := map[string]Entry{}
+	if current != nil {
+		for _, entry := range current.Entries {
+			currentByName[entry.Name] = entry
+		}
+	}
+
+	names := make([]string, 0, len(latestByName))
+	for name := range latestByName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	updates := make([]Update, 0)
+	for _, name := range names {
+		next := latestByName[name]
+		prev := currentByName[name]
+		if prev.RegistryCommitSHA == next.RegistryCommitSHA &&
+			prev.ContentHash == next.ContentHash &&
+			prev.InstallCommandHash == next.InstallCommandHash {
+			continue
+		}
+		updates = append(updates, Update{
+			Name:        name,
+			CurrentSHA:  prev.RegistryCommitSHA,
+			LatestSHA:   next.RegistryCommitSHA,
+			CurrentHash: prev.ContentHash,
+			LatestHash:  next.ContentHash,
+		})
+	}
+	return updates
+}

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -1,0 +1,67 @@
+package lockfile
+
+import (
+	"strings"
+	"testing"
+)
+
+const hashA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+const hashB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+func TestParseEncodeValidate(t *testing.T) {
+	raw := []byte(`
+version: 1
+registry: acme/skills
+entries:
+  - name: deploy
+    source_registry: acme/skills
+    registry_commit_sha: abc123
+    content_hash: ` + hashA + `
+    install_command_hash: ` + hashB + `
+`)
+	lf, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if lf.Registry != "acme/skills" || len(lf.Entries) != 1 {
+		t.Fatalf("unexpected lockfile: %+v", lf)
+	}
+	encoded, err := lf.Encode()
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	if !strings.Contains(string(encoded), "scribe") && !strings.Contains(string(encoded), "deploy") {
+		t.Fatalf("encoded lockfile missing entry: %s", encoded)
+	}
+}
+
+func TestValidateRejectsDuplicateEntries(t *testing.T) {
+	lf := &Lockfile{
+		Version:  SchemaVersion,
+		Registry: "acme/skills",
+		Entries: []Entry{
+			{Name: "deploy", SourceRegistry: "acme/skills", RegistryCommitSHA: "a", ContentHash: hashA},
+			{Name: "deploy", SourceRegistry: "acme/skills", RegistryCommitSHA: "b", ContentHash: hashB},
+		},
+	}
+	if err := lf.Validate(); err == nil {
+		t.Fatal("Validate() should reject duplicate entries")
+	}
+}
+
+func TestDiffReportsChangedPins(t *testing.T) {
+	current := &Lockfile{Version: SchemaVersion, Registry: "acme/skills", Entries: []Entry{
+		{Name: "deploy", SourceRegistry: "acme/skills", RegistryCommitSHA: "old", ContentHash: hashA},
+	}}
+	latest := &Lockfile{Version: SchemaVersion, Registry: "acme/skills", Entries: []Entry{
+		{Name: "deploy", SourceRegistry: "acme/skills", RegistryCommitSHA: "new", ContentHash: hashB},
+		{Name: "review", SourceRegistry: "acme/skills", RegistryCommitSHA: "new", ContentHash: hashA},
+	}}
+	updates := Diff(current, latest)
+	if len(updates) != 2 {
+		t.Fatalf("len(updates) = %d, want 2: %+v", len(updates), updates)
+	}
+	if updates[0].Name != "deploy" || updates[0].CurrentSHA != "old" || updates[0].LatestSHA != "new" {
+		t.Fatalf("unexpected first update: %+v", updates[0])
+	}
+}

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -10,12 +10,12 @@ const hashB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
 func TestParseEncodeValidate(t *testing.T) {
 	raw := []byte(`
-version: 1
+format_version: 1
 registry: acme/skills
 entries:
   - name: deploy
     source_registry: acme/skills
-    registry_commit_sha: abc123
+    commit_sha: abc123
     content_hash: ` + hashA + `
     install_command_hash: ` + hashB + `
 `)
@@ -35,13 +35,48 @@ entries:
 	}
 }
 
+func TestParseRejectsUnknownFormatVersion(t *testing.T) {
+	raw := []byte(`
+format_version: 99
+registry: acme/skills
+entries:
+  - name: deploy
+    source_registry: acme/skills
+    commit_sha: abc123
+    content_hash: ` + hashA + `
+`)
+	_, err := Parse(raw)
+	if err == nil {
+		t.Fatal("Parse() should reject unknown format_version")
+	}
+	if !strings.Contains(err.Error(), "unsupported lockfile format_version 99") {
+		t.Fatalf("Parse() error = %v, want unsupported format_version", err)
+	}
+}
+
+func TestParseRejectsLegacyFieldNames(t *testing.T) {
+	raw := []byte(`
+version: 1
+registry: acme/skills
+entries:
+  - name: deploy
+    source_registry: acme/skills
+    registry_commit_sha: abc123
+    content_hash: ` + hashA + `
+`)
+	_, err := Parse(raw)
+	if err == nil {
+		t.Fatal("Parse() should reject legacy field names")
+	}
+}
+
 func TestValidateRejectsDuplicateEntries(t *testing.T) {
 	lf := &Lockfile{
-		Version:  SchemaVersion,
-		Registry: "acme/skills",
+		FormatVersion: SchemaVersion,
+		Registry:      "acme/skills",
 		Entries: []Entry{
-			{Name: "deploy", SourceRegistry: "acme/skills", RegistryCommitSHA: "a", ContentHash: hashA},
-			{Name: "deploy", SourceRegistry: "acme/skills", RegistryCommitSHA: "b", ContentHash: hashB},
+			{Name: "deploy", SourceRegistry: "acme/skills", CommitSHA: "a", ContentHash: hashA},
+			{Name: "deploy", SourceRegistry: "acme/skills", CommitSHA: "b", ContentHash: hashB},
 		},
 	}
 	if err := lf.Validate(); err == nil {
@@ -50,12 +85,12 @@ func TestValidateRejectsDuplicateEntries(t *testing.T) {
 }
 
 func TestDiffReportsChangedPins(t *testing.T) {
-	current := &Lockfile{Version: SchemaVersion, Registry: "acme/skills", Entries: []Entry{
-		{Name: "deploy", SourceRegistry: "acme/skills", RegistryCommitSHA: "old", ContentHash: hashA},
+	current := &Lockfile{FormatVersion: SchemaVersion, Registry: "acme/skills", Entries: []Entry{
+		{Name: "deploy", SourceRegistry: "acme/skills", CommitSHA: "old", ContentHash: hashA},
 	}}
-	latest := &Lockfile{Version: SchemaVersion, Registry: "acme/skills", Entries: []Entry{
-		{Name: "deploy", SourceRegistry: "acme/skills", RegistryCommitSHA: "new", ContentHash: hashB},
-		{Name: "review", SourceRegistry: "acme/skills", RegistryCommitSHA: "new", ContentHash: hashA},
+	latest := &Lockfile{FormatVersion: SchemaVersion, Registry: "acme/skills", Entries: []Entry{
+		{Name: "deploy", SourceRegistry: "acme/skills", CommitSHA: "new", ContentHash: hashB},
+		{Name: "review", SourceRegistry: "acme/skills", CommitSHA: "new", ContentHash: hashA},
 	}}
 	updates := Diff(current, latest)
 	if len(updates) != 2 {

--- a/internal/sync/adapter.go
+++ b/internal/sync/adapter.go
@@ -15,6 +15,9 @@ type TreeEntry = provider.TreeEntry
 // WrapGitHubClient returns a GitHubFetcher backed by a real gh.Client.
 // Delegates to provider.WrapGitHubClient — provider.GitHubClient is a superset of GitHubFetcher.
 func WrapGitHubClient(c *gh.Client) GitHubFetcher {
+	if c == nil {
+		return &NoopFetcher{}
+	}
 	return provider.WrapGitHubClient(c)
 }
 

--- a/internal/sync/events.go
+++ b/internal/sync/events.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"strings"
 
+	"github.com/Naoray/scribe/internal/lockfile"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/reconcile"
 	"github.com/Naoray/scribe/internal/state"
@@ -50,6 +51,7 @@ type SkillStatus struct {
 	IsPackage  bool
 	LatestSHA  string // resolved SHA for branch-pinned skills; empty if unavailable
 	BlobSHAs   map[string]string
+	LockEntry  *lockfile.Entry
 }
 
 // DisplayVersion returns the best human-readable version for this skill.

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -381,10 +381,10 @@ func applyLockPins(statuses []SkillStatus, lf *lockfile.Lockfile) {
 		}
 		entry := *statuses[i].Entry
 		statuses[i].LockEntry = &pin
-		if src, err := manifest.ParseSource(entry.Source); err == nil && pin.RegistryCommitSHA != "" {
-			src.Ref = pin.RegistryCommitSHA
+		if src, err := manifest.ParseSource(entry.Source); err == nil && pin.CommitSHA != "" {
+			src.Ref = pin.CommitSHA
 			entry.Source = src.String()
-			statuses[i].LatestSHA = pin.RegistryCommitSHA
+			statuses[i].LatestSHA = pin.CommitSHA
 			statuses[i].Entry = &entry
 		}
 	}

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -716,11 +716,7 @@ func validateFetchedLockHash(sk SkillStatus, files []tools.SkillFile) error {
 	if sk.LockEntry == nil {
 		return nil
 	}
-	hashFiles := make([]lockfile.File, 0, len(files))
-	for _, file := range files {
-		hashFiles = append(hashFiles, lockfile.File{Path: file.Path, Content: file.Content})
-	}
-	hash, err := lockfile.HashFiles(hashFiles)
+	hash, err := HashInstallableFiles(files)
 	if err != nil {
 		return err
 	}
@@ -736,6 +732,16 @@ func validateFetchedLockHash(sk SkillStatus, files []tools.SkillFile) error {
 			Reason:       "downloaded content hash differs from lockfile pin",
 		}},
 	}
+}
+
+func HashInstallableFiles(files []tools.SkillFile) (string, error) {
+	hashFiles := make([]lockfile.File, 0, len(files))
+	for _, file := range files {
+		if shouldInclude(file.Path) {
+			hashFiles = append(hashFiles, lockfile.File{Path: file.Path, Content: file.Content})
+		}
+	}
+	return lockfile.HashFiles(hashFiles)
 }
 
 func (s *Syncer) emit(msg any) {

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	ibudget "github.com/Naoray/scribe/internal/budget"
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/Naoray/scribe/internal/lockfile"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/migrate"
 	"github.com/Naoray/scribe/internal/provider"
@@ -77,6 +79,25 @@ type Syncer struct {
 	// NameConflictResolver is called when a real directory already exists at
 	// the incoming skill name. Nil means non-interactive conflict.
 	NameConflictResolver func(NameConflict) (NameConflictResolution, error)
+}
+
+type LockRefusal struct {
+	Name         string `json:"name"`
+	ExpectedHash string `json:"expected_hash"`
+	ActualHash   string `json:"actual_hash"`
+	Reason       string `json:"reason"`
+}
+
+type LockMismatchError struct {
+	Registry string        `json:"registry"`
+	Refused  []LockRefusal `json:"refused"`
+}
+
+func (e *LockMismatchError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s: local skill content diverges from %s", e.Registry, lockfile.Filename)
 }
 
 // ModifiedStrategy controls how sync treats outdated skills with local edits.
@@ -256,6 +277,10 @@ func (s *Syncer) Run(ctx context.Context, teamRepo string, st *state.State) erro
 	if err != nil {
 		return fmt.Errorf("sync %s: %w", teamRepo, err)
 	}
+	lf, err := s.FetchLockfile(ctx, teamRepo)
+	if err != nil {
+		return err
+	}
 	if len(s.SkillFilter) > 0 {
 		allowed := make(map[string]bool, len(s.SkillFilter))
 		for _, n := range s.SkillFilter {
@@ -269,7 +294,100 @@ func (s *Syncer) Run(ctx context.Context, teamRepo string, st *state.State) erro
 		}
 		statuses = filtered
 	}
+	if lf != nil {
+		if err := s.validateInstalledAgainstLock(teamRepo, statuses, lf); err != nil {
+			return err
+		}
+		applyLockPins(statuses, lf)
+	}
 	return s.apply(ctx, teamRepo, statuses, st)
+}
+
+func (s *Syncer) FetchLockfile(ctx context.Context, teamRepo string) (*lockfile.Lockfile, error) {
+	if s.Client == nil {
+		return nil, nil
+	}
+	if _, ok := s.Client.(*NoopFetcher); ok {
+		return nil, nil
+	}
+	owner, repo, err := manifest.ParseOwnerRepo(teamRepo)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := s.Client.FetchFile(ctx, owner, repo, lockfile.Filename, "HEAD")
+	if err != nil {
+		// Existing registries may not have adopted scribe.lock yet. The update
+		// command creates it; sync enforces it whenever present.
+		if clierrors.ExitCode(err) == clierrors.ExitNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	lf, err := lockfile.Parse(raw)
+	if err != nil {
+		return nil, clierrors.Wrap(err, "LOCKFILE_INVALID", clierrors.ExitValid,
+			clierrors.WithMessage(fmt.Sprintf("invalid %s for %s: %v", lockfile.Filename, teamRepo, err)),
+			clierrors.WithResource(teamRepo),
+		)
+	}
+	if lf.Registry != teamRepo {
+		return nil, clierrors.Wrap(fmt.Errorf("registry is %q", lf.Registry), "LOCKFILE_INVALID", clierrors.ExitValid,
+			clierrors.WithMessage(fmt.Sprintf("invalid %s for %s: registry is %q", lockfile.Filename, teamRepo, lf.Registry)),
+			clierrors.WithResource(teamRepo),
+		)
+	}
+	return lf, nil
+}
+
+func (s *Syncer) validateInstalledAgainstLock(teamRepo string, statuses []SkillStatus, lf *lockfile.Lockfile) error {
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		return err
+	}
+	var refused []LockRefusal
+	for _, sk := range statuses {
+		pin, ok := lf.Entry(sk.Name)
+		if !ok || sk.IsPackage || sk.Installed == nil || sk.Status == StatusMissing || sk.Status == StatusExtra {
+			continue
+		}
+		hash, err := lockfile.HashDir(filepath.Join(storeDir, sk.Name))
+		if err != nil {
+			refused = append(refused, LockRefusal{Name: sk.Name, ExpectedHash: pin.ContentHash, Reason: err.Error()})
+			continue
+		}
+		if hash != pin.ContentHash {
+			refused = append(refused, LockRefusal{
+				Name:         sk.Name,
+				ExpectedHash: pin.ContentHash,
+				ActualHash:   hash,
+				Reason:       "local content hash differs from lockfile pin",
+			})
+		}
+	}
+	if len(refused) > 0 {
+		return &LockMismatchError{Registry: teamRepo, Refused: refused}
+	}
+	return nil
+}
+
+func applyLockPins(statuses []SkillStatus, lf *lockfile.Lockfile) {
+	for i := range statuses {
+		pin, ok := lf.Entry(statuses[i].Name)
+		if !ok || statuses[i].Entry == nil {
+			continue
+		}
+		entry := *statuses[i].Entry
+		statuses[i].LockEntry = &pin
+		if src, err := manifest.ParseSource(entry.Source); err == nil && pin.RegistryCommitSHA != "" {
+			src.Ref = pin.RegistryCommitSHA
+			entry.Source = src.String()
+			statuses[i].LatestSHA = pin.RegistryCommitSHA
+			statuses[i].Entry = &entry
+		}
+	}
 }
 
 func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillStatus, st *state.State) error {
@@ -354,8 +472,14 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 			// only when the manifest already declared a command-only
 			// package (handled above via sk.IsPackage).
 			if DetectKind(tFiles) == KindPackage {
+				if err := validateFetchedLockHash(sk, tFiles); err != nil {
+					return err
+				}
 				s.applyTreePackage(ctx, sk, teamRepo, tFiles, st, &summary)
 				continue
+			}
+			if err := validateFetchedLockHash(sk, tFiles); err != nil {
+				return err
 			}
 
 			// Check for local modifications before writing.
@@ -586,6 +710,32 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 
 	s.emit(summary)
 	return nil
+}
+
+func validateFetchedLockHash(sk SkillStatus, files []tools.SkillFile) error {
+	if sk.LockEntry == nil {
+		return nil
+	}
+	hashFiles := make([]lockfile.File, 0, len(files))
+	for _, file := range files {
+		hashFiles = append(hashFiles, lockfile.File{Path: file.Path, Content: file.Content})
+	}
+	hash, err := lockfile.HashFiles(hashFiles)
+	if err != nil {
+		return err
+	}
+	if hash == sk.LockEntry.ContentHash {
+		return nil
+	}
+	return &LockMismatchError{
+		Registry: sk.LockEntry.SourceRegistry,
+		Refused: []LockRefusal{{
+			Name:         sk.Name,
+			ExpectedHash: sk.LockEntry.ContentHash,
+			ActualHash:   hash,
+			Reason:       "downloaded content hash differs from lockfile pin",
+		}},
+	}
 }
 
 func (s *Syncer) emit(msg any) {

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "6d654842",
+      "content_hash": "e70437e5",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe-agent",


### PR DESCRIPTION
Adds scribe.lock pinning + plan/apply update flow.

## Summary
- scribe.lock YAML format committed alongside registry catalog
- Pins commit SHA + content hash + install command hash per entry
- scribe sync validates against lockfile, refuses on mismatch (exit 5)
- scribe check lists available updates (read-only)
- scribe update refreshes lockfile with --apply gate (plan/apply pattern)

Closes #44

## Test plan
- [x] go test ./...
- [ ] scribe check --json (no updates)
- [ ] scribe update (plan view)
- [ ] scribe update --apply (writes new lockfile)
- [ ] scribe sync against stale lockfile (exit 5)
- [x] scribe schema {check,update} --json