### PR TITLE
fix(migrate): tolerate unreadable dirs during project scan

### DIFF
--- a/internal/projectmigrate/discovery.go
+++ b/internal/projectmigrate/discovery.go
@@ -173,9 +173,17 @@ func DiscoverCandidateProjects(searchRoots []string, st *state.State) ([]Project
 		}
 
 		foundInRoot := false
-		err = filepath.WalkDir(abs, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
+		err = filepath.WalkDir(abs, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				// Skip unreadable paths (e.g. macOS-protected ~/.Trash, ~/Library)
+				// instead of aborting the whole scan.
+				if errors.Is(walkErr, os.ErrPermission) {
+					if d != nil && d.IsDir() {
+						return filepath.SkipDir
+					}
+					return nil
+				}
+				return walkErr
 			}
 			if d.IsDir() && path != abs && shouldSkipProjectWalkDir(d.Name()) {
 				return filepath.SkipDir
@@ -235,7 +243,7 @@ func pathWithin(path, root string) bool {
 
 func shouldSkipProjectWalkDir(name string) bool {
 	switch name {
-	case ".git", ".hg", ".svn", ".anvil", "node_modules", "vendor":
+	case ".git", ".hg", ".svn", ".anvil", ".Trash", "node_modules", "vendor":
 		return true
 	default:
 		return false

--- a/internal/projectmigrate/discovery_test.go
+++ b/internal/projectmigrate/discovery_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/Naoray/scribe/internal/state"
@@ -92,6 +93,43 @@ func TestDiscoverCandidateProjectsIncludesEmptySearchRoot(t *testing.T) {
 
 	if len(projects) != 1 || projects[0].Path != root || projects[0].Source != "search_root" {
 		t.Fatalf("projects = %#v, want search root candidate", projects)
+	}
+}
+
+func TestDiscoverCandidateProjectsSkipsUnreadableDirs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission semantics differ on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+
+	root := t.TempDir()
+	app := filepath.Join(root, "app")
+	locked := filepath.Join(root, "locked")
+	mustMkdir(t, app)
+	mustMkdir(t, locked)
+	if err := os.WriteFile(filepath.Join(app, ".scribe.yaml"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a macOS-style protected dir (e.g. ~/.Trash).
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	projects, err := DiscoverCandidateProjects([]string{root}, nil)
+	if err != nil {
+		t.Fatalf("DiscoverCandidateProjects() error = %v, want nil", err)
+	}
+
+	got := []string{}
+	for _, project := range projects {
+		got = append(got, project.Path)
+	}
+	want := []string{app}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("projects = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `scribe migrate global-to-projects` aborted with `open /Users/<you>/.Trash: operation not permitted` whenever it ran from a directory whose tree contained a macOS-protected dir (`~/.Trash`, `~/Library`, etc.).
- `filepath.WalkDir` propagated the EACCES from the directory open as a fatal error, even though the path is irrelevant for project discovery.
- Skip permission errors during the walk and add `.Trash` to the in-tree skip list so the syscall never happens in the first place. Other walk errors still bubble up.

## Repro before fix
```
cd ~
scribe migrate global-to-projects
# error[GENERAL]: discover migration candidates: scan project candidates: open /Users/<you>/.Trash: operation not permitted
```

## After fix
```
cd ~
scribe migrate global-to-projects --dry-run
# Dry run: found 238 globally projected skill link(s) for 125 skill(s) ...
```

## Test plan
- [x] `go test ./internal/projectmigrate/...` — new `TestDiscoverCandidateProjectsSkipsUnreadableDirs` covers a chmod-0 dir, full suite green
- [x] `go test ./...` — all packages pass
- [x] Manual: built binary and ran `migrate global-to-projects --dry-run` from `~`, scan completed instead of aborting

🤖 Generated with [Claude Code](https://claude.com/claude-code)