### PR TITLE
docs(launch): v1.0 launch drafts (AWAITING-VOICE-REVIEW)

### DIFF
--- a/docs/launch/asciinema-cast-script.md
+++ b/docs/launch/asciinema-cast-script.md
@@ -1,0 +1,114 @@
+# Asciinema cast — scribe v1.0 demo  **AWAITING-VOICE-REVIEW**
+
+> *Storyboard order and which commands to feature need user review. Recording itself is human work.*
+
+Target length: **60-90 seconds**.
+
+The cast tells one story: **from a fresh machine to a synced project, with a lockfile to prove it's reproducible.**
+
+## Recording setup
+
+```bash
+# Clean shell, minimal prompt, fixed window size for portrait readability on web embeds.
+PS1='% ' bash --noprofile --norc
+
+# Record with a generous idle cap so pauses look natural without bloating the cast.
+asciinema rec scribe-v1-demo.cast \
+  --idle-time-limit 1.5 \
+  --cols 80 --rows 24 \
+  --title "scribe v1.0 — connect, sync, lock" \
+  --command "bash --noprofile --norc"
+```
+
+Inside the recording shell, set up a clean home so the demo isn't polluted by the recorder's real config:
+
+```bash
+export HOME=$(mktemp -d)
+export PS1='% '
+mkdir my-project && cd my-project
+clear
+```
+
+## Storyboard (run in this order, type at conversational speed)
+
+```bash
+# 0. Sanity — show this is a fresh machine. Beat: 1s pause after.
+scribe --version
+
+# 1. Connect to the curated essentials registry.
+#    Beat: pause briefly while the catalog fetches so the registry name is readable.
+scribe registry connect Naoray/scribe-skills-essentials
+
+# 2. Sync — writes scribe.lock, projects skills into ~/.claude/skills/, ~/.codex/skills/, etc.
+#    Use --json | jq for a clean structured summary instead of the full TUI flow.
+scribe sync --all --json | jq '.data.summary'
+
+# 3. Show the lockfile that just got written. This is the reproducibility receipt.
+cat scribe.lock | head -20
+
+# 4. List what we got. The TUI flashes by; this is fine — it shows the count + names.
+scribe list --json --fields name,managed,targets | jq '.data.skills[:5]'
+
+# 5. Show source attribution on a single skill.
+scribe explain tdd --json | jq '.data.source'
+
+# 6. Re-sync against the lockfile — proves reproducibility.
+#    Should report 0 changes.
+scribe sync --json | jq '.data.summary'
+
+# 7. (Closing beat) doctor for the agent contract. Quick health check.
+scribe doctor --json | jq '.status, .data'
+```
+
+## Beat sheet (~75s budget)
+
+| Beat | Command | Pause after | Why it earns its seconds |
+|---:|---|---:|---|
+| 1 | `scribe --version` | 1s | Establishes "fresh install" baseline. |
+| 2 | `scribe registry connect ...` | 2s | Names the canonical 1-step setup. |
+| 3 | `scribe sync --all --json \| jq` | 3s | The headline result — reproducible install with a structured receipt. |
+| 4 | `cat scribe.lock` | 3s | Shows `commit_sha` + `content_hash`. The lockfile is the v1.0 hero. |
+| 5 | `scribe list --json --fields ...` | 2s | Demonstrates `--fields` projection — agent ergonomics. |
+| 6 | `scribe explain tdd --json` | 2s | Source attribution = "where did this skill come from?" |
+| 7 | `scribe sync --json` (re-run) | 2s | "0 changes" proves the lockfile works. |
+| 8 | `scribe doctor --json` | 2s | Closing health check, JSON envelope on screen. |
+
+Total: ~75s with prompt + typing. Trim beat 7 or 8 if the recording overruns 90s.
+
+## Notes for recording
+
+- **Window**: 80×24 — narrow enough to read on a phone-width blog embed, wide enough that `scribe.lock` rows don't wrap.
+- **Prompt**: Set `PS1='% '`. Default zsh/bash prompts eat half the line.
+- **Typing speed**: Slightly slower than natural. The viewer needs to read the command before output flashes by.
+- **Pauses**: Let `--idle-time-limit 1.5` do the trimming. Don't try to be perfectly cadenced live.
+- **`jq` availability**: Confirm `jq` is on PATH in the demo shell. It's the one external dep this storyboard relies on.
+- **Sanitize**: Run once, then watch the playback at full speed before uploading. Look for stray paths under `/var/folders/...` (the `mktemp` home) — if they show up, redact in post or set `HOME` to a friendlier path like `/tmp/scribe-demo`.
+- **Exit code on beat 3**: `scribe sync --all --json` may emit `partial_success` exit code `10` on a fresh install if any skill fails to project (rare, but possible on macOS without `gh` auth). If that happens during recording, either re-run after fixing or trim the trailing failure to keep the story clean. Don't fake it.
+
+## Upload
+
+```bash
+asciinema upload scribe-v1-demo.cast
+# returns a URL like https://asciinema.org/a/<id>
+```
+
+Embed it in:
+
+- `README.md` — replace the `<!-- TODO: hero terminal screenshot or asciinema GIF of scribe list TUI -->` placeholder near the top.
+- `docs/launch/blog-post.md` — link in the **Walkthrough** section ("The asciinema cast linked at the top walks through the same flow in 90 seconds.").
+- The HN submission's first reply if the post does well — works as a low-friction "show, don't tell" follow-up.
+
+## Optional: GIF fallback for the README
+
+Asciinema embeds need JS. For pure-static markdown surfaces (release notes, mirrors), produce a GIF as well:
+
+```bash
+# Requires agg (https://github.com/asciinema/agg)
+agg scribe-v1-demo.cast scribe-v1-demo.gif --speed 1.2 --cols 80 --rows 24
+```
+
+Keep the GIF under 4 MB; trim with `gifsicle -O3` if needed.
+
+---
+
+*AWAITING-VOICE-REVIEW: storyboard order, which subset of commands to feature, and copy choices (e.g. `tdd` as the example skill in beat 6) need user review. Re-record after any CLI behavior changes between draft and v1.0.0 tag.*

