### PR TITLE
docs(kits): document agent-driven kit + snippet authoring (v1.0 path)

### DIFF
--- a/docs/projects-and-kits.md
+++ b/docs/projects-and-kits.md
@@ -56,6 +56,27 @@ skills:
 
 Projects list which kits they want via `kits:` in `.scribe.yaml`. Multiple kits union; the project may add or remove individual skills on top with `add:` / `remove:`.
 
+### Authoring kits and snippets (today)
+
+A user-facing `scribe kit` / `scribe snippet` CLI is on the v1.1 roadmap. Until it ships, the embedded scribe skill (installed automatically the first time you run scribe in a Claude Code, Codex, or Cursor session) knows how to scaffold kits and snippets directly. **Ask your AI agent.**
+
+Examples:
+
+```text
+You: Create a kit called web-baseline with tdd, code-review, and commit-message.
+Agent: <writes ~/.scribe/kits/web-baseline.yaml, runs `scribe sync`>
+
+You: Add a snippet that enforces commit discipline, target Claude and Codex.
+Agent: <writes ~/.scribe/snippets/commit-discipline.md, lists targets in frontmatter>
+
+You: Wire web-baseline into this project.
+Agent: <edits .scribe.yaml in the repo root, runs `scribe sync`>
+```
+
+The agent uses the schema documented above (kit YAML) and the snippet schema below (markdown frontmatter), then runs `scribe sync` to apply changes. No separate CLI is required — the storage format and resolver are stable contracts as of v1.0.
+
+If you want to author by hand, the YAML files at `~/.scribe/kits/<name>.yaml` and `~/.scribe/snippets/<name>.md` are the source of truth — `scribe sync` picks them up on every run.
+
 Kits are **not** personas. The forward path for role specialization (adversarial review, security/a11y experts, context isolation) is subagent routing metadata inside kits — not a separate primitive. That metadata is not in the v1 surface.
 
 ### Codex budget guardrail


### PR DESCRIPTION
## Summary

User-facing complement to PR #144 (which taught the embedded scribe skill how to scaffold kits/snippets). This PR tells **users** they have that path today, with concrete examples of asking their AI agent to create kits.

## What's added

New "Authoring kits and snippets (today)" section in `docs/projects-and-kits.md` with three example prompts:
- Create a kit
- Add a snippet
- Wire a kit into a project

Plus the manual file path for hand-editing (`~/.scribe/kits/<name>.yaml`, `~/.scribe/snippets/<name>.md`) since `scribe sync` picks them up.

## Test plan
- [ ] Visual review of doc rendering
- [ ] Examples are accurate vs the schema documented above the new section