### PR TITLE
docs: broaden agent coverage messaging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,9 +99,9 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe tools disable` | --json | no |
 | `scribe tools enable` | --json | no |
 | `scribe tools` | --json | no |
+| `scribe update` | --apply, --json | yes |
 | `scribe upgrade-agent` | --json | no |
 | `scribe upgrade` | --check, --json | no |
-| `scribe update` | --apply, --json | yes |
 | `scribe` |  | no |
 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 |___/\___|_|_\___|___/___|
 ```
 
-> Agent-first skill manager for Claude Code, Codex, and Cursor. Your team's AI coding skills, always in sync — one manifest, one command.
+> Agent-first skill manager for any AI coding agent. Built-in support for Claude Code, Codex, Cursor, and Gemini; register any other agent with `scribe tools add`. Your team's AI coding skills, always in sync — one manifest, one command.
 
 <!-- TODO: hero terminal screenshot or asciinema GIF of `scribe list` TUI -->
 
@@ -18,7 +18,7 @@ AI coding agents work better when you teach them how your team works — code re
 Scribe makes the skill set declarative.
 
 - **One source of truth.** Put your team's skills in a GitHub repo with a `scribe.yaml` manifest. Teammates run `scribe registry connect` once.
-- **Cross-tool projection.** One canonical store under `~/.scribe/skills/` projects to Claude Code, Codex, and Cursor at the right paths.
+- **Cross-tool projection.** One canonical store under `~/.scribe/skills/` projects to whatever agent you use — Claude Code, Codex, Cursor, and Gemini ship as built-ins; register others (Aider, Cline, Roo, your own tool) with `scribe tools add`.
 - **Agent-first, scriptable.** Every migrated command emits a versioned JSON envelope (`{status, format_version, data, meta}`) with exit codes, partial-success semantics, and JSON Schema introspection.
 
 ## Install
@@ -55,7 +55,7 @@ Verify: `scribe --version`. Update via `brew upgrade scribe`, the same `go insta
 
 ### Install via your agent
 
-Paste this into Claude Code, Cursor, or Codex with shell access — it installs scribe and registers the agent skill so future sessions pick it up automatically:
+Paste this into your AI coding agent (Claude Code, Codex, Cursor, Gemini, or any agent with shell access) — it installs scribe and registers the agent skill so future sessions pick it up automatically:
 
 ```
 I want to use Scribe to manage my AI coding-agent skills on this machine.
@@ -121,10 +121,10 @@ For a default starter set, connect `Naoray/scribe-skills-essentials` and run `sc
 
 ## Why scribe?
 
-- **Agents-first**: versioned JSON envelope, JSON Schema for every migrated command, distinct exit codes, machine-readable error remediation. Drops cleanly into Claude Code / Codex / Cursor agent loops.
+- **Agents-first**: versioned JSON envelope, JSON Schema for every migrated command, distinct exit codes, machine-readable error remediation. Drops cleanly into any agent loop — Claude Code, Codex, Cursor, Gemini, or a custom tool you registered with `scribe tools add`.
 - **Project-local projection**: scopes skill availability to the project you're in, instead of dumping every installed skill into every session. Keeps Codex inside its 5440-byte description budget by construction.
 - **Adoption, not migration**: claims hand-rolled skills already in `~/.claude/skills/` etc. via symlink — nothing moves, nothing breaks, scribe just starts managing them.
-- **One manifest, every tool**: `scribe.yaml` works across Claude Code, Codex, and Cursor. No per-tool maintenance.
+- **One manifest, every tool**: `scribe.yaml` works across every supported agent — built-ins (Claude Code, Codex, Cursor, Gemini) plus any custom tool you register. No per-tool maintenance.
 
 ## Documentation
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -183,7 +183,7 @@ Commit after each logical phase of work, not just at the end.
 Use `[agent]` prefix on every commit message...
 ```
 
-Required frontmatter: `name`, `description`, `targets`. `targets` is a YAML list of agent tool names (`claude`, `codex`, `cursor`). Body is plain markdown — no variables, no conditionals.
+Required frontmatter: `name`, `description`, `targets`. `targets` is a YAML list of agent tool names — built-ins are `claude`, `codex`, `cursor`, `gemini`; any custom tool registered via `scribe tools add` works here too. Body is plain markdown — no variables, no conditionals.
 
 ### Wiring a kit/snippet into a project
 

--- a/docs/projects-and-kits.md
+++ b/docs/projects-and-kits.md
@@ -58,7 +58,7 @@ Projects list which kits they want via `kits:` in `.scribe.yaml`. Multiple kits 
 
 ### Authoring kits and snippets (today)
 
-A user-facing `scribe kit` / `scribe snippet` CLI is on the v1.1 roadmap. Until it ships, the embedded scribe skill (installed automatically the first time you run scribe in a Claude Code, Codex, or Cursor session) knows how to scaffold kits and snippets directly. **Ask your AI agent.**
+A user-facing `scribe kit` / `scribe snippet` CLI is on the v1.1 roadmap. Until it ships, the embedded scribe skill (installed automatically the first time you run scribe in any supported agent session — Claude Code, Codex, Cursor, Gemini, or a custom tool registered via `scribe tools add`) knows how to scaffold kits and snippets directly. **Ask your AI agent.**
 
 Examples:
 

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "33ca0040",
+      "content_hash": "0f906d8e",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe",


### PR DESCRIPTION
## Summary

- Reframe README hero / projection bullet / install-via-agent / agents-first / one-manifest copy from \"Claude Code, Codex, Cursor\" only to \"any AI coding agent\" with built-ins (Claude Code, Codex, Cursor, Gemini) plus \`scribe tools add\` for custom tools.
- Mirror the broader framing in \`SKILL.md\` (snippet \`targets\` reference) and \`docs/projects-and-kits.md\` (embedded-skill bootstrap paragraph).
- Concrete paths, JSON samples, and real file names stay specific on purpose — only positioning copy was widened.
- \`go generate\` refresh for \`CLAUDE.md\`. Refreshed \`testdata/golden/list.legacy.json\` for the new embedded \`SKILL.md\` content hash.

## Why

Scribe already supports any agent via \`scribe tools add <name>\` with detect/install/uninstall templates, and Gemini is built-in. The marketing copy was lagging behind the actual surface area.

## Test plan

- [x] \`go test ./...\` green
- [x] \`go generate ./...\` clean (CLAUDE.md regenerated)
- [ ] Spot-read README on GitHub render to confirm tone is still tight

🤖 Generated with [Claude Code](https://claude.com/claude-code)