### PR TITLE
fix(upgrade): respect debug.ReadBuildInfo for go install builds

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -22,6 +22,14 @@ type upgradeRunner func(ctx context.Context, method upgrade.Method, release *gog
 
 var upgradeCheck bool
 
+// currentVersion returns the version scribe should compare against the latest
+// release. Falls back to debug.ReadBuildInfo for `go install`-style builds where
+// goreleaser ldflags weren't applied (e.g. `go install github.com/Naoray/scribe@v1.0.1`).
+// Wrapped in a var so tests can override.
+var currentVersion = func() string {
+	return resolveVersion(Version, readBuildInfo())
+}
+
 func newUpgradeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade",
@@ -39,7 +47,7 @@ func runUpgrade(cmd *cobra.Command, _ []string) error {
 	factory := newCommandFactory()
 
 	// Dev builds should not attempt self-upgrade.
-	isDevBuild, _ := upgrade.NeedsUpgrade(Version, "")
+	isDevBuild, _ := upgrade.NeedsUpgrade(currentVersion(), "")
 	if isDevBuild {
 		fmt.Println("Running development build, skipping upgrade.")
 		return nil
@@ -74,9 +82,10 @@ func runUpgradeCheckWithDeps(ctx context.Context, client upgradeClient) error {
 		return fmt.Errorf("check latest version: %w", err)
 	}
 	latestTag := release.GetTagName()
-	_, needsUpgrade := upgrade.NeedsUpgrade(Version, latestTag)
+	current := currentVersion()
+	_, needsUpgrade := upgrade.NeedsUpgrade(current, latestTag)
 	if needsUpgrade {
-		fmt.Printf("New version available: %s (current: %s)\n", latestTag, Version)
+		fmt.Printf("New version available: %s (current: %s)\n", latestTag, current)
 	} else {
 		fmt.Printf("Already up to date (%s)\n", latestTag)
 	}
@@ -90,7 +99,8 @@ func runUpgradeWithDeps(ctx context.Context, st *state.State, client upgradeClie
 	}
 
 	latestTag := release.GetTagName()
-	_, needsUpgrade := upgrade.NeedsUpgrade(Version, latestTag)
+	current := currentVersion()
+	_, needsUpgrade := upgrade.NeedsUpgrade(current, latestTag)
 	if !needsUpgrade {
 		fmt.Printf("Already up to date (%s)\n", latestTag)
 		st.RecordScribeBinaryUpdateSuccess()
@@ -100,7 +110,7 @@ func runUpgradeWithDeps(ctx context.Context, st *state.State, client upgradeClie
 		return nil
 	}
 
-	fmt.Printf("Upgrading v%s → %s...\n", Version, latestTag)
+	fmt.Printf("Upgrading v%s → %s...\n", current, latestTag)
 
 	if err := runner(ctx, method, release, isTTY); err != nil {
 		return err

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -152,6 +152,39 @@ func TestRunUpgradeWithDepsAllowsUnauthenticatedReleaseChecks(t *testing.T) {
 	}
 }
 
+func TestRunUpgradeCheckResolvesGoInstallVersion(t *testing.T) {
+	origVersion := Version
+	origCurrent := currentVersion
+	Version = "dev"
+	currentVersion = func() string { return "1.2.3" }
+	t.Cleanup(func() {
+		Version = origVersion
+		currentVersion = origCurrent
+	})
+
+	r, w, _ := os.Pipe()
+	origStdout := os.Stdout
+	os.Stdout = w
+
+	err := runUpgradeCheckWithDeps(context.Background(), fakeUpgradeClient{tag: "v1.2.3"})
+
+	w.Close()
+	os.Stdout = origStdout
+	var buf strings.Builder
+	io.Copy(&buf, r)
+
+	if err != nil {
+		t.Fatalf("runUpgradeCheckWithDeps() error = %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Already up to date") {
+		t.Fatalf("dev binary with module-version BuildInfo should compare cleanly; got %q", out)
+	}
+	if strings.Contains(out, "New version available") {
+		t.Fatalf("dev fallback should not report new version against matching tag; got %q", out)
+	}
+}
+
 func TestRunUpgradeCheckReportsUpToDate(t *testing.T) {
 	origVersion := Version
 	Version = "1.2.3"


### PR DESCRIPTION
## Summary

- `scribe upgrade` previously dev-skipped any binary where the `Version` package var was `"dev"`, which includes `go install github.com/Naoray/scribe@v1.0.1` because goreleaser ldflags only run at release time.
- Routing the dev-check + comparison through a new `currentVersion()` helper reuses the existing `resolveVersion` + `debug.ReadBuildInfo` fallback (already used for `--version` display since #115), so module-versioned go-install installs participate in the upgrade flow.
- Local source builds (`go build`, `go install ./...`) still report `(devel)` from BuildInfo and remain dev-skipped, which is correct.

## Test plan

- [x] `go test ./cmd/ -run "TestRunUpgrade|TestResolveVersion"` — all green
- [x] `go test ./...` — all green
- [x] New `TestRunUpgradeCheckResolvesGoInstallVersion` exercises the dev → resolved-version path
- [ ] Manually: `go install github.com/Naoray/scribe@v1.0.1 && scribe upgrade --check` reports the right comparison instead of "Running development build, skipping upgrade."

🤖 Generated with [Claude Code](https://claude.com/claude-code)