### PR TITLE
fix(migrate): skip hidden dirs and tolerate transient walk errors

### DIFF
--- a/internal/projectmigrate/discovery.go
+++ b/internal/projectmigrate/discovery.go
@@ -175,15 +175,13 @@ func DiscoverCandidateProjects(searchRoots []string, st *state.State) ([]Project
 		foundInRoot := false
 		err = filepath.WalkDir(abs, func(path string, d fs.DirEntry, walkErr error) error {
 			if walkErr != nil {
-				// Skip unreadable paths (e.g. macOS-protected ~/.Trash, ~/Library)
-				// instead of aborting the whole scan.
-				if errors.Is(walkErr, os.ErrPermission) {
-					if d != nil && d.IsDir() {
-						return filepath.SkipDir
-					}
-					return nil
+				if path == abs {
+					return walkErr
 				}
-				return walkErr
+				if d != nil && d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
 			}
 			if d.IsDir() && path != abs && shouldSkipProjectWalkDir(d.Name()) {
 				return filepath.SkipDir
@@ -242,8 +240,11 @@ func pathWithin(path, root string) bool {
 }
 
 func shouldSkipProjectWalkDir(name string) bool {
+	if strings.HasPrefix(name, ".") {
+		return true
+	}
 	switch name {
-	case ".git", ".hg", ".svn", ".anvil", ".Trash", "node_modules", "vendor":
+	case "node_modules", "vendor":
 		return true
 	default:
 		return false

--- a/internal/projectmigrate/discovery_test.go
+++ b/internal/projectmigrate/discovery_test.go
@@ -96,6 +96,60 @@ func TestDiscoverCandidateProjectsIncludesEmptySearchRoot(t *testing.T) {
 	}
 }
 
+func TestDiscoverCandidateProjectsSkipsHiddenDirs(t *testing.T) {
+	root := t.TempDir()
+	visible := filepath.Join(root, "app")
+	hiddenLooksLikeProject := filepath.Join(root, ".cache", "fake-project")
+	mustMkdir(t, visible)
+	mustMkdir(t, hiddenLooksLikeProject)
+	if err := os.WriteFile(filepath.Join(visible, ".scribe.yaml"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hiddenLooksLikeProject, ".scribe.yaml"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projects, err := DiscoverCandidateProjects([]string{root}, nil)
+	if err != nil {
+		t.Fatalf("DiscoverCandidateProjects() error = %v, want nil", err)
+	}
+
+	got := []string{}
+	for _, project := range projects {
+		got = append(got, project.Path)
+	}
+	want := []string{visible}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("projects = %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCandidateProjectsTolerantOfTransientErrors(t *testing.T) {
+	root := t.TempDir()
+	app := filepath.Join(root, "app")
+	weird := filepath.Join(root, "weird")
+	mustMkdir(t, app)
+	mustMkdir(t, weird)
+	if err := os.WriteFile(filepath.Join(app, ".scribe.yaml"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustSymlink(t, filepath.Join(weird, "missing-target"), filepath.Join(weird, "broken"))
+
+	projects, err := DiscoverCandidateProjects([]string{root}, nil)
+	if err != nil {
+		t.Fatalf("DiscoverCandidateProjects() error = %v, want nil", err)
+	}
+
+	got := []string{}
+	for _, project := range projects {
+		got = append(got, project.Path)
+	}
+	want := []string{app}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("projects = %v, want %v", got, want)
+	}
+}
+
 func TestDiscoverCandidateProjectsSkipsUnreadableDirs(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("permission semantics differ on Windows")


### PR DESCRIPTION
## Summary
v1.0.3 fixed `migrate global-to-projects` aborting on `~/.Trash` by adding it to a hardcoded skip list. Same class of problem still bites for any other hidden dir with weird state — verified by a user hitting `open ~/.openclaw/plugin-runtime-deps/.../.openclaw-runtime-mirror.lock: no such file or directory` (ENOENT from a broken runtime mirror symlink).

## Fix
- **Skip all hidden (dot-prefixed) directories** in `shouldSkipProjectWalkDir`. Hidden dirs are tool/runtime state (`.cache`, `.npm`, `.openclaw`, `.Trash`, `.git`, `.anvil`, etc.) and never host scribe projects. One rule replaces the hardcoded enumeration.
- **Tolerate every non-root walk error.** Project discovery is best-effort. Broken symlinks (ENOENT), unreadable subtrees (EACCES), and races with disappearing files now SkipDir for directories or no-op for files. Only an error on the walk root itself still aborts.

## Repro before fix
```
cd ~
scribe migrate global-to-projects
# error[GENERAL]: discover migration candidates: scan project candidates: open /Users/<you>/.openclaw/plugin-runtime-deps/openclaw-2026.4.29-2376bfaa06d2/.openclaw-runtime-mirror.lock: no such file or directory
```

## After fix
```
cd ~
scribe migrate global-to-projects --dry-run
# Dry run: found 238 globally projected skill link(s) for 125 skill(s) ...
```

## Test plan
- [x] `go test ./internal/projectmigrate/...` — new `TestDiscoverCandidateProjectsSkipsHiddenDirs` and `TestDiscoverCandidateProjectsTolerantOfTransientErrors` pass alongside the existing unreadable-dir test
- [x] `go test ./...` — full suite green
- [x] Manual: rebuilt binary, ran `scribe migrate global-to-projects --dry-run` from `~`, scan completed instead of aborting

🤖 Generated with [Claude Code](https://claude.com/claude-code)