--- a/docs/launch/blog-post.md
+++ b/docs/launch/blog-post.md
@@ -1,0 +1,134 @@
+# Scribe 1.0: One manifest for every agent's skills  **AWAITING-VOICE-REVIEW**
+
+> *Voice + technical claims need user review before publication. Do not publish as-is.*
+
+AI coding agents work better when you teach them how your team works — code review style, deployment checklists, the framework patterns you actually use. Lately every agent has its own way to load that knowledge: `~/.claude/skills/`, `~/.codex/skills/`, `.cursor/rules/`, plugin folders, dotfiles. Sharing it has meant Slack links and copy-paste. New teammates have no idea what exists. Skills go stale silently. Three agents on one laptop means three separate stores, none of them in sync.
+
+Scribe 1.0 is the skill manager that fixes this. One manifest, one command, every agent.
+
+## The problem
+
+Skill files are simple — a `SKILL.md` with frontmatter, often a folder of supporting scripts. The hard part is everything around them: distribution, versioning, scoping, attribution, and keeping a fleet of agents on the same page.
+
+Today, most teams handle that manually:
+
+- Someone writes a `tdd.md` and pastes it in the team channel.
+- Half the team copies it into `~/.claude/skills/`. The other half forgets.
+- Two weeks later, a small fix lands in the original. Nobody resyncs.
+- A teammate switches from Claude Code to Codex and starts from scratch.
+- A new project inherits every skill on the laptop, blowing past Codex's 5440-byte session-description budget.
+- A reviewer asks "where did this skill come from?" and there's no answer in the file.
+
+There is no `package.json` for agent skills. No lockfile. No "what's installed and why." No reproducible setup for a new hire. The Agent Skills spec gave us a portable file format; what's missing is the thing that ships, pins, projects, and adopts those files across tools.
+
+## What scribe does differently
+
+Scribe treats skills like packages and treats agents like first-class consumers.
+
+**One source of truth.** Put your team's skills in a GitHub repo with a `scribe.yaml` manifest. Teammates run `scribe registry connect <owner>/<repo>` once. Updates land via `scribe sync`. The same manifest works for everyone, no per-tool maintenance.
+
+**Reproducible installs.** `scribe.lock` pins each entry by `commit_sha` and `content_hash`. `scribe sync` refuses to run when the lockfile diverges from what's on disk; `scribe check` lists what would change; `scribe update` advances the lock after review. This is the workflow you already have for npm, Cargo, or Go modules — applied to the layer above the language runtime.
+
+**Cross-tool projection.** One canonical store under `~/.scribe/skills/` projects to Claude Code, Codex, Cursor, and Gemini at the right paths. Add a tool integration once and every existing skill picks it up. No duplicated copies in three different folders that drift on the next edit.
+
+**Project-local, not global.** A `.scribe.yaml` in the project directory declares which kits and skills belong to *that* project. The agent only sees what's relevant. Cross-cutting skills (review, TDD) stay global; per-stack skills (Laravel patterns, Tauri integration) stay scoped. The Codex description budget gets enforced by construction, not by guesswork.
+
+**Adoption, not migration.** You probably already have hand-rolled skills in `~/.claude/skills/`. `scribe adopt` claims them via symlink — nothing moves, nothing breaks, scribe just starts managing them. You can roll back at any time.
+
+**Author publishing.** `scribe init` scaffolds a package manifest by discovering the `SKILL.md` files in the current directory. `scribe registry create` scaffolds a registry repo on GitHub. `scribe push` ships local skill edits back upstream. The path from "I just wrote a skill" to "the team has it" is two commands.
+
+**Agent-first contract.** Every migrated command emits a versioned JSON envelope:
+
+```json
+{ "status": "ok", "format_version": "1", "data": { ... }, "meta": { ... } }
+```
+
+Mutators use semantic exit codes — `2` for usage errors, `3` not-found, `4` permission, `5` conflict, `6` network, `7` dependency, `8` validation, `9` user-canceled, `10` partial success. `scribe schema <command> --json` returns JSON Schema 2020-12 for inputs and outputs, so an agent can compose calls without guessing flags. `--fields name,version` projects tabular output gh-style. Designed for `jq` and for Claude Code / Codex / Cursor agent loops.
+
+## Walkthrough
+
+The 60-second story, from a fresh machine to a synced project:
+
+```bash
+brew install Naoray/tap/scribe
+
+scribe registry connect Naoray/scribe-skills-essentials
+scribe sync --all
+scribe list
+```
+
+That's it. The first command installs scribe. The second connects a curated starter registry. The third walks the registry catalog, writes `scribe.lock`, projects every skill into the right tool directories, and reports a structured summary. The fourth opens the interactive TUI (or emits the JSON envelope when piped) so you can see what landed and where.
+
+For team setup, swap the registry for your own:
+
+```bash
+scribe registry connect ArtistfyHQ/team-skills
+scribe sync
+```
+
+Commit the resulting `scribe.lock` to your project. The next teammate runs `scribe sync` and gets the exact same skill set, byte-for-byte.
+
+For authoring:
+
+```bash
+cd my-skills-repo
+scribe init           # scaffolds scribe.yaml from existing SKILL.md files
+git add scribe.yaml && git commit -m "scribe manifest"
+git push
+
+scribe registry add Naoray/scribe-skills-essentials   # if you have access
+scribe push my-skill                                   # PRs the local edit upstream
+```
+
+The asciinema cast linked at the top walks through the same flow in 90 seconds.
+
+## What v1.0 commits to
+
+Tagging 1.0 means scribe stops moving the floor under integrators. Specifically:
+
+- The JSON envelope is `format_version: "1"` and stable. Breaking changes bump `format_version`.
+- Exit codes 0-10 are stable. New conditions get new codes, not reassignments.
+- `scribe schema <command> --json` is the source of truth for flags and payloads. If a flag is in the schema, scripts can rely on it.
+- `scribe.yaml` and `scribe.lock` follow SemVer. `format_version` in each makes future migrations explicit.
+- `scribe.yaml` (registries) and `.scribe.yaml` (projects) are forward-compatible: unknown fields are ignored.
+
+A handful of older mutator commands (`install`, `remove`, `resolve`, `restore`, `skill`, `tools`, `config`, `create`, `registry*`, `upgrade`, `migrate`, `browse`) still emit pre-envelope output and reject `--json` with `JSON_NOT_SUPPORTED`. They migrate in the next minor release without changing argument semantics. `scribe schema --all --json` is the live source of truth for which commands are migrated.
+
+Deprecations get a one-minor-release warning window with `DEPRECATED:` prefixed in stderr and the schema, before removal in the following minor.
+
+## What's next
+
+A few of the things on deck for 1.x:
+
+- **Kits and snippets, end to end.** The schema and resolver are in; the user-facing `scribe kit` and `scribe snippet` commands are next so a project can pull in `laravel-baseline` or `react-typescript` as one entry instead of seven.
+- **Hooks, opt-in.** `scribe-hook.sh` and the installer are shipped; the next step is wiring `sync` and `doctor` into Claude Code session lifecycle hooks so a project's skill set is always current when an agent starts.
+- **Public registry index.** Today, you discover registries by URL. Next, an opt-in directory makes "what skill registries are out there" answerable from the CLI.
+- **Per-skill tool overrides.** `scribe skill edit --tools` ships; a richer tool-affinity language for "this skill only matters in Claude Code" is on deck.
+
+Some of this depends on what teams actually need. The [open issues](https://github.com/Naoray/scribe/issues) are the working list.
+
+## Get started
+
+```bash
+brew install Naoray/tap/scribe
+scribe registry connect Naoray/scribe-skills-essentials
+scribe sync --all
+scribe list
+```
+
+Or paste this into Claude Code, Cursor, or Codex with shell access:
+
+> I want to use Scribe to manage my AI coding-agent skills on this machine.
+> Repo: https://github.com/Naoray/scribe (setup steps: /blob/main/SKILL.md)
+>
+> Please set it up: install if missing, run `scribe add Naoray/scribe:scribe-agent --yes --json`, then show me `scribe list --json`.
+
+The agent picks it up from there. Future sessions register the bootstrap skill automatically.
+
+Skill format follows [agentskills.io](https://agentskills.io) — anything that works with `skills.sh` or Paks works with scribe.
+
+Compare with [skills.sh, Superpowers, Anthropic skills, Cursor rules, Cline/Roo, and MCP](../comparison.md) if you're picking a tool.
+
+---
+
+*AWAITING-VOICE-REVIEW: voice and technical claims need user review before publication. Cross-check the "What v1.0 commits to" section against the final SemVer policy. Confirm the `scribe push` and `scribe init` flows match the shipping CLI before publishing externally.*

--- a/docs/launch/hn-pitch.md
+++ b/docs/launch/hn-pitch.md
@@ -1,0 +1,50 @@
+# HN submission — scribe 1.0  **AWAITING-VOICE-REVIEW**
+
+> *Title and pitch need user review. Aim for HN tone — concrete, no marketing fluff.*
+
+## Title (under 80 chars)
+
+**Primary:**
+> Show HN: Scribe 1.0 – lockfile-driven skill manager for AI coding agents
+
+(72 chars)
+
+**Alternates to consider:**
+- `Show HN: Scribe – one manifest for Claude Code, Codex, and Cursor skills` (72 chars)
+- `Show HN: Scribe – package manager for AI coding-agent skills` (60 chars)
+- `Show HN: Scribe 1.0 – scribe.lock for reproducible AI agent setups` (66 chars)
+
+## URL
+
+```
+https://github.com/Naoray/scribe
+```
+
+(Switch to the v1.0.0 release URL once tagged: `https://github.com/Naoray/scribe/releases/tag/v1.0.0`.)
+
+## First comment / Show HN body
+
+> Hi HN — I built scribe because every AI coding agent on my laptop wanted its own copy of the same skills, and there was no good way to keep them in sync. Claude Code reads `~/.claude/skills/`, Codex reads `~/.codex/skills/`, Cursor reads `.cursor/rules/`, and so on. Sharing skills across a team meant Slack links and copy-paste. Skills went stale silently and nobody could answer "what's installed and why?"
+>
+> Scribe is a CLI that treats `SKILL.md` files like packages. You connect a GitHub registry once (`scribe registry connect <owner>/<repo>`), run `scribe sync`, and a canonical store under `~/.scribe/skills/` projects to every detected agent at the right paths. `scribe.lock` pins each skill by `commit_sha` and `content_hash`, so a teammate running `scribe sync` gets the exact same skill set you have. `scribe check` shows pending updates; `scribe update` advances the lock after review. `scribe adopt` claims hand-rolled skills already on the machine via symlink — nothing moves, nothing breaks.
+>
+> The other thing I cared about: agent ergonomics. Every migrated command emits a versioned JSON envelope (`{status, format_version, data, meta}`), uses semantic exit codes (10 for partial success, etc.), and exposes its JSON Schema via `scribe schema <command> --json`, so an agent can compose calls without guessing flags. Project-level `.scribe.yaml` scopes which skills load per-project, which keeps Codex inside its 5440-byte session-description budget without manual pruning.
+>
+> Skill format is the open [agentskills.io](https://agentskills.io) `SKILL.md`, so anything that works with skills.sh or Paks works with scribe. The [comparison doc](https://github.com/Naoray/scribe/blob/main/docs/comparison.md) is honest about when other tools (Superpowers, Cursor MDC, Cline/Roo, MCP servers) are a better fit — scribe is not trying to be an IDE agent or an MCP server, it's the layer that ships and pins the skills those tools consume.
+>
+> Brew: `brew install Naoray/tap/scribe`. Or paste the README's "install via your agent" block into Claude Code / Cursor / Codex with shell access and it bootstraps itself. Curious what's missing — please tire-kick.
+
+---
+
+## Notes for the user before posting
+
+- HN is allergic to marketing. Drop any sentence that sounds like a release post if rewriting. The current draft leans concrete on purpose; trim further if it still reads "launchy."
+- Mention what scribe is *not* (not an IDE agent, not an MCP server) early to pre-empt "isn't this just X?" comments.
+- Have answers ready for: "why not just commit a folder of skills to the team repo?" (no cross-tool projection, no lockfile, no adoption, no per-project scoping); "how is this different from skills.sh?" (skills.sh is the format spec; scribe is the manager); "why Go?" (single binary, no runtime to install on a teammate's laptop).
+- Pick the title last. The "lockfile-driven" framing tends to land well with the package-manager-comfortable HN crowd.
+- Submit Tuesday-Thursday morning Pacific for best window. Avoid Friday/Sunday.
+- If posting requires a Show HN, the body above already opens with "Hi HN — I built scribe…" which fits the form. If posting as a regular submission, drop the "Hi HN" line.
+
+---
+
+*AWAITING-VOICE-REVIEW: title, body voice, and timing all need user review. Cross-check claims against the v1.0.0 release before submitting.*


### PR DESCRIPTION
Three launch artifacts under `docs/launch/`. ALL marked **AWAITING-VOICE-REVIEW** — voice + claims need user review before publication.

## Files

- `docs/launch/blog-post.md` (~1300 words) — long-form launch announcement
- `docs/launch/hn-pitch.md` — Show HN title options + body draft + posting notes
- `docs/launch/asciinema-cast-script.md` — 60-90s storyboard + recording instructions + GIF fallback

## Voice + claims sourced from

- `README.md` (hero positioning, install snippets, "install via your agent")
- `docs/comparison.md` (when-to-pick framing, alternatives tone)
- `CHANGELOG.md` Unreleased (envelope contract, exit codes, schema introspection, partial success)
- Recent feature commits: `scribe.lock` (#139), `scribe init` (#138), `scribe push` (#136), source attribution (#135)

## Test plan

- [ ] User reviews voice + tone (HN tone in particular — current draft leans concrete on purpose; trim further if it still reads "launchy")
- [ ] User cross-checks technical claims vs current scribe state (especially the v1.0 SemVer commitments paragraph in blog-post.md)
- [ ] User confirms `scribe push` and `scribe init` flows match the shipping CLI surfaces
- [ ] User picks final HN title from the four options
- [ ] User updates / replaces drafts before any external publication

## DO NOT MERGE without user voice review.

This PR is a staging area. After voice pass, files may move out of `docs/launch/` or be cherry-picked into a launch repo / blog CMS.