### PR TITLE
feat(skill): rename embedded skill scribe-agent → scribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Changed
+
+- **BREAKING — embedded skill renamed `scribe-agent` → `scribe`** — first-run installs as `scribe`, and existing v1.0 installs are migrated automatically on next invocation (state entries + canonical store + projection symlinks repointed in one shot). Update any automation that hardcoded the skill name. ([#TBD](https://github.com/Naoray/scribe/pull/TBD))
+
 ## SemVer commitment (from v1.0.0)
 
 Starting with v1.0.0 we follow [Semantic Versioning](https://semver.org).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Changed
 
-- **BREAKING — embedded skill renamed `scribe-agent` → `scribe`** — first-run installs as `scribe`, and existing v1.0 installs are migrated automatically on next invocation (state entries + canonical store + projection symlinks repointed in one shot). Update any automation that hardcoded the skill name. ([#TBD](https://github.com/Naoray/scribe/pull/TBD))
+- **BREAKING — embedded skill renamed `scribe-agent` → `scribe`** — first-run installs as `scribe`, and existing v1.0 installs are migrated automatically on next invocation (state entries + canonical store + projection symlinks repointed in one shot). Update any automation that hardcoded the skill name. ([#146](https://github.com/Naoray/scribe/pull/146))
 
 ## SemVer commitment (from v1.0.0)
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Repo: https://github.com/Naoray/scribe (setup steps: /blob/main/SKILL.md)
 
 Please set it up for me:
   1. If `scribe --version` fails, install it (prefer brew, fall back to release binary, last resort `go install`).
-  2. Register Scribe's own agent-facing skill: `scribe add Naoray/scribe:scribe-agent --yes --json`
+  2. Register Scribe's own agent-facing skill: `scribe add Naoray/scribe:scribe --yes --json`
   3. Show me `scribe list --json` to confirm.
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: scribe-agent
+name: scribe
 description: Use when the user wants to install, list, sync, remove, or manage AI coding-agent skills on this machine. Scribe manages a canonical skill store and links skills into Claude Code, Cursor, Codex, and other supported tools.
 ---
 
-# scribe-agent
+# scribe
 
 ## First-run bootstrap (do this before anything else)
 
@@ -78,17 +78,17 @@ Step 3 — make sure this skill is registered locally so it survives future sess
 scribe list --json
 ```
 
-If the output already contains an entry with `"name": "scribe-agent"`, you're done — continue with the user's actual request.
+If the output already contains an entry with `"name": "scribe"`, you're done — continue with the user's actual request.
 
 If it does not, install this skill now. First trigger first-run so the `Naoray/scribe` built-in registry is wired up, then install:
 
 ```bash
 scribe status --json
-scribe add Naoray/scribe:scribe-agent --yes --json
+scribe add Naoray/scribe:scribe --yes --json
 scribe list --json
 ```
 
-Confirm the final `scribe list --json` includes `scribe-agent`. If anything in this bootstrap fails, report the failing command and its stderr verbatim — do not guess around it.
+Confirm the final `scribe list --json` includes `scribe`. If anything in this bootstrap fails, report the failing command and its stderr verbatim — do not guess around it.
 
 Once bootstrap succeeds, proceed with the user's request using the command reference below.
 

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -1,9 +1,9 @@
 ---
-name: scribe-agent
+name: scribe
 description: Use when the user wants to install, list, sync, remove, or manage AI coding-agent skills on this machine. Scribe manages a canonical skill store and links skills into Claude Code, Cursor, Codex, and other supported tools.
 ---
 
-# scribe-agent
+# scribe
 
 {{- if .NeedsBootstrap }}
 
@@ -67,17 +67,17 @@ Step 3 - make sure this skill is registered locally so it survives future sessio
 scribe list --json
 ```
 
-If the output already contains an entry with `"name": "scribe-agent"`, you're done - continue with the user's actual request.
+If the output already contains an entry with `"name": "scribe"`, you're done - continue with the user's actual request.
 
 If it does not, install this skill now. First trigger first-run so the `Naoray/scribe` built-in registry is wired up, then install:
 
 ```bash
 scribe status --json
-scribe add Naoray/scribe:scribe-agent --yes --json
+scribe add Naoray/scribe:scribe --yes --json
 scribe list --json
 ```
 
-Confirm the final `scribe list --json` includes `scribe-agent`. If anything in this bootstrap fails, report the failing command and its stderr verbatim - do not guess around it.
+Confirm the final `scribe list --json` includes `scribe`. If anything in this bootstrap fails, report the failing command and its stderr verbatim - do not guess around it.
 
 Once bootstrap succeeds, delete this entire block (both marker lines included) and proceed with the user's request using the command reference below.
 ===setup-end===

--- a/agentskill.go
+++ b/agentskill.go
@@ -2,7 +2,7 @@ package scribe
 
 import _ "embed"
 
-// AgentSkillTemplate is the scribe-agent SKILL.md template embedded at build time.
+// AgentSkillTemplate is the scribe SKILL.md template embedded at build time.
 // It is rendered at install time by internal/agent based on local state.
 //
 //go:embed SKILL.md.tmpl

--- a/cmd/add_scribe_agent_test.go
+++ b/cmd/add_scribe_agent_test.go
@@ -20,7 +20,7 @@ func (p *singleFileProvider) Discover(_ context.Context, repo string) (*provider
 	return &provider.DiscoverResult{
 		IsTeam: true,
 		Entries: []manifest.Entry{{
-			Name:   "scribe-agent",
+			Name:   "scribe",
 			Source: "github:Naoray/scribe@HEAD",
 			Path:   "SKILL.md",
 		}},
@@ -30,7 +30,7 @@ func (p *singleFileProvider) Discover(_ context.Context, repo string) (*provider
 func (p *singleFileProvider) Fetch(_ context.Context, entry manifest.Entry) ([]provider.File, error) {
 	return []provider.File{{
 		Path:    "SKILL.md",
-		Content: []byte("---\nname: scribe-agent\ndescription: test\n---\nbody\n"),
+		Content: []byte("---\nname: scribe\ndescription: test\n---\nbody\n"),
 	}}, nil
 }
 
@@ -67,7 +67,7 @@ func TestAddScribeAgent_SingleFileSkill_EndToEnd(t *testing.T) {
 	if err := runAddDirectInstall(
 		context.Background(),
 		"Naoray/scribe",
-		"scribe-agent",
+		"scribe",
 		cfg,
 		st,
 		syncer,
@@ -78,7 +78,7 @@ func TestAddScribeAgent_SingleFileSkill_EndToEnd(t *testing.T) {
 		t.Fatalf("install failed: %v", err)
 	}
 
-	storeDir := filepath.Join(os.Getenv("HOME"), ".scribe", "skills", "scribe-agent")
+	storeDir := filepath.Join(os.Getenv("HOME"), ".scribe", "skills", "scribe")
 	entries, err := os.ReadDir(storeDir)
 	if err != nil {
 		t.Fatalf("read store dir: %v", err)
@@ -98,7 +98,7 @@ func TestAddScribeAgent_SingleFileSkill_EndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read SKILL.md: %v", err)
 	}
-	if !bytes.Contains(content, []byte("name: scribe-agent")) {
+	if !bytes.Contains(content, []byte("name: scribe")) {
 		t.Errorf("SKILL.md missing expected frontmatter: %q", string(content))
 	}
 }

--- a/cmd/exit_codes_test.go
+++ b/cmd/exit_codes_test.go
@@ -17,7 +17,7 @@ func TestSemanticExitCodesSubprocessMatrix(t *testing.T) {
 		{name: "cobra parse usage", args: []string{"--json", "nonsense-cmd"}, wantCode: 2, wantErr: "USAGE"},
 		{name: "schema command not found", args: []string{"--json", "schema", "nonsense-cmd"}, wantCode: 3, wantErr: "SCHEMA_COMMAND_NOT_FOUND"},
 		{name: "skill not found", args: []string{"--json", "explain", "nonsense-skill"}, wantCode: 3, wantErr: "SKILL_NOT_FOUND"},
-		{name: "auth failure", args: []string{"--json", "add", "Naoray/scribe:scribe-agent"}, wantCode: 4, wantErr: "GH_AUTH_FAILED"},
+		{name: "auth failure", args: []string{"--json", "add", "Naoray/scribe:scribe"}, wantCode: 4, wantErr: "GH_AUTH_FAILED"},
 		{name: "usage validation", args: []string{"--json", "connect"}, wantCode: 2, wantErr: "USAGE_CONNECT_REPO_REQUIRED"},
 		{name: "plain operational error", args: []string{"--json", "list"}, wantCode: 1, wantErr: "GENERAL", badHome: true},
 	}

--- a/cmd/list_tui_test.go
+++ b/cmd/list_tui_test.go
@@ -1623,7 +1623,7 @@ func TestExecuteActionTools_OpensToolsEditor(t *testing.T) {
 			Config: &config.Config{},
 			State: &state.State{
 				Installed: map[string]state.InstalledSkill{
-					"scribe-agent": {
+					"scribe": {
 						ToolsMode: state.ToolsModeInherit,
 						Tools:     []string{"claude"},
 					},
@@ -1632,9 +1632,9 @@ func TestExecuteActionTools_OpensToolsEditor(t *testing.T) {
 		},
 		filtered: []listRow{
 			{
-				Name:    "scribe-agent",
+				Name:    "scribe",
 				Managed: true,
-				Local:   &discovery.Skill{Name: "scribe-agent", LocalPath: "/tmp/scribe-agent"},
+				Local:   &discovery.Skill{Name: "scribe", LocalPath: "/tmp/scribe"},
 			},
 		},
 	}
@@ -1707,9 +1707,9 @@ func TestRenderDetailPane_ToolsEditor(t *testing.T) {
 		toolSelection: map[string]bool{"claude": true},
 	}
 	row := listRow{
-		Name:    "scribe-agent",
+		Name:    "scribe",
 		Managed: true,
-		Local:   &discovery.Skill{Name: "scribe-agent", LocalPath: "/tmp/scribe-agent"},
+		Local:   &discovery.Skill{Name: "scribe", LocalPath: "/tmp/scribe"},
 	}
 
 	out := m.renderDetailPane(row, 60)
@@ -1737,9 +1737,9 @@ func TestRenderDetailPane_ToolsEditorInheritUsesInheritedMarker(t *testing.T) {
 		},
 	}
 	row := listRow{
-		Name:    "scribe-agent",
+		Name:    "scribe",
 		Managed: true,
-		Local:   &discovery.Skill{Name: "scribe-agent", LocalPath: "/tmp/scribe-agent"},
+		Local:   &discovery.Skill{Name: "scribe", LocalPath: "/tmp/scribe"},
 	}
 
 	out := m.renderDetailPane(row, 60)

--- a/cmd/read_only_envelope_test.go
+++ b/cmd/read_only_envelope_test.go
@@ -200,8 +200,8 @@ func normalizeListLegacyData(t *testing.T, raw json.RawMessage, home string) any
 	skills, _ := data["skills"].([]any)
 	for _, item := range skills {
 		skill, _ := item.(map[string]any)
-		if path, _ := skill["path"].(string); path == filepath.Join(home, ".scribe", "skills", "scribe-agent") {
-			skill["path"] = "$HOME/.scribe/skills/scribe-agent"
+		if path, _ := skill["path"].(string); path == filepath.Join(home, ".scribe", "skills", "scribe") {
+			skill["path"] = "$HOME/.scribe/skills/scribe"
 		}
 	}
 	return data

--- a/cmd/read_only_envelope_test.go
+++ b/cmd/read_only_envelope_test.go
@@ -68,6 +68,50 @@ func TestReadOnlyCommandsEmitEnvelopeAndValidateOutputSchema(t *testing.T) {
 	}
 }
 
+func TestReadOnlyCommandMigratesEmbeddedSkillRenameState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stateDir := filepath.Join(home, ".scribe")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	oldState := `{
+  "schema_version": 5,
+  "installed": {
+    "scribe-agent": {
+      "revision": 1,
+      "installed_hash": "old",
+      "installed_at": "2026-04-30T12:00:00Z",
+      "origin": "bootstrap"
+    }
+  },
+  "kits": {},
+  "snippets": {},
+  "removed_by_user": []
+}`
+	if err := os.WriteFile(filepath.Join(stateDir, "state.json"), []byte(oldState), 0o644); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	_ = executeEnvelopeCommand(t, []string{"status", "--json"})
+
+	updated, err := os.ReadFile(filepath.Join(stateDir, "state.json"))
+	if err != nil {
+		t.Fatalf("read migrated state: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(updated, &parsed); err != nil {
+		t.Fatalf("unmarshal migrated state: %v\n%s", err, updated)
+	}
+	installed, _ := parsed["installed"].(map[string]any)
+	if _, ok := installed["scribe-agent"]; ok {
+		t.Fatalf("old embedded skill entry remains: %s", updated)
+	}
+	if _, ok := installed["scribe"]; !ok {
+		t.Fatalf("new embedded skill entry missing: %s", updated)
+	}
+}
+
 func TestListEnvelopeDataMatchesLegacyGolden(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -176,7 +176,7 @@ func newRootCmd() *cobra.Command {
 				}
 			}
 			if len(naorayRemoved) > 0 {
-				fmt.Fprintf(c.ErrOrStderr(), "scribe: removed Naoray/scribe from connected registries (scribe-agent is now managed by the binary)\n")
+				fmt.Fprintf(c.ErrOrStderr(), "scribe: removed Naoray/scribe from connected registries (scribe is now managed by the binary)\n")
 				if err := cfg.Save(); err != nil {
 					return err
 				}
@@ -193,15 +193,15 @@ func newRootCmd() *cobra.Command {
 				}
 			}
 
-			// Auto-install or refresh the embedded scribe-agent skill on every run.
+			// Auto-install or refresh the embedded scribe skill on every run.
 			// EnsureScribeAgent is idempotent — it skips the write when the content
 			// matches the embedded version, so there is no meaningful overhead.
 			if storeDir, sdErr := tools.StoreDir(); sdErr == nil {
 				if changed, ensureErr := agent.EnsureScribeAgent(storeDir, st, cfg); ensureErr != nil {
-					fmt.Fprintf(c.ErrOrStderr(), "scribe: scribe-agent bootstrap warning: %v\n", ensureErr)
+					fmt.Fprintf(c.ErrOrStderr(), "scribe: scribe bootstrap warning: %v\n", ensureErr)
 				} else if changed {
 					if err := st.Save(); err != nil {
-						fmt.Fprintf(c.ErrOrStderr(), "scribe: scribe-agent state save warning: %v\n", err)
+						fmt.Fprintf(c.ErrOrStderr(), "scribe: scribe state save warning: %v\n", err)
 					}
 				}
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,6 +115,34 @@ func newRootCmd() *cobra.Command {
 
 			factory := commandFactory()
 			if commandReadOnly(c) {
+				stateFileExists, err := state.FileExists()
+				if err != nil {
+					return err
+				}
+				if !stateFileExists {
+					return nil
+				}
+			}
+			st, err := factory.State()
+			if err != nil {
+				return err
+			}
+			migrationResult, err := state.MigrateEmbeddedSkillRename(st)
+			if err != nil {
+				return err
+			}
+			if migrationResult.Conflict {
+				fmt.Fprintf(c.ErrOrStderr(), "scribe: embedded skill rename warning: both %q and %q exist in state; leaving both unchanged\n", state.OldEmbeddedSkillName, state.EmbeddedSkillName)
+			}
+			for _, warning := range migrationResult.Warnings {
+				fmt.Fprintf(c.ErrOrStderr(), "scribe: embedded skill rename warning: %s\n", warning)
+			}
+			if migrationResult.Changed {
+				if err := st.Save(); err != nil {
+					return err
+				}
+			}
+			if commandReadOnly(c) {
 				return nil
 			}
 			if err := runStoreMigration(factory); err != nil {
@@ -124,10 +152,6 @@ func newRootCmd() *cobra.Command {
 			isFirstRun := firstrun.IsFirstRun()
 
 			cfg, err := factory.Config()
-			if err != nil {
-				return err
-			}
-			st, err := factory.State()
 			if err != nil {
 				return err
 			}

--- a/cmd/root_hub.go
+++ b/cmd/root_hub.go
@@ -106,7 +106,7 @@ func writeStatusPlain(w io.Writer, cfg *config.Config, st *state.State) {
 	fmt.Fprintf(w, "Skills:     %d installed\n", len(st.Installed))
 	fmt.Fprintf(w, "Last sync:  %s\n", syncTime(st.LastSync))
 	if shouldShowNoToolHint(st) {
-		fmt.Fprintln(w, "Hint: scribe-agent installed but no AI tool detected. Run `scribe tools` to see what's supported.")
+		fmt.Fprintln(w, "Hint: scribe installed but no AI tool detected. Run `scribe tools` to see what's supported.")
 	}
 }
 
@@ -141,7 +141,7 @@ func writeStatusStyled(w io.Writer, cfg *config.Config, st *state.State) {
 	if shouldShowNoToolHint(st) {
 		fmt.Fprintf(w, "  %s  %s\n",
 			labelStyle.Render(fmt.Sprintf("%*s", labelWidth, "Hint")),
-			valueStyle.Render("scribe-agent installed but no AI tool detected. Run `scribe tools` to see what's supported."),
+			valueStyle.Render("scribe installed but no AI tool detected. Run `scribe tools` to see what's supported."),
 		)
 	}
 	fmt.Fprintln(w)
@@ -151,7 +151,7 @@ func shouldShowNoToolHint(st *state.State) bool {
 	if len(st.Installed) != 1 {
 		return false
 	}
-	installed, ok := st.Installed["scribe-agent"]
+	installed, ok := st.Installed["scribe"]
 	if !ok {
 		return false
 	}

--- a/cmd/root_hub_test.go
+++ b/cmd/root_hub_test.go
@@ -147,7 +147,7 @@ func TestWriteStatusShowsNoToolHintForBootstrapOnlyState(t *testing.T) {
 	cfg := &config.Config{}
 	st := &state.State{
 		Installed: map[string]state.InstalledSkill{
-			"scribe-agent": {Origin: state.OriginBootstrap, Tools: nil},
+			"scribe": {Origin: state.OriginBootstrap, Tools: nil},
 		},
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -105,7 +105,7 @@ func TestRoot_JSONFlag_StdoutIsCleanJSON_EvenDuringBuiltinsBackfill(t *testing.T
 	if !strings.Contains(stderr, "Welcome to Scribe") {
 		t.Errorf("expected first-run banner on stderr, got: %q", stderr)
 	}
-	// Naoray/scribe is no longer a builtin — scribe-agent is managed by the binary.
+	// Naoray/scribe is no longer a builtin — scribe is managed by the binary.
 	if strings.Contains(stderr, "Naoray/scribe") {
 		t.Errorf("Naoray/scribe must not appear in first-run banner, got: %q", stderr)
 	}

--- a/cmd/upgrade_agent.go
+++ b/cmd/upgrade_agent.go
@@ -26,7 +26,7 @@ type upgradeAgentClient interface {
 func newUpgradeAgentCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "upgrade-agent",
-		Short: "Refresh the embedded scribe-agent skill from Naoray/scribe",
+		Short: "Refresh the embedded scribe skill from Naoray/scribe",
 		Args:  cobra.NoArgs,
 		RunE:  runUpgradeAgent,
 	}
@@ -72,7 +72,7 @@ func runUpgradeAgentWithDeps(
 
 	tmpl, err := client.FetchFile(ctx, "Naoray", "scribe", "SKILL.md.tmpl", tag)
 	if err != nil {
-		return fmt.Errorf("fetch scribe-agent template at %s: %w", tag, err)
+		return fmt.Errorf("fetch scribe template at %s: %w", tag, err)
 	}
 
 	storeDir, err := tools.StoreDir()
@@ -82,7 +82,7 @@ func runUpgradeAgentWithDeps(
 
 	content, err := agent.RenderSkillTemplate(tmpl, storeDir, st)
 	if err != nil {
-		return fmt.Errorf("render scribe-agent template: %w", err)
+		return fmt.Errorf("render scribe template: %w", err)
 	}
 
 	changed, err := agent.InstallScribeAgent(storeDir, st, content, tag)

--- a/cmd/upgrade_agent_test.go
+++ b/cmd/upgrade_agent_test.go
@@ -39,16 +39,16 @@ func TestUpgradeAgentCommandRefreshesFromNetwork(t *testing.T) {
 	if err := runUpgradeAgentWithDeps(context.Background(), cfg, st, fakeUpgradeAgentClient{
 		authenticated: true,
 		tag:           "v1.2.3",
-		content:       []byte("---\nname: scribe-agent\ndescription: test\n---\nbody\n"),
+		content:       []byte("---\nname: scribe\ndescription: test\n---\nbody\n"),
 	}); err != nil {
 		t.Fatalf("runUpgradeAgentWithDeps() error = %v", err)
 	}
 
-	storePath := filepath.Join(os.Getenv("HOME"), ".scribe", "skills", "scribe-agent", "SKILL.md")
+	storePath := filepath.Join(os.Getenv("HOME"), ".scribe", "skills", "scribe", "SKILL.md")
 	if _, err := os.Stat(storePath); err != nil {
 		t.Fatalf("expected store file at %s: %v", storePath, err)
 	}
-	if got := st.Installed["scribe-agent"].Sources[0].Ref; got != "v1.2.3" {
+	if got := st.Installed["scribe"].Sources[0].Ref; got != "v1.2.3" {
 		t.Fatalf("source ref = %q, want v1.2.3", got)
 	}
 }
@@ -73,7 +73,7 @@ func TestUpgradeAgentCommandRequiresAuth(t *testing.T) {
 	err := runUpgradeAgentWithDeps(context.Background(), &config.Config{}, &state.State{Installed: map[string]state.InstalledSkill{}}, fakeUpgradeAgentClient{
 		authenticated: false,
 		tag:           "v1.2.3",
-		content:       []byte("---\nname: scribe-agent\n---\n"),
+		content:       []byte("---\nname: scribe\n---\n"),
 	})
 	if !errors.Is(err, errAuthRequired) {
 		t.Fatalf("err = %v, want errAuthRequired", err)
@@ -90,8 +90,8 @@ func TestEnsureScribeAgentNotCalledByVersionCommand(t *testing.T) {
 		t.Fatalf("--version execute: %v", err)
 	}
 
-	storePath := filepath.Join(home, ".scribe", "skills", "scribe-agent", "SKILL.md")
+	storePath := filepath.Join(home, ".scribe", "skills", "scribe", "SKILL.md")
 	if _, err := os.Stat(storePath); !os.IsNotExist(err) {
-		t.Fatalf("version command should not bootstrap scribe-agent; stat err = %v", err)
+		t.Fatalf("version command should not bootstrap scribe; stat err = %v", err)
 	}
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,7 +23,7 @@ For machine-readable details (input flags, output schema, exit codes), pair this
 | `scribe status` | Show connected registries, installed count, and last sync |
 | `scribe tools` | List detected AI tools on this machine; enable, disable, or register custom ones |
 | `scribe explain <skill>` | AI-powered skill explanation (or `--raw` for the rendered SKILL.md body) |
-| `scribe upgrade-agent` | Refresh the embedded scribe-agent bootstrap skill |
+| `scribe upgrade-agent` | Refresh the embedded scribe bootstrap skill |
 
 ## Registry management
 

--- a/internal/agent/bootstrap.go
+++ b/internal/agent/bootstrap.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// EnsureScribeAgent installs or refreshes the embedded scribe-agent skill in
+// EnsureScribeAgent installs or refreshes the embedded scribe skill in
 // the canonical store. It never performs network I/O.
 func EnsureScribeAgent(store string, st *state.State, cfg *config.Config) (bool, error) {
 	if cfg != nil && !cfg.ScribeAgent.Enabled {
@@ -25,11 +25,11 @@ func EnsureScribeAgent(store string, st *state.State, cfg *config.Config) (bool,
 	// cooldown window flips and the rendered content no longer hash-matches.
 	// We still verify both files exist and the base file passes frontmatter
 	// validation so that corruption or manual edits are repaired.
-	if installed, ok := st.Installed["scribe-agent"]; ok &&
+	if installed, ok := st.Installed["scribe"]; ok &&
 		installed.Origin == state.OriginBootstrap &&
 		len(installed.Sources) > 0 &&
 		installed.Sources[0].Ref == EmbeddedVersion {
-		skillDir := filepath.Join(store, "scribe-agent")
+		skillDir := filepath.Join(store, "scribe")
 		_, skillErr := os.Stat(filepath.Join(skillDir, "SKILL.md"))
 		_, claudeErr := os.Stat(filepath.Join(skillDir, "CLAUDE.md"))
 		baseContent, baseErr := os.ReadFile(filepath.Join(skillDir, ".scribe-base.md"))
@@ -44,14 +44,14 @@ func EnsureScribeAgent(store string, st *state.State, cfg *config.Config) (bool,
 	return InstallScribeAgent(store, st, content, EmbeddedVersion)
 }
 
-// InstallScribeAgent validates and installs a scribe-agent skill payload into
+// InstallScribeAgent validates and installs a scribe skill payload into
 // the canonical store and state using the provided version string.
 func InstallScribeAgent(store string, st *state.State, content []byte, version string) (bool, error) {
 	if err := validateSkillContent(content); err != nil {
 		return false, err
 	}
 
-	skillDir := filepath.Join(store, "scribe-agent")
+	skillDir := filepath.Join(store, "scribe")
 	skillPath := filepath.Join(skillDir, "SKILL.md")
 	claudePath := filepath.Join(skillDir, "CLAUDE.md")
 	basePath := filepath.Join(skillDir, ".scribe-base.md")
@@ -62,7 +62,7 @@ func InstallScribeAgent(store string, st *state.State, content []byte, version s
 			claudeErr == nil &&
 			skillMatches(existingBaseContent, content) &&
 			skillMatches(existingClaudeContent, EmbeddedClaudeTemplate) {
-			if installed, ok := st.Installed["scribe-agent"]; ok && installed.Origin == state.OriginBootstrap {
+			if installed, ok := st.Installed["scribe"]; ok && installed.Origin == state.OriginBootstrap {
 				if len(installed.Sources) > 0 && installed.Sources[0].Ref == version {
 					return false, nil
 				}
@@ -83,7 +83,7 @@ func InstallScribeAgent(store string, st *state.State, content []byte, version s
 		return false, fmt.Errorf("write bootstrap base: %w", err)
 	}
 
-	existing := st.Installed["scribe-agent"]
+	existing := st.Installed["scribe"]
 	revision := existing.Revision
 	if revision == 0 {
 		revision = 1
@@ -95,7 +95,7 @@ func InstallScribeAgent(store string, st *state.State, content []byte, version s
 		installedAt = time.Now().UTC()
 	}
 
-	st.Installed["scribe-agent"] = state.InstalledSkill{
+	st.Installed["scribe"] = state.InstalledSkill{
 		Revision:      revision,
 		InstalledHash: isync.ComputeFileHash(content),
 		Sources: []state.SkillSource{{
@@ -140,17 +140,17 @@ func validateSkillContent(content []byte) error {
 	}
 	var raw frontmatter
 	if len(content) == 0 {
-		return fmt.Errorf("validate scribe-agent skill: empty content")
+		return fmt.Errorf("validate scribe skill: empty content")
 	}
 	parts := bytes.SplitN(content, []byte("---\n"), 3)
 	if len(parts) < 3 {
-		return fmt.Errorf("validate scribe-agent skill: missing frontmatter")
+		return fmt.Errorf("validate scribe skill: missing frontmatter")
 	}
 	if err := yaml.Unmarshal(parts[1], &raw); err != nil {
-		return fmt.Errorf("validate scribe-agent skill: parse frontmatter: %w", err)
+		return fmt.Errorf("validate scribe skill: parse frontmatter: %w", err)
 	}
-	if raw.Name != "scribe-agent" {
-		return fmt.Errorf("validate scribe-agent skill: unexpected name %q", raw.Name)
+	if raw.Name != "scribe" {
+		return fmt.Errorf("validate scribe skill: unexpected name %q", raw.Name)
 	}
 	return nil
 }

--- a/internal/agent/bootstrap_test.go
+++ b/internal/agent/bootstrap_test.go
@@ -40,11 +40,11 @@ func TestEnsureScribeAgentInstallsWhenMissing(t *testing.T) {
 		t.Fatal("EnsureScribeAgent() changed = false, want true")
 	}
 
-	got, err := os.ReadFile(filepath.Join(store, "scribe-agent", "SKILL.md"))
+	got, err := os.ReadFile(filepath.Join(store, "scribe", "SKILL.md"))
 	if err != nil {
 		t.Fatalf("read SKILL.md: %v", err)
 	}
-	gotClaude, err := os.ReadFile(filepath.Join(store, "scribe-agent", "CLAUDE.md"))
+	gotClaude, err := os.ReadFile(filepath.Join(store, "scribe", "CLAUDE.md"))
 	if err != nil {
 		t.Fatalf("read CLAUDE.md: %v", err)
 	}
@@ -57,8 +57,8 @@ func TestEnsureScribeAgentInstallsWhenMissing(t *testing.T) {
 	if strings.Contains(string(got), "## Keep `scribe` current") {
 		t.Fatal("daily upgrade prompt should not appear during bootstrap")
 	}
-	if st.Installed["scribe-agent"].Origin != state.OriginBootstrap {
-		t.Fatalf("origin = %q, want %q", st.Installed["scribe-agent"].Origin, state.OriginBootstrap)
+	if st.Installed["scribe"].Origin != state.OriginBootstrap {
+		t.Fatalf("origin = %q, want %q", st.Installed["scribe"].Origin, state.OriginBootstrap)
 	}
 }
 
@@ -66,7 +66,7 @@ func TestEnsureScribeAgentNoOpWhenPresent(t *testing.T) {
 	withFakeScribeBinary(t)
 
 	store := filepath.Join(t.TempDir(), "skills")
-	skillDir := filepath.Join(store, "scribe-agent")
+	skillDir := filepath.Join(store, "scribe")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestEnsureScribeAgentNoOpWhenPresent(t *testing.T) {
 	}
 
 	st := &state.State{Installed: map[string]state.InstalledSkill{
-		"scribe-agent": {
+		"scribe": {
 			Revision: 1,
 			Origin:   state.OriginBootstrap,
 			Sources:  []state.SkillSource{{Ref: EmbeddedVersion}},
@@ -112,7 +112,7 @@ func TestEnsureScribeAgentRepairsMissingBaseFile(t *testing.T) {
 	withFakeScribeBinary(t)
 
 	store := filepath.Join(t.TempDir(), "skills")
-	skillDir := filepath.Join(store, "scribe-agent")
+	skillDir := filepath.Join(store, "scribe")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestEnsureScribeAgentRepairsMissingBaseFile(t *testing.T) {
 	}
 
 	st := &state.State{Installed: map[string]state.InstalledSkill{
-		"scribe-agent": {
+		"scribe": {
 			Revision: 1,
 			Origin:   state.OriginBootstrap,
 			Sources:  []state.SkillSource{{Ref: EmbeddedVersion}},
@@ -149,8 +149,8 @@ func TestEnsureScribeAgentRepairsMissingBaseFile(t *testing.T) {
 	if !changed {
 		t.Fatal("EnsureScribeAgent() changed = false, want true when .scribe-base.md is missing")
 	}
-	if st.Installed["scribe-agent"].Revision != 1 {
-		t.Fatalf("revision = %d, want 1 for same-version repair", st.Installed["scribe-agent"].Revision)
+	if st.Installed["scribe"].Revision != 1 {
+		t.Fatalf("revision = %d, want 1 for same-version repair", st.Installed["scribe"].Revision)
 	}
 
 	baseContent, err := os.ReadFile(filepath.Join(skillDir, ".scribe-base.md"))
@@ -166,7 +166,7 @@ func TestEnsureScribeAgentRepairsStaleBaseFile(t *testing.T) {
 	withFakeScribeBinary(t)
 
 	store := filepath.Join(t.TempDir(), "skills")
-	skillDir := filepath.Join(store, "scribe-agent")
+	skillDir := filepath.Join(store, "scribe")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestEnsureScribeAgentRepairsStaleBaseFile(t *testing.T) {
 	}
 
 	st := &state.State{Installed: map[string]state.InstalledSkill{
-		"scribe-agent": {
+		"scribe": {
 			Revision: 1,
 			Origin:   state.OriginBootstrap,
 			Sources:  []state.SkillSource{{Ref: EmbeddedVersion}},
@@ -206,8 +206,8 @@ func TestEnsureScribeAgentRepairsStaleBaseFile(t *testing.T) {
 	if !changed {
 		t.Fatal("EnsureScribeAgent() changed = false, want true when .scribe-base.md is stale")
 	}
-	if st.Installed["scribe-agent"].Revision != 1 {
-		t.Fatalf("revision = %d, want 1 for same-version repair", st.Installed["scribe-agent"].Revision)
+	if st.Installed["scribe"].Revision != 1 {
+		t.Fatalf("revision = %d, want 1 for same-version repair", st.Installed["scribe"].Revision)
 	}
 
 	baseContent, err := os.ReadFile(filepath.Join(skillDir, ".scribe-base.md"))
@@ -223,7 +223,7 @@ func TestEnsureScribeAgentReinstallsOnVersionMismatch(t *testing.T) {
 	withFakeScribeBinary(t)
 
 	store := filepath.Join(t.TempDir(), "skills")
-	skillDir := filepath.Join(store, "scribe-agent")
+	skillDir := filepath.Join(store, "scribe")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestEnsureScribeAgentReinstallsOnVersionMismatch(t *testing.T) {
 	}
 
 	st := &state.State{Installed: map[string]state.InstalledSkill{
-		"scribe-agent": {Revision: 2, Origin: state.OriginBootstrap},
+		"scribe": {Revision: 2, Origin: state.OriginBootstrap},
 	}}
 	cfg := &config.Config{}
 	cfg.ScribeAgent.Enabled = true
@@ -250,11 +250,11 @@ func TestEnsureScribeAgentReinstallsOnVersionMismatch(t *testing.T) {
 	if !changed {
 		t.Fatal("EnsureScribeAgent() changed = false, want true")
 	}
-	if st.Installed["scribe-agent"].Revision != 3 {
-		t.Fatalf("revision = %d, want 3", st.Installed["scribe-agent"].Revision)
+	if st.Installed["scribe"].Revision != 3 {
+		t.Fatalf("revision = %d, want 3", st.Installed["scribe"].Revision)
 	}
 
-	got, err := os.ReadFile(filepath.Join(store, "scribe-agent", "SKILL.md"))
+	got, err := os.ReadFile(filepath.Join(store, "scribe", "SKILL.md"))
 	if err != nil {
 		t.Fatalf("read SKILL.md: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestEnsureScribeAgentReinstallsOnVersionMismatch(t *testing.T) {
 	if strings.Contains(string(got), "===setup-start===") {
 		t.Fatal("bootstrap section should not be present in steady state")
 	}
-	gotClaude, err := os.ReadFile(filepath.Join(store, "scribe-agent", "CLAUDE.md"))
+	gotClaude, err := os.ReadFile(filepath.Join(store, "scribe", "CLAUDE.md"))
 	if err != nil {
 		t.Fatalf("read CLAUDE.md: %v", err)
 	}
@@ -326,7 +326,7 @@ func TestRenderScribeAgentSteadyStateWhenInstalled(t *testing.T) {
 	now := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
 	rendered, err := renderScribeAgentMarkdown(buildScribeAgentRenderContextAt(&state.State{
 		Installed: map[string]state.InstalledSkill{
-			"scribe-agent": {},
+			"scribe": {},
 		},
 	}, now))
 	if err != nil {
@@ -362,7 +362,7 @@ func TestRenderScribeAgentOmitUpgradePromptWhenCooldownFresh(t *testing.T) {
 	now := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
 	st := &state.State{
 		Installed: map[string]state.InstalledSkill{
-			"scribe-agent": {},
+			"scribe": {},
 		},
 		BinaryUpdateChecks: map[string]state.BinaryUpdateCheck{},
 	}
@@ -383,7 +383,7 @@ func TestRenderScribeAgentShowUpgradePromptWhenCooldownExpired(t *testing.T) {
 	now := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
 	st := &state.State{
 		Installed: map[string]state.InstalledSkill{
-			"scribe-agent": {},
+			"scribe": {},
 		},
 		BinaryUpdateChecks: map[string]state.BinaryUpdateCheck{},
 	}
@@ -404,7 +404,7 @@ func TestRenderScribeAgentShowUpgradePromptWhenCooldownMissing(t *testing.T) {
 	now := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
 	rendered, err := renderScribeAgentMarkdown(buildScribeAgentRenderContextAt(&state.State{
 		Installed: map[string]state.InstalledSkill{
-			"scribe-agent": {},
+			"scribe": {},
 		},
 	}, now))
 	if err != nil {

--- a/internal/agent/embed.go
+++ b/internal/agent/embed.go
@@ -9,7 +9,7 @@ import (
 
 const embeddedRendererFormatVersion = "v2"
 
-// EmbeddedSkillTemplate is the scribe-agent SKILL.md template. It lives at the
+// EmbeddedSkillTemplate is the scribe SKILL.md template. It lives at the
 // repo root (SKILL.md.tmpl) and is embedded via the root package.
 var EmbeddedSkillTemplate = scribe.AgentSkillTemplate
 

--- a/internal/agent/render.go
+++ b/internal/agent/render.go
@@ -17,7 +17,7 @@ type scribeAgentRenderContext struct {
 	ShowDailyUpgradePrompt  bool
 }
 
-var scribeAgentTemplate = template.Must(template.New("scribe-agent").Parse(string(EmbeddedSkillTemplate)))
+var scribeAgentTemplate = template.Must(template.New("scribe").Parse(string(EmbeddedSkillTemplate)))
 
 func buildScribeAgentRenderContext(st *state.State) scribeAgentRenderContext {
 	return buildScribeAgentRenderContextAt(st, time.Now().UTC())
@@ -27,7 +27,7 @@ func buildScribeAgentRenderContextAt(st *state.State, now time.Time) scribeAgent
 	hasBinary := hasScribeBinary()
 	hasInstalled := st != nil && st.Installed != nil
 	if hasInstalled {
-		_, hasInstalled = st.Installed["scribe-agent"]
+		_, hasInstalled = st.Installed["scribe"]
 	}
 	needsBootstrap := !hasBinary || !hasInstalled
 	showPrompt := !needsBootstrap && !st.ScribeBinaryUpdateCooldownFresh(now)
@@ -52,7 +52,7 @@ func buildScribeAgentRenderContextForStoreAt(store string, st *state.State, now 
 func renderScribeAgentMarkdown(ctx scribeAgentRenderContext) ([]byte, error) {
 	var buf bytes.Buffer
 	if err := scribeAgentTemplate.Execute(&buf, ctx); err != nil {
-		return nil, fmt.Errorf("render scribe-agent skill: %w", err)
+		return nil, fmt.Errorf("render scribe skill: %w", err)
 	}
 	return buf.Bytes(), nil
 }
@@ -61,14 +61,14 @@ func renderScribeAgentMarkdown(ctx scribeAgentRenderContext) ([]byte, error) {
 // the same context that EnsureScribeAgent uses. Use this when upgrading from
 // a fetched SKILL.md.tmpl so the bootstrap section is shown only when needed.
 func RenderSkillTemplate(tmpl []byte, store string, st *state.State) ([]byte, error) {
-	t, err := template.New("scribe-agent").Parse(string(tmpl))
+	t, err := template.New("scribe").Parse(string(tmpl))
 	if err != nil {
-		return nil, fmt.Errorf("parse scribe-agent template: %w", err)
+		return nil, fmt.Errorf("parse scribe template: %w", err)
 	}
 	ctx := buildScribeAgentRenderContextForStore(store, st)
 	var buf bytes.Buffer
 	if err := t.Execute(&buf, ctx); err != nil {
-		return nil, fmt.Errorf("render scribe-agent skill: %w", err)
+		return nil, fmt.Errorf("render scribe skill: %w", err)
 	}
 	return buf.Bytes(), nil
 }

--- a/internal/firstrun/firstrun.go
+++ b/internal/firstrun/firstrun.go
@@ -198,7 +198,7 @@ func ApplyBuiltinsRemove(cfg *config.Config, st *state.State, removed []string) 
 // config on a one-shot migration. The entry is only removed if it carries
 // Builtin: true — registries the user added manually are left untouched.
 //
-// Background: scribe-agent is now managed by the embedded binary
+// Background: scribe is now managed by the embedded binary
 // (EnsureScribeAgent) rather than a registry sync, so the source repo no
 // longer needs to be a connected registry.
 func RemoveNaorayScribeRegistry(cfg *config.Config, st *state.State) ([]string, bool) {

--- a/internal/firstrun/firstrun_test.go
+++ b/internal/firstrun/firstrun_test.go
@@ -77,7 +77,7 @@ func TestApplyBuiltins_FirstRunAddsAllAndMarksVersion(t *testing.T) {
 		t.Errorf("first run should add 3 builtins, got %d: %v", len(added), added)
 	}
 	if cfg.FindRegistry("Naoray/scribe") != nil {
-		t.Error("Naoray/scribe must not be added as a builtin (scribe-agent is binary-managed)")
+		t.Error("Naoray/scribe must not be added as a builtin (scribe is binary-managed)")
 	}
 	if cfg.FindRegistry("mattpocock/skills") == nil {
 		t.Error("mattpocock/skills should be a builtin")

--- a/internal/projectmigrate/exceptions.go
+++ b/internal/projectmigrate/exceptions.go
@@ -1,7 +1,7 @@
 package projectmigrate
 
 var globalSkillExceptions = map[string]struct{}{
-	"scribe-agent": {},
+	"scribe": {},
 }
 
 func isGlobalSkillException(skill string) bool {

--- a/internal/projectmigrate/migrate_test.go
+++ b/internal/projectmigrate/migrate_test.go
@@ -71,14 +71,14 @@ func TestMigrationPreservesScribeAgentGlobalSymlink(t *testing.T) {
 	store := filepath.Join(home, ".scribe", "skills")
 	project := filepath.Join(tmp, "project")
 	normalLink := filepath.Join(home, ".claude", "skills", "tdd")
-	scribeAgentLink := filepath.Join(home, ".claude", "skills", "scribe-agent")
+	scribeAgentLink := filepath.Join(home, ".claude", "skills", "scribe")
 
 	mustMkdir(t, filepath.Join(store, "tdd"))
-	mustMkdir(t, filepath.Join(store, "scribe-agent"))
+	mustMkdir(t, filepath.Join(store, "scribe"))
 	mustMkdir(t, filepath.Dir(normalLink))
 	mustMkdir(t, project)
 	mustSymlink(t, filepath.Join(store, "tdd"), normalLink)
-	mustSymlink(t, filepath.Join(store, "scribe-agent"), scribeAgentLink)
+	mustSymlink(t, filepath.Join(store, "scribe"), scribeAgentLink)
 
 	discovery, err := Discover(DiscoveryOptions{
 		HomeDir:     home,
@@ -109,7 +109,7 @@ func TestMigrationPreservesScribeAgentGlobalSymlink(t *testing.T) {
 		t.Fatalf("normal global symlink still exists or unexpected stat error: %v", err)
 	}
 	if _, err := os.Lstat(scribeAgentLink); err != nil {
-		t.Fatalf("scribe-agent global symlink should remain: %v", err)
+		t.Fatalf("scribe global symlink should remain: %v", err)
 	}
 
 	pf, err := projectfile.Load(filepath.Join(project, projectfile.Filename))
@@ -120,8 +120,8 @@ func TestMigrationPreservesScribeAgentGlobalSymlink(t *testing.T) {
 		t.Fatalf("project add = %v, want [tdd]", pf.Add)
 	}
 	for _, link := range plan.RemovedLinks {
-		if link.Skill == "scribe-agent" {
-			t.Fatalf("scribe-agent should not be scheduled for removal: %#v", plan.RemovedLinks)
+		if link.Skill == "scribe" {
+			t.Fatalf("scribe should not be scheduled for removal: %#v", plan.RemovedLinks)
 		}
 	}
 }

--- a/internal/provider/github_fetch_test.go
+++ b/internal/provider/github_fetch_test.go
@@ -12,13 +12,13 @@ import (
 func TestGitHubProvider_Fetch_SingleFileSkill(t *testing.T) {
 	client := &stubClient{
 		files: map[string][]byte{
-			"Naoray/scribe/SKILL.md": []byte("---\nname: scribe-agent\n---\nbody\n"),
+			"Naoray/scribe/SKILL.md": []byte("---\nname: scribe\n---\nbody\n"),
 		},
 	}
 	p := provider.NewGitHubProvider(client)
 
 	entry := manifest.Entry{
-		Name:   "scribe-agent",
+		Name:   "scribe",
 		Source: "github:Naoray/scribe@HEAD",
 		Path:   "SKILL.md",
 	}

--- a/internal/state/migrate_skill_rename.go
+++ b/internal/state/migrate_skill_rename.go
@@ -1,0 +1,227 @@
+package state
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Naoray/scribe/internal/paths"
+)
+
+const (
+	OldEmbeddedSkillName = "scribe-agent"
+	EmbeddedSkillName    = "scribe"
+)
+
+type EmbeddedSkillRenameMigrationResult struct {
+	Changed  bool
+	Conflict bool
+	Warnings []string
+}
+
+// MigrateEmbeddedSkillRename renames the v1.0 embedded bootstrap skill state
+// from "scribe-agent" to "scribe". It is intentionally idempotent.
+func MigrateEmbeddedSkillRename(s *State) (EmbeddedSkillRenameMigrationResult, error) {
+	var result EmbeddedSkillRenameMigrationResult
+	if s == nil || s.Installed == nil {
+		return result, nil
+	}
+	oldSkill, hasOld := s.Installed[OldEmbeddedSkillName]
+	_, hasNew := s.Installed[EmbeddedSkillName]
+	if !hasOld {
+		return result, nil
+	}
+	if hasNew {
+		result.Conflict = true
+		return result, nil
+	}
+
+	storeDir, err := paths.StoreDir()
+	if err != nil {
+		return result, fmt.Errorf("resolve store dir: %w", err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return result, fmt.Errorf("home dir: %w", err)
+	}
+
+	oldCanonical := filepath.Join(storeDir, OldEmbeddedSkillName)
+	newCanonical := filepath.Join(storeDir, EmbeddedSkillName)
+	warnings, err := renameCanonicalStore(oldCanonical, newCanonical)
+	if err != nil {
+		return result, err
+	}
+	result.Warnings = append(result.Warnings, warnings...)
+
+	projectionMoves := embeddedProjectionMoves(home, oldSkill, oldCanonical, newCanonical)
+	for _, move := range projectionMoves {
+		changed, warning, err := repointManagedProjection(move)
+		if err != nil {
+			return result, err
+		}
+		if warning != "" {
+			result.Warnings = append(result.Warnings, warning)
+		}
+		if changed {
+			result.Changed = true
+		}
+	}
+
+	delete(s.Installed, OldEmbeddedSkillName)
+	oldSkill.Paths = renameSkillPaths(oldSkill.Paths)
+	oldSkill.ManagedPaths = renameSkillPaths(oldSkill.ManagedPaths)
+	for i := range oldSkill.Conflicts {
+		oldSkill.Conflicts[i].Path = renameSkillPath(oldSkill.Conflicts[i].Path)
+	}
+	for i := range oldSkill.Sources {
+		oldSkill.Sources[i].Path = renameSkillPath(oldSkill.Sources[i].Path)
+	}
+	s.Installed[EmbeddedSkillName] = oldSkill
+
+	result.Changed = true
+	return result, nil
+}
+
+func renameCanonicalStore(oldCanonical, newCanonical string) ([]string, error) {
+	if _, err := os.Lstat(oldCanonical); errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("stat old embedded skill store: %w", err)
+	}
+	if _, err := os.Lstat(newCanonical); err == nil {
+		return []string{fmt.Sprintf("embedded skill store %s already exists; leaving %s in place", newCanonical, oldCanonical)}, nil
+	} else if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("stat new embedded skill store: %w", err)
+	}
+	if err := os.Rename(oldCanonical, newCanonical); err != nil {
+		return nil, fmt.Errorf("rename embedded skill store: %w", err)
+	}
+	return nil, nil
+}
+
+type projectionMove struct {
+	OldPath string
+	NewPath string
+	Target  string
+}
+
+func embeddedProjectionMoves(home string, skill InstalledSkill, oldCanonical, newCanonical string) []projectionMove {
+	moves := []projectionMove{
+		{
+			OldPath: filepath.Join(home, ".claude", "skills", OldEmbeddedSkillName),
+			NewPath: filepath.Join(home, ".claude", "skills", EmbeddedSkillName),
+			Target:  newCanonical,
+		},
+		{
+			OldPath: filepath.Join(home, ".codex", "skills", OldEmbeddedSkillName),
+			NewPath: filepath.Join(home, ".codex", "skills", EmbeddedSkillName),
+			Target:  newCanonical,
+		},
+		{
+			OldPath: filepath.Join(home, ".cursor", "rules", OldEmbeddedSkillName+".mdc"),
+			NewPath: filepath.Join(home, ".cursor", "rules", EmbeddedSkillName+".mdc"),
+			Target:  filepath.Join(newCanonical, ".cursor.mdc"),
+		},
+	}
+	for _, projection := range skill.Projections {
+		if projection.Project == "" {
+			continue
+		}
+		moves = append(moves,
+			projectionMove{
+				OldPath: filepath.Join(projection.Project, ".claude", "skills", OldEmbeddedSkillName),
+				NewPath: filepath.Join(projection.Project, ".claude", "skills", EmbeddedSkillName),
+				Target:  newCanonical,
+			},
+			projectionMove{
+				OldPath: filepath.Join(projection.Project, ".codex", "skills", OldEmbeddedSkillName),
+				NewPath: filepath.Join(projection.Project, ".codex", "skills", EmbeddedSkillName),
+				Target:  newCanonical,
+			},
+			projectionMove{
+				OldPath: filepath.Join(projection.Project, ".cursor", "rules", OldEmbeddedSkillName+".mdc"),
+				NewPath: filepath.Join(projection.Project, ".cursor", "rules", EmbeddedSkillName+".mdc"),
+				Target:  filepath.Join(newCanonical, ".cursor.mdc"),
+			},
+		)
+	}
+	for _, path := range append(append([]string{}, skill.Paths...), skill.ManagedPaths...) {
+		newPath := renameSkillPath(path)
+		if newPath == path {
+			continue
+		}
+		moves = append(moves, projectionMove{
+			OldPath: path,
+			NewPath: newPath,
+			Target:  migrationProjectionTarget(path, oldCanonical, newCanonical),
+		})
+	}
+	return dedupeProjectionMoves(moves)
+}
+
+func migrationProjectionTarget(path, oldCanonical, newCanonical string) string {
+	if strings.HasSuffix(path, OldEmbeddedSkillName+".mdc") {
+		return filepath.Join(newCanonical, ".cursor.mdc")
+	}
+	if strings.HasPrefix(path, oldCanonical) {
+		return renameSkillPath(path)
+	}
+	return newCanonical
+}
+
+func dedupeProjectionMoves(moves []projectionMove) []projectionMove {
+	seen := map[string]bool{}
+	unique := moves[:0]
+	for _, move := range moves {
+		key := move.OldPath + "\x00" + move.NewPath
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		unique = append(unique, move)
+	}
+	return unique
+}
+
+func repointManagedProjection(move projectionMove) (bool, string, error) {
+	info, err := os.Lstat(move.OldPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, "", nil
+	}
+	if err != nil {
+		return false, "", fmt.Errorf("stat old embedded skill projection %s: %w", move.OldPath, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return false, fmt.Sprintf("embedded skill projection %s is not a symlink; leaving it in place", move.OldPath), nil
+	}
+	if _, err := os.Lstat(move.NewPath); err == nil {
+		return false, fmt.Sprintf("embedded skill projection %s already exists; leaving %s in place", move.NewPath, move.OldPath), nil
+	} else if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return false, "", fmt.Errorf("stat new embedded skill projection %s: %w", move.NewPath, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(move.NewPath), 0o755); err != nil {
+		return false, "", fmt.Errorf("create embedded skill projection dir: %w", err)
+	}
+	if err := os.Remove(move.OldPath); err != nil {
+		return false, "", fmt.Errorf("remove old embedded skill projection %s: %w", move.OldPath, err)
+	}
+	if err := os.Symlink(move.Target, move.NewPath); err != nil {
+		return false, "", fmt.Errorf("symlink embedded skill projection %s -> %s: %w", move.NewPath, move.Target, err)
+	}
+	return true, "", nil
+}
+
+func renameSkillPaths(values []string) []string {
+	for i := range values {
+		values[i] = renameSkillPath(values[i])
+	}
+	return values
+}
+
+func renameSkillPath(value string) string {
+	value = strings.ReplaceAll(value, OldEmbeddedSkillName+".mdc", EmbeddedSkillName+".mdc")
+	return strings.ReplaceAll(value, OldEmbeddedSkillName, EmbeddedSkillName)
+}

--- a/internal/state/migrate_skill_rename_test.go
+++ b/internal/state/migrate_skill_rename_test.go
@@ -1,0 +1,142 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMigrateEmbeddedSkillRenameRenamesStateStoreAndProjections(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	store := filepath.Join(home, ".scribe", "skills")
+	oldCanonical := filepath.Join(store, OldEmbeddedSkillName)
+	newCanonical := filepath.Join(store, EmbeddedSkillName)
+	if err := os.MkdirAll(oldCanonical, 0o755); err != nil {
+		t.Fatalf("mkdir old canonical: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(oldCanonical, "SKILL.md"), []byte("---\nname: scribe\n---\n"), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(oldCanonical, ".cursor.mdc"), []byte("cursor"), 0o644); err != nil {
+		t.Fatalf("write cursor mdc: %v", err)
+	}
+
+	claudeOld := filepath.Join(home, ".claude", "skills", OldEmbeddedSkillName)
+	codexOld := filepath.Join(home, ".codex", "skills", OldEmbeddedSkillName)
+	cursorOld := filepath.Join(home, ".cursor", "rules", OldEmbeddedSkillName+".mdc")
+	for _, link := range []string{claudeOld, codexOld, cursorOld} {
+		if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+			t.Fatalf("mkdir projection parent: %v", err)
+		}
+	}
+	if err := os.Symlink(oldCanonical, claudeOld); err != nil {
+		t.Fatalf("symlink claude: %v", err)
+	}
+	if err := os.Symlink(oldCanonical, codexOld); err != nil {
+		t.Fatalf("symlink codex: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(oldCanonical, ".cursor.mdc"), cursorOld); err != nil {
+		t.Fatalf("symlink cursor: %v", err)
+	}
+
+	st := &State{Installed: map[string]InstalledSkill{
+		OldEmbeddedSkillName: {
+			Revision:    4,
+			InstalledAt: time.Now(),
+			Paths:       []string{claudeOld, codexOld, cursorOld},
+			ManagedPaths: []string{
+				claudeOld,
+				codexOld,
+				cursorOld,
+			},
+			Conflicts: []ProjectionConflict{{Tool: "claude", Path: claudeOld}},
+			Sources:   []SkillSource{{Registry: "Naoray/scribe", Path: "skills/" + OldEmbeddedSkillName + "/SKILL.md"}},
+			Origin:    OriginBootstrap,
+		},
+	}}
+
+	result, err := MigrateEmbeddedSkillRename(st)
+	if err != nil {
+		t.Fatalf("MigrateEmbeddedSkillRename() error = %v", err)
+	}
+	if !result.Changed || result.Conflict {
+		t.Fatalf("result = %#v, want changed without conflict", result)
+	}
+	if _, ok := st.Installed[OldEmbeddedSkillName]; ok {
+		t.Fatal("old state entry still exists")
+	}
+	migrated, ok := st.Installed[EmbeddedSkillName]
+	if !ok {
+		t.Fatal("new state entry missing")
+	}
+	if migrated.Revision != 4 || migrated.Origin != OriginBootstrap {
+		t.Fatalf("migrated state lost metadata: %#v", migrated)
+	}
+	for _, path := range append(append([]string{}, migrated.Paths...), migrated.ManagedPaths...) {
+		if filepath.Base(path) == OldEmbeddedSkillName || filepath.Base(path) == OldEmbeddedSkillName+".mdc" {
+			t.Fatalf("old path retained in state: %q", path)
+		}
+	}
+	if migrated.Conflicts[0].Path != filepath.Join(home, ".claude", "skills", EmbeddedSkillName) {
+		t.Fatalf("conflict path = %q", migrated.Conflicts[0].Path)
+	}
+	if migrated.Sources[0].Path != "skills/"+EmbeddedSkillName+"/SKILL.md" {
+		t.Fatalf("source path = %q", migrated.Sources[0].Path)
+	}
+
+	if _, err := os.Stat(filepath.Join(newCanonical, "SKILL.md")); err != nil {
+		t.Fatalf("new canonical missing: %v", err)
+	}
+	if _, err := os.Lstat(oldCanonical); !os.IsNotExist(err) {
+		t.Fatalf("old canonical should be gone, err=%v", err)
+	}
+	assertSymlinkTarget(t, filepath.Join(home, ".claude", "skills", EmbeddedSkillName), newCanonical)
+	assertSymlinkTarget(t, filepath.Join(home, ".codex", "skills", EmbeddedSkillName), newCanonical)
+	assertSymlinkTarget(t, filepath.Join(home, ".cursor", "rules", EmbeddedSkillName+".mdc"), filepath.Join(newCanonical, ".cursor.mdc"))
+	for _, oldPath := range []string{claudeOld, codexOld, cursorOld} {
+		if _, err := os.Lstat(oldPath); !os.IsNotExist(err) {
+			t.Fatalf("old projection %s should be gone, err=%v", oldPath, err)
+		}
+	}
+
+	second, err := MigrateEmbeddedSkillRename(st)
+	if err != nil {
+		t.Fatalf("second MigrateEmbeddedSkillRename() error = %v", err)
+	}
+	if second.Changed || second.Conflict {
+		t.Fatalf("second result = %#v, want no-op", second)
+	}
+}
+
+func TestMigrateEmbeddedSkillRenameLeavesConflictUnmerged(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	st := &State{Installed: map[string]InstalledSkill{
+		OldEmbeddedSkillName: {Revision: 1},
+		EmbeddedSkillName:    {Revision: 2},
+	}}
+
+	result, err := MigrateEmbeddedSkillRename(st)
+	if err != nil {
+		t.Fatalf("MigrateEmbeddedSkillRename() error = %v", err)
+	}
+	if !result.Conflict || result.Changed {
+		t.Fatalf("result = %#v, want conflict without change", result)
+	}
+	if st.Installed[OldEmbeddedSkillName].Revision != 1 || st.Installed[EmbeddedSkillName].Revision != 2 {
+		t.Fatalf("state should be left as-is: %#v", st.Installed)
+	}
+}
+
+func assertSymlinkTarget(t *testing.T, link, want string) {
+	t.Helper()
+	got, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("readlink %s: %v", link, err)
+	}
+	if got != want {
+		t.Fatalf("readlink %s = %q, want %q", link, got, want)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -725,6 +725,20 @@ func statePath() (string, error) {
 	return paths.StatePath()
 }
 
+func FileExists() (bool, error) {
+	path, err := statePath()
+	if err != nil {
+		return false, err
+	}
+	if _, err := os.Stat(path); err == nil {
+		return true, nil
+	} else if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	} else {
+		return false, err
+	}
+}
+
 func normalizeBranchSourceSHAs(s *State) {
 	storeDir, err := paths.StoreDir()
 	if err != nil {

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -111,7 +111,7 @@ func TestDiffAcceptsNonTeamRegistryWithSkills(t *testing.T) {
 		Client: &diffTestFetcher{},
 		Provider: &nonTeamProvider{
 			entries: []manifest.Entry{{
-				Name:   "scribe-agent",
+				Name:   "scribe",
 				Path:   "SKILL.md",
 				Source: "github:Naoray/scribe@main",
 			}},

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -5,7 +5,7 @@ package tools
 
 import "os"
 
-const bootstrapSkillName = "scribe-agent"
+const bootstrapSkillName = "scribe"
 
 // SkillFile represents a file to be written to the skill store.
 type SkillFile struct {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -147,27 +147,27 @@ func TestClaudeInstallEmptyProjectRootWritesGlobalPath(t *testing.T) {
 }
 
 func TestScribeAgentAlwaysProjectsGlobal(t *testing.T) {
-	canonicalDir := setupNamedSkill(t, "scribe-agent")
+	canonicalDir := setupNamedSkill(t, "scribe")
 	home := os.Getenv("HOME")
 	projectRoot := t.TempDir()
 
-	claudePaths, err := tools.ClaudeTool{}.Install("scribe-agent", canonicalDir, projectRoot)
+	claudePaths, err := tools.ClaudeTool{}.Install("scribe", canonicalDir, projectRoot)
 	if err != nil {
 		t.Fatalf("claude Install: %v", err)
 	}
-	codexPaths, err := tools.CodexTool{}.Install("scribe-agent", canonicalDir, projectRoot)
+	codexPaths, err := tools.CodexTool{}.Install("scribe", canonicalDir, projectRoot)
 	if err != nil {
 		t.Fatalf("codex Install: %v", err)
 	}
-	cursorPaths, err := tools.CursorTool{}.Install("scribe-agent", canonicalDir, projectRoot)
+	cursorPaths, err := tools.CursorTool{}.Install("scribe", canonicalDir, projectRoot)
 	if err != nil {
 		t.Fatalf("cursor Install: %v", err)
 	}
 
 	wants := []string{
-		filepath.Join(home, ".claude", "skills", "scribe-agent"),
-		filepath.Join(home, ".codex", "skills", "scribe-agent"),
-		filepath.Join(home, ".cursor", "rules", "scribe-agent.mdc"),
+		filepath.Join(home, ".claude", "skills", "scribe"),
+		filepath.Join(home, ".codex", "skills", "scribe"),
+		filepath.Join(home, ".cursor", "rules", "scribe.mdc"),
 	}
 	got := []string{claudePaths[0], codexPaths[0], cursorPaths[0]}
 	for i := range wants {

--- a/internal/workflow/list_load.go
+++ b/internal/workflow/list_load.go
@@ -136,7 +136,7 @@ func BuildLocalRows(skills []discovery.Skill, st *state.State) []ListRow {
 	var unmanagedRows []ListRow
 	for i := range skills {
 		sk := &skills[i]
-		// Bootstrap skills (e.g. scribe-agent) are auto-managed by the CLI:
+		// Bootstrap skills (e.g. scribe) are auto-managed by the CLI:
 		// installed/refreshed on every run, not user-installable, not
 		// removable. Hide them from list output to keep the surface clean.
 		if installed, ok := st.Installed[sk.Name]; ok && installed.Origin == state.OriginBootstrap {

--- a/internal/workflow/list_test.go
+++ b/internal/workflow/list_test.go
@@ -398,16 +398,16 @@ func TestPrintLocalJSON(t *testing.T) {
 }
 
 func TestBuildLocalRows_HidesBootstrapOrigin(t *testing.T) {
-	// Regression for #487: scribe-agent (Origin=Bootstrap) is auto-managed
+	// Regression for #487: scribe (Origin=Bootstrap) is auto-managed
 	// by the CLI and shouldn't appear in `scribe list`. It can't be removed
 	// — the next invocation re-installs it — so listing it just clutters.
 	st := &state.State{Installed: map[string]state.InstalledSkill{
 		"my-skill":     {Origin: state.OriginRegistry},
-		"scribe-agent": {Origin: state.OriginBootstrap},
+		"scribe": {Origin: state.OriginBootstrap},
 	}}
 	skills := []discovery.Skill{
 		{Name: "my-skill", Managed: true},
-		{Name: "scribe-agent", Managed: true},
+		{Name: "scribe", Managed: true},
 	}
 
 	rows := BuildLocalRows(skills, st)
@@ -421,10 +421,10 @@ func TestBuildLocalRows_HidesBootstrapOrigin(t *testing.T) {
 
 func TestBuildLocalRows_OnlyBootstrapReturnsEmpty(t *testing.T) {
 	st := &state.State{Installed: map[string]state.InstalledSkill{
-		"scribe-agent": {Origin: state.OriginBootstrap},
+		"scribe": {Origin: state.OriginBootstrap},
 	}}
 	skills := []discovery.Skill{
-		{Name: "scribe-agent", Managed: true},
+		{Name: "scribe", Managed: true},
 	}
 
 	rows := BuildLocalRows(skills, st)
@@ -440,12 +440,12 @@ func TestBuildLocalRowsExcluding_FiltersBootstrapAfterMatching(t *testing.T) {
 	st := &state.State{Installed: map[string]state.InstalledSkill{
 		"matched":      {Origin: state.OriginRegistry},
 		"my-skill":     {Origin: state.OriginRegistry},
-		"scribe-agent": {Origin: state.OriginBootstrap},
+		"scribe": {Origin: state.OriginBootstrap},
 	}}
 	skills := []discovery.Skill{
 		{Name: "matched", Managed: true},
 		{Name: "my-skill", Managed: true},
-		{Name: "scribe-agent", Managed: true},
+		{Name: "scribe", Managed: true},
 	}
 	matched := map[string]bool{"matched": true}
 

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -145,7 +145,7 @@ func StepEnsureScribeAgent(_ context.Context, b *Bag) error {
 
 	changed, err := agent.EnsureScribeAgent(storeDir, b.State, b.Config)
 	if err != nil {
-		return fmt.Errorf("ensure scribe-agent: %w", err)
+		return fmt.Errorf("ensure scribe: %w", err)
 	}
 	if !changed {
 		return nil

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,11 +2,11 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "e70437e5",
+      "content_hash": "33ca0040",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
-      "name": "scribe-agent",
-      "path": "$HOME/.scribe/skills/scribe-agent",
+      "name": "scribe",
+      "path": "$HOME/.scribe/skills/scribe",
       "revision": 1,
       "targets": []
     }


### PR DESCRIPTION
## Summary\n\nRenames the embedded skill from `scribe-agent` to `scribe`. The skill teaches AI agents how to use scribe — calling it `scribe` is more direct.\n\nIncludes a one-shot, idempotent state migration so existing v1.0 installs auto-rename on next invocation (state entries, canonical store dir, projection symlinks).\n\n## BREAKING\n\nUser-facing skill name changes. Automation that hardcoded `scribe-agent` (e.g. `scribe explain scribe-agent`) needs to use `scribe` after upgrade. Migration is automatic — no user action required.\n\n## Test plan\n- [x] go test ./...\n- [ ] Fresh HOME: `scribe status --json` triggers first-run, embedded skill installs as `scribe`\n- [x] Migration smoke: HOME with state.json containing `scribe-agent` entry → run any command → state has `scribe` instead\n- [x] Existing projection symlinks repointed (no orphans in ~/.claude/skills/scribe-agent/)\n- [x] CHANGELOG marks BREAKING