### PR TITLE
chore(migrate): drop stale Trash comment in test

### DIFF
--- a/internal/projectmigrate/discovery_test.go
+++ b/internal/projectmigrate/discovery_test.go
@@ -166,7 +166,6 @@ func TestDiscoverCandidateProjectsSkipsUnreadableDirs(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(app, ".scribe.yaml"), []byte(""), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// Simulate a macOS-style protected dir (e.g. ~/.Trash).
 	if err := os.Chmod(locked, 0o000); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
The chmod-0 directory test was originally written as a stand-in for `~/.Trash` in v1.0.3. v1.0.4 generalized the skip rule to drop all hidden dirs, so `~/.Trash` is now filtered before reaching this code path. The comment became misleading.

The test itself still has value — it exercises EACCES tolerance for unreadable *non-hidden* subtrees, which the walk callback still handles. Just removing the stale comment.

## Test plan
- [x] `go test ./internal/projectmigrate/...` — all green
- [x] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)