### PR TITLE
fix(migrate): contract change, --undo, budget preflight, dry-run verbosity (v1.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## Unreleased
 
+## v1.0.5 — 2026-05-02
+
+### Breaking
+
+- **`scribe migrate global-to-projects` now refuses without `--project`** — bare non-interactive migration no longer auto-selects every discovered project when global symlinks exist. Pass one or more `--project <path>` values, or select projects interactively.
+
+### Added
+
+- **Migration recovery snapshots and `--undo`** — successful migrations persist pre-apply JSON snapshots in `~/.scribe/migration-history/`, retain the latest 10, and support latest-only `scribe migrate global-to-projects --undo`.
+- **Non-interactive confirmation controls** — `--yes` skips destructive confirmation prompts, and `--force` allows migration when budget preflight would otherwise refuse.
+- **Budget-aware migration plans** — migration simulates each target project's post-migration skill set, refuses over-budget writes unless `--force` is passed, and prints per-agent budget status in dry-run output.
+- **Doctor signal for migration budget overflow** — `scribe doctor` warns when migration-derived project projections exceed an agent budget even though sync preserves them for compatibility.
+- **JSON output schema** — `scribe migrate global-to-projects` now registers an output schema for automation via `scribe schema migrate global-to-projects --json`.
+
+### Fixed
+
+- **Legacy projection state is cleaned up during migration** — migrated skills no longer keep empty-project legacy projection entries after global symlink removal.
+- **Project-scoped migration projections are recorded immediately** — migrated projects get state entries tagged as migration-derived, preventing the legacy global projection banner from firing again after a clean migration.
+
 ## v1.0.4 — 2026-05-02
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe init` | --force, --json | yes |
 | `scribe install` | --alias, --all, --force, --json, --registry | no |
 | `scribe list` | --fields, --json, --registry, --remote | yes |
-| `scribe migrate global-to-projects` | --dry-run, --json, --project | no |
+| `scribe migrate global-to-projects` | --dry-run, --force, --json, --project, --undo, --yes | yes |
 | `scribe migrate` | --json | no |
 | `scribe push` | --json | yes |
 | `scribe registry add` | --install, --json, --registry, --yes | no |

--- a/cmd/migrate_global.go
+++ b/cmd/migrate_global.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"charm.land/huh/v2"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
+	"github.com/Naoray/scribe/internal/budget"
 	"github.com/Naoray/scribe/internal/cli/envelope"
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/projectmigrate"
@@ -198,9 +200,10 @@ func printGlobalToProjectsResult(cmd *cobra.Command, result projectmigrate.Migra
 		for _, change := range result.ProjectFiles {
 			action := "unchanged"
 			if change.Changed {
-				action = "update"
+				action = "write"
 			}
-			fmt.Fprintf(out, "  %s %s (%d skill%s)\n", action, change.Project, len(change.Skills), plural(len(change.Skills)))
+			fmt.Fprintf(out, "  %s %s (%d skill%s, %d added)\n", action, change.File, len(change.Skills), plural(len(change.Skills)), len(change.AddedSkills))
+			printBudgetLines(out, change.BudgetPerAgent)
 		}
 	}
 	linkRemovals := result.RemovedGlobalLinks
@@ -208,9 +211,57 @@ func printGlobalToProjectsResult(cmd *cobra.Command, result projectmigrate.Migra
 		linkRemovals = result.PlannedGlobalLinkRemovals
 	}
 	fmt.Fprintf(out, "%sremoved %d global symlink(s)\n", prefix, linkRemovals)
+	links := result.RemovedLinks
+	if result.DryRun {
+		links = result.RemovedLinks
+	}
+	sample := links
+	if len(sample) > 5 {
+		sample = sample[:5]
+	}
+	for _, link := range sample {
+		fmt.Fprintf(out, "    - %s → %s\n", link.Path, link.CanonicalPath)
+	}
+	if len(links) > 5 {
+		fmt.Fprintf(out, "    ... and %d more\n", len(links)-5)
+	}
 	if result.SkippedGlobalLinks > 0 {
 		fmt.Fprintf(out, "skipped %d global path(s) that were already gone or no longer symlinks\n", result.SkippedGlobalLinks)
 	}
+}
+
+func printBudgetLines(out interface{ Write([]byte) (int, error) }, results map[string]budget.Result) {
+	agents := make([]string, 0, len(results))
+	for agent := range results {
+		agents = append(agents, agent)
+	}
+	sort.Strings(agents)
+	for _, agent := range agents {
+		result := results[agent]
+		if result.Limit <= 0 {
+			continue
+		}
+		status := "PASS"
+		if result.Status == budget.StatusRefuse {
+			status = "REFUSE"
+		}
+		fmt.Fprintf(out, "  budget: %s %s %s / %s", agent, status, formatBudgetAmount(result.Used), formatBudgetAmount(result.Limit))
+		if result.Status == budget.StatusRefuse {
+			fmt.Fprintf(out, " (+%s)", formatBudgetAmount(result.Used-result.Limit))
+		}
+		fmt.Fprintln(out)
+	}
+}
+
+func formatBudgetAmount(bytes int) string {
+	if bytes < 1024 {
+		return fmt.Sprintf("%dB", bytes)
+	}
+	value := float64(bytes) / 1024
+	if value == float64(int(value)) {
+		return fmt.Sprintf("%dKB", int(value))
+	}
+	return fmt.Sprintf("%.1fKB", value)
 }
 
 func plural(n int) string {

--- a/cmd/migrate_global.go
+++ b/cmd/migrate_global.go
@@ -35,6 +35,7 @@ files for those projects, and remove the global symlinks.`,
 		RunE: runGlobalToProjects,
 	}
 	cmd.Flags().Bool("dry-run", false, "Preview migration without writing .scribe.yaml or removing global symlinks")
+	cmd.Flags().Bool("force", false, "Allow migration even if a project exceeds an agent skill budget")
 	cmd.Flags().Bool("undo", false, "Restore the latest global-to-projects migration snapshot")
 	cmd.Flags().Bool("yes", false, "Skip confirmation prompts")
 	cmd.Flags().StringArray("project", nil, "Project directory to keep the current global skill set (repeatable; skips prompt)")
@@ -47,6 +48,7 @@ func runGlobalToProjects(cmd *cobra.Command, args []string) error {
 
 func runGlobalToProjectsWithSelector(cmd *cobra.Command, _ []string, selector projectSelector) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	forceBudget, _ := cmd.Flags().GetBool("force")
 	undo, _ := cmd.Flags().GetBool("undo")
 	yes, _ := cmd.Flags().GetBool("yes")
 	jsonFlag := jsonFlagPassed(cmd)
@@ -133,7 +135,7 @@ func runGlobalToProjectsWithSelector(cmd *cobra.Command, _ []string, selector pr
 		}
 	}
 
-	plan, err := projectmigrate.BuildPlan(discovery, selected, dryRun)
+	plan, err := projectmigrate.BuildPlan(discovery, selected, dryRun, forceBudget)
 	if err != nil {
 		return err
 	}

--- a/cmd/migrate_global.go
+++ b/cmd/migrate_global.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Naoray/scribe/internal/cli/envelope"
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/projectmigrate"
 	"github.com/Naoray/scribe/internal/tools"
 )
@@ -34,6 +35,7 @@ files for those projects, and remove the global symlinks.`,
 		RunE: runGlobalToProjects,
 	}
 	cmd.Flags().Bool("dry-run", false, "Preview migration without writing .scribe.yaml or removing global symlinks")
+	cmd.Flags().Bool("yes", false, "Skip confirmation prompts")
 	cmd.Flags().StringArray("project", nil, "Project directory to keep the current global skill set (repeatable; skips prompt)")
 	return markJSONSupported(cmd)
 }
@@ -44,6 +46,7 @@ func runGlobalToProjects(cmd *cobra.Command, args []string) error {
 
 func runGlobalToProjectsWithSelector(cmd *cobra.Command, _ []string, selector projectSelector) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	yes, _ := cmd.Flags().GetBool("yes")
 	jsonFlag := jsonFlagPassed(cmd)
 	projectFlags, _ := cmd.Flags().GetStringArray("project")
 
@@ -83,11 +86,26 @@ func runGlobalToProjectsWithSelector(cmd *cobra.Command, _ []string, selector pr
 			return err
 		}
 	}
-	if len(selected) == 0 && (jsonFlag || dryRun) {
-		selected = projectPaths(discovery.Projects)
-	}
 	if len(selected) == 0 && len(discovery.GlobalSymlinks) > 0 {
-		return fmt.Errorf("no projects selected")
+		return clierrors.Wrap(
+			fmt.Errorf("must pass --project <path>; refusing to remove global symlinks"),
+			"USAGE",
+			clierrors.ExitUsage,
+			clierrors.WithRemediation("scribe migrate global-to-projects --project <path> --dry-run"),
+		)
+	}
+	if !dryRun && !jsonFlag && !yes && len(projectFlags) > 0 && globalToProjectsIsTerminal() {
+		var confirm bool
+		err := huh.NewConfirm().
+			Title("Remove legacy global symlinks and write selected project .scribe.yaml files?").
+			Value(&confirm).
+			Run()
+		if err != nil {
+			return err
+		}
+		if !confirm {
+			return clierrors.Wrap(fmt.Errorf("migration canceled"), "CANCELED", clierrors.ExitCanceled)
+		}
 	}
 
 	plan, err := projectmigrate.BuildPlan(discovery, selected, dryRun)

--- a/cmd/migrate_global.go
+++ b/cmd/migrate_global.go
@@ -35,6 +35,7 @@ files for those projects, and remove the global symlinks.`,
 		RunE: runGlobalToProjects,
 	}
 	cmd.Flags().Bool("dry-run", false, "Preview migration without writing .scribe.yaml or removing global symlinks")
+	cmd.Flags().Bool("undo", false, "Restore the latest global-to-projects migration snapshot")
 	cmd.Flags().Bool("yes", false, "Skip confirmation prompts")
 	cmd.Flags().StringArray("project", nil, "Project directory to keep the current global skill set (repeatable; skips prompt)")
 	return markJSONSupported(cmd)
@@ -46,9 +47,33 @@ func runGlobalToProjects(cmd *cobra.Command, args []string) error {
 
 func runGlobalToProjectsWithSelector(cmd *cobra.Command, _ []string, selector projectSelector) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	undo, _ := cmd.Flags().GetBool("undo")
 	yes, _ := cmd.Flags().GetBool("yes")
 	jsonFlag := jsonFlagPassed(cmd)
 	projectFlags, _ := cmd.Flags().GetStringArray("project")
+
+	if undo {
+		if dryRun || len(projectFlags) > 0 {
+			return clierrors.Wrap(fmt.Errorf("--undo cannot be combined with --project or --dry-run"), "USAGE_FLAG_CONFLICT", clierrors.ExitUsage)
+		}
+		path, err := projectmigrate.LatestSnapshotPath()
+		if err != nil {
+			return err
+		}
+		snapshot, err := projectmigrate.LoadSnapshot(path)
+		if err != nil {
+			return err
+		}
+		result, err := projectmigrate.Undo(snapshot, path)
+		if err != nil {
+			return err
+		}
+		if jsonFlag {
+			return renderMutatorEnvelope(cmd, result, envelope.StatusOK)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "restored %d global symlink(s)\n", result.RestoredLinks)
+		return nil
+	}
 
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/cmd/migrate_global.go
+++ b/cmd/migrate_global.go
@@ -31,8 +31,20 @@ func newGlobalToProjectsCommand() *cobra.Command {
 		Use:   "global-to-projects",
 		Short: "Move legacy global skill links into project .scribe.yaml files",
 		Long: `Detect Scribe-managed symlinks in legacy global tool skill directories,
-let the user choose projects that should keep that skill set, write .scribe.yaml
-files for those projects, and remove the global symlinks.`,
+write .scribe.yaml files for explicitly selected projects, and remove the
+global symlinks.
+
+This command refuses to remove global symlinks unless at least one --project
+path is passed or selected interactively. Run --dry-run first to inspect the
+project files, symlink removals, and budget status. Successful migrations write
+a JSON snapshot to ~/.scribe/migration-history/ for latest-only --undo.
+
+Do not run multiple global-to-projects migrations concurrently.
+
+Examples:
+  scribe migrate global-to-projects --project . --dry-run
+  scribe migrate global-to-projects --project . --yes
+  scribe migrate global-to-projects --undo`,
 		Args: cobra.NoArgs,
 		RunE: runGlobalToProjects,
 	}

--- a/cmd/migrate_global_schema.go
+++ b/cmd/migrate_global_schema.go
@@ -1,0 +1,80 @@
+package cmd
+
+import clischema "github.com/Naoray/scribe/internal/cli/schema"
+
+var migrateGlobalToProjectsOutputSchema = `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["dry_run", "found_global_links", "found_skills", "selected_projects", "planned_project_file_writes", "planned_global_link_removals", "wrote_project_files", "removed_global_links", "skipped_global_links", "project_files", "removed_links", "candidate_projects"],
+  "properties": {
+    "dry_run": {"type": "boolean"},
+    "found_global_links": {"type": "integer"},
+    "found_skills": {"type": "integer"},
+    "selected_projects": {"type": "integer"},
+    "planned_project_file_writes": {"type": "integer"},
+    "planned_global_link_removals": {"type": "integer"},
+    "wrote_project_files": {"type": "integer"},
+    "removed_global_links": {"type": "integer"},
+    "skipped_global_links": {"type": "integer"},
+    "project_files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["project", "file", "added_skills", "skills", "changed"],
+        "properties": {
+          "project": {"type": "string"},
+          "file": {"type": "string"},
+          "added_skills": {"type": "array", "items": {"type": "string"}},
+          "skills": {"type": "array", "items": {"type": "string"}},
+          "changed": {"type": "boolean"},
+          "budget_per_agent": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "removed_links": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/global_link"}
+    },
+    "skipped_links": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/global_link"}
+    },
+    "candidate_projects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "source"],
+        "properties": {
+          "path": {"type": "string"},
+          "source": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "global_link": {
+      "type": "object",
+      "required": ["tool", "skill", "path", "canonical_path"],
+      "properties": {
+        "tool": {"type": "string"},
+        "skill": {"type": "string"},
+        "path": {"type": "string"},
+        "canonical_path": {"type": "string"}
+      },
+      "additionalProperties": false
+    }
+  }
+}`
+
+func init() {
+	clischema.Register("scribe migrate global-to-projects", migrateGlobalToProjectsOutputSchema)
+}

--- a/cmd/migrate_global_test.go
+++ b/cmd/migrate_global_test.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/projectmigrate"
 )
@@ -61,6 +63,89 @@ func TestGlobalToProjectsJSONDryRunDoesNotMutateHome(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(project, projectfile.Filename)); !os.IsNotExist(err) {
 		t.Fatalf(".scribe.yaml should not exist after dry-run, stat err = %v", err)
+	}
+}
+
+func TestGlobalToProjects_RefusesWithoutProject(t *testing.T) {
+	home, project, link := setupGlobalToProjectsFixture(t, "claude", "tdd")
+	t.Setenv("HOME", home)
+	t.Chdir(project)
+
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"migrate", "global-to-projects"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatalf("Execute() error = nil, want refusal\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+	if got := clierrors.ExitCode(err); got != clierrors.ExitUsage {
+		t.Fatalf("exit code = %d, want %d; err=%v", got, clierrors.ExitUsage, err)
+	}
+	if !strings.Contains(err.Error(), "must pass --project <path>; refusing to remove global symlinks") {
+		t.Fatalf("error = %q, want project refusal", err.Error())
+	}
+	if _, err := os.Lstat(link); err != nil {
+		t.Fatalf("global symlink should remain after refusal: %v", err)
+	}
+}
+
+func TestGlobalToProjects_DryRunRefusesWithoutProject(t *testing.T) {
+	home, project, link := setupGlobalToProjectsFixture(t, "claude", "tdd")
+	t.Setenv("HOME", home)
+	t.Chdir(project)
+
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"--json", "migrate", "global-to-projects", "--dry-run"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatalf("Execute() error = nil, want refusal\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+	if got := clierrors.ExitCode(err); got != clierrors.ExitUsage {
+		t.Fatalf("exit code = %d, want %d; err=%v", got, clierrors.ExitUsage, err)
+	}
+	if !strings.Contains(err.Error(), "must pass --project <path>; refusing to remove global symlinks") {
+		t.Fatalf("error = %q, want project refusal", err.Error())
+	}
+	if _, err := os.Lstat(link); err != nil {
+		t.Fatalf("global symlink should remain after refusal: %v", err)
+	}
+}
+
+func TestGlobalToProjects_NoLinksSucceedsSilent(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	project := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Chdir(project)
+
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"--json", "migrate", "global-to-projects"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	var env struct {
+		Status string `json:"status"`
+		Data   struct {
+			FoundGlobalLinks int `json:"found_global_links"`
+			SelectedProjects int `json:"selected_projects"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal stdout: %v\n%s", err, stdout.String())
+	}
+	if env.Status != "no_change" || env.Data.FoundGlobalLinks != 0 || env.Data.SelectedProjects != 0 {
+		t.Fatalf("env = %#v, want silent no_change", env)
 	}
 }
 

--- a/cmd/migrate_global_test.go
+++ b/cmd/migrate_global_test.go
@@ -178,6 +178,53 @@ func TestGlobalToProjectsInteractiveSelectorAppliesMigration(t *testing.T) {
 	}
 }
 
+func TestGlobalToProjects_UndoFlag(t *testing.T) {
+	home, project, link := setupGlobalToProjectsFixture(t, "claude", "tdd")
+	t.Setenv("HOME", home)
+	t.Chdir(project)
+
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"migrate", "global-to-projects", "--project", project})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("migrate Execute() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatalf("global symlink should be removed after migrate, stat err = %v", err)
+	}
+
+	root = newRootCmd()
+	stdout.Reset()
+	stderr.Reset()
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"--json", "migrate", "global-to-projects", "--undo"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("undo Execute() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	var env struct {
+		Status string `json:"status"`
+		Data   struct {
+			RestoredLinks int    `json:"restored_links"`
+			Snapshot      string `json:"snapshot"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal stdout: %v\n%s", err, stdout.String())
+	}
+	if env.Status != "ok" || env.Data.RestoredLinks != 1 || env.Data.Snapshot == "" {
+		t.Fatalf("env = %#v, want undo result", env)
+	}
+	if _, err := os.Lstat(link); err != nil {
+		t.Fatalf("global symlink should be restored after undo: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(project, projectfile.Filename)); !os.IsNotExist(err) {
+		t.Fatalf(".scribe.yaml should be deleted after undo, stat err = %v", err)
+	}
+}
+
 func setupGlobalToProjectsFixture(t *testing.T, tool, skill string) (home, project, link string) {
 	t.Helper()
 	tmp := t.TempDir()

--- a/cmd/migrate_global_test.go
+++ b/cmd/migrate_global_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Naoray/scribe/internal/budget"
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/projectmigrate"
@@ -222,6 +223,74 @@ func TestGlobalToProjects_UndoFlag(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(project, projectfile.Filename)); !os.IsNotExist(err) {
 		t.Fatalf(".scribe.yaml should be deleted after undo, stat err = %v", err)
+	}
+}
+
+func TestPrintGlobalToProjectsResult_DryRunShowsPaths(t *testing.T) {
+	cmd := newGlobalToProjectsCommand()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	printGlobalToProjectsResult(cmd, projectmigrate.MigrationResult{
+		DryRun:                    true,
+		FoundGlobalLinks:          6,
+		FoundSkills:               2,
+		PlannedProjectFileWrites:  1,
+		PlannedGlobalLinkRemovals: 6,
+		ProjectFiles: []projectmigrate.ProjectChange{{
+			Project:     "/tmp/project",
+			File:        "/tmp/project/.scribe.yaml",
+			Skills:      []string{"review", "tdd"},
+			AddedSkills: []string{"tdd"},
+			Changed:     true,
+			BudgetPerAgent: map[string]budget.Result{
+				"claude": {Agent: "claude", Limit: 8192, Used: 6348, Status: budget.StatusWarn},
+			},
+		}},
+		RemovedLinks: []projectmigrate.GlobalSymlink{
+			{Path: "/tmp/home/.claude/skills/a", CanonicalPath: "/tmp/home/.scribe/skills/a"},
+			{Path: "/tmp/home/.claude/skills/b", CanonicalPath: "/tmp/home/.scribe/skills/b"},
+			{Path: "/tmp/home/.claude/skills/c", CanonicalPath: "/tmp/home/.scribe/skills/c"},
+			{Path: "/tmp/home/.claude/skills/d", CanonicalPath: "/tmp/home/.scribe/skills/d"},
+			{Path: "/tmp/home/.claude/skills/e", CanonicalPath: "/tmp/home/.scribe/skills/e"},
+			{Path: "/tmp/home/.claude/skills/f", CanonicalPath: "/tmp/home/.scribe/skills/f"},
+		},
+	})
+	out := stdout.String()
+	for _, want := range []string{
+		"  write /tmp/project/.scribe.yaml (2 skills, 1 added)",
+		"  budget: claude PASS 6.2KB / 8KB",
+		"    - /tmp/home/.claude/skills/a → /tmp/home/.scribe/skills/a",
+		"    ... and 1 more",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintGlobalToProjectsResult_OverBudget(t *testing.T) {
+	cmd := newGlobalToProjectsCommand()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	printGlobalToProjectsResult(cmd, projectmigrate.MigrationResult{
+		DryRun:                    true,
+		FoundGlobalLinks:          1,
+		FoundSkills:               1,
+		PlannedProjectFileWrites:  1,
+		PlannedGlobalLinkRemovals: 1,
+		ProjectFiles: []projectmigrate.ProjectChange{{
+			File:        "/tmp/project/.scribe.yaml",
+			Skills:      []string{"oversized"},
+			AddedSkills: []string{"oversized"},
+			Changed:     true,
+			BudgetPerAgent: map[string]budget.Result{
+				"claude": {Agent: "claude", Limit: 8192, Used: 35533, Status: budget.StatusRefuse},
+			},
+		}},
+	})
+	out := stdout.String()
+	if !strings.Contains(out, "  budget: claude REFUSE 34.7KB / 8KB (+26.7KB)") {
+		t.Fatalf("output = %s, want overbudget line", out)
 	}
 }
 

--- a/cmd/migrate_global_test.go
+++ b/cmd/migrate_global_test.go
@@ -331,6 +331,28 @@ func TestPrintGlobalToProjectsResult_OverBudget(t *testing.T) {
 	}
 }
 
+func TestHelpDocumentsContract(t *testing.T) {
+	cmd := newGlobalToProjectsCommand()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"refuses to remove global symlinks unless at least one --project",
+		"~/.scribe/migration-history/",
+		"scribe migrate global-to-projects --project . --dry-run",
+		"scribe migrate global-to-projects --undo",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("help missing %q\n%s", want, out)
+		}
+	}
+}
+
 func setupGlobalToProjectsFixture(t *testing.T, tool, skill string) (home, project, link string) {
 	t.Helper()
 	tmp := t.TempDir()

--- a/cmd/migrate_global_test.go
+++ b/cmd/migrate_global_test.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/Naoray/scribe/internal/budget"
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	clischema "github.com/Naoray/scribe/internal/cli/schema"
 	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/projectmigrate"
+	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
 type fakeProjectSelector struct {
@@ -64,6 +66,41 @@ func TestGlobalToProjectsJSONDryRunDoesNotMutateHome(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(project, projectfile.Filename)); !os.IsNotExist(err) {
 		t.Fatalf(".scribe.yaml should not exist after dry-run, stat err = %v", err)
+	}
+}
+
+func TestGlobalToProjectsSchema_MatchesEnvelope(t *testing.T) {
+	home, project, _ := setupGlobalToProjectsFixture(t, "claude", "tdd")
+	t.Setenv("HOME", home)
+	t.Chdir(project)
+	rawSchema, ok := clischema.Get("scribe migrate global-to-projects")
+	if !ok {
+		t.Fatal("missing migrate global-to-projects output schema")
+	}
+	compiled, err := jsonschema.CompileString("migrate-global-to-projects.schema.json", rawSchema)
+	if err != nil {
+		t.Fatalf("compile schema: %v\n%s", err, rawSchema)
+	}
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"--json", "migrate", "global-to-projects", "--dry-run", "--project", project})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	var env struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal stdout: %v\n%s", err, stdout.String())
+	}
+	var data any
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("unmarshal data: %v\n%s", err, string(env.Data))
+	}
+	if err := compiled.Validate(data); err != nil {
+		t.Fatalf("schema validation: %v\ndata=%s\nschema=%s", err, string(env.Data), rawSchema)
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Naoray/scribe/internal/budget"
 	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/skillmd"
 	"github.com/Naoray/scribe/internal/state"
@@ -18,8 +19,9 @@ import (
 type IssueKind string
 
 const (
-	IssueCanonicalMetadata IssueKind = "canonical_metadata"
-	IssueProjectionDrift   IssueKind = "projection_drift"
+	IssueCanonicalMetadata       IssueKind = "canonical_metadata"
+	IssueMigrationBudgetOverflow IssueKind = "migration_budget_overflow"
+	IssueProjectionDrift         IssueKind = "projection_drift"
 )
 
 type Issue struct {
@@ -64,6 +66,7 @@ func InspectManagedSkills(cfg *config.Config, st *state.State, name string) (Rep
 			issues = append(issues, projectionIssue)
 		}
 	}
+	issues = append(issues, inspectMigrationBudgetOverflow(st, name)...)
 
 	sort.SliceStable(issues, func(i, j int) bool {
 		if issues[i].Skill != issues[j].Skill {
@@ -79,6 +82,70 @@ func InspectManagedSkills(cfg *config.Config, st *state.State, name string) (Rep
 	})
 
 	return Report{Issues: issues}, nil
+}
+
+func inspectMigrationBudgetOverflow(st *state.State, name string) []Issue {
+	type groupKey struct {
+		project string
+		agent   string
+	}
+	groups := map[groupKey][]string{}
+	for skillName, installed := range st.Installed {
+		if name != "" && skillName != name {
+			continue
+		}
+		for _, projection := range installed.Projections {
+			if projection.Source != state.SourceMigration || projection.Project == "" {
+				continue
+			}
+			for _, tool := range projection.Tools {
+				if _, ok := budget.AgentBudgets[tool]; !ok {
+					continue
+				}
+				key := groupKey{project: projection.Project, agent: tool}
+				if !containsString(groups[key], skillName) {
+					groups[key] = append(groups[key], skillName)
+				}
+			}
+		}
+	}
+	var issues []Issue
+	for key, names := range groups {
+		sort.Strings(names)
+		skills := make([]budget.Skill, 0, len(names))
+		for _, skillName := range names {
+			dir, err := storeSkillDir(skillName)
+			if err != nil {
+				continue
+			}
+			content, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+			if err != nil {
+				continue
+			}
+			skills = append(skills, budget.Skill{Name: skillName, Content: content})
+		}
+		result := budget.CheckBudget(skills, key.agent)
+		if result.Status != budget.StatusRefuse {
+			continue
+		}
+		issues = append(issues, Issue{
+			Skill:   key.project,
+			Tool:    key.agent,
+			Kind:    IssueMigrationBudgetOverflow,
+			Status:  "warn",
+			Message: fmt.Sprintf("migration-derived projections exceed %s budget by %d bytes", key.agent, result.Used-result.Limit),
+		})
+	}
+	return issues
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func managedSkillNames(st *state.State, name string) []string {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Naoray/scribe/internal/budget"
 	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/tools"
@@ -517,6 +518,73 @@ description: Keep daily notes and summaries.
 	}
 	if len(report.Issues) != 0 {
 		t.Fatalf("Issues = %d, want 0: %+v", len(report.Issues), report.Issues)
+	}
+}
+
+func TestDoctor_WarnsMigrationBudgetOverflow(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	old := budget.AgentBudgets
+	budget.AgentBudgets = map[string]int{"claude": 20}
+	t.Cleanup(func() { budget.AgentBudgets = old })
+	writeSkill(t, "recap", []byte("---\nname: recap\ndescription: "+strings.Repeat("x", 200)+"\n---\n"))
+	project := filepath.Join(home, "project")
+	st := &state.State{
+		SchemaVersion: 5,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Revision: 1,
+				Projections: []state.ProjectionEntry{{
+					Project: project,
+					Tools:   []string{"claude"},
+					Source:  state.SourceMigration,
+				}},
+			},
+		},
+	}
+	report, err := InspectManagedSkills(nil, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+	for _, issue := range report.Issues {
+		if issue.Kind == IssueMigrationBudgetOverflow && issue.Tool == "claude" && issue.Status == "warn" {
+			return
+		}
+	}
+	t.Fatalf("Issues = %+v, want migration budget overflow", report.Issues)
+}
+
+func TestDoctor_NoNewWarningsAfterMigrate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	old := budget.AgentBudgets
+	budget.AgentBudgets = map[string]int{"claude": 8000}
+	t.Cleanup(func() { budget.AgentBudgets = old })
+	writeSkill(t, "recap", []byte("---\nname: recap\ndescription: small\n---\n"))
+	project := filepath.Join(home, "project")
+	st := &state.State{
+		SchemaVersion: 5,
+		Installed: map[string]state.InstalledSkill{
+			"recap": {
+				Revision: 1,
+				Projections: []state.ProjectionEntry{{
+					Project: project,
+					Tools:   []string{"claude"},
+					Source:  state.SourceMigration,
+				}},
+			},
+		},
+	}
+	report, err := InspectManagedSkills(nil, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+	for _, issue := range report.Issues {
+		if issue.Kind == IssueMigrationBudgetOverflow {
+			t.Fatalf("unexpected migration budget issue: %+v", issue)
+		}
 	}
 }
 

--- a/internal/projectmigrate/budget.go
+++ b/internal/projectmigrate/budget.go
@@ -1,0 +1,40 @@
+package projectmigrate
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/Naoray/scribe/internal/budget"
+)
+
+func BudgetForProjectChange(change ProjectChange, links []GlobalSymlink) (map[string]budget.Result, error) {
+	pathBySkill := map[string]string{}
+	for _, link := range links {
+		if _, ok := pathBySkill[link.Skill]; !ok {
+			pathBySkill[link.Skill] = link.CanonicalPath
+		}
+	}
+	skills := make([]budget.Skill, 0, len(change.Skills))
+	for _, name := range change.Skills {
+		dir, ok := pathBySkill[name]
+		if !ok {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+		if err != nil {
+			continue
+		}
+		skills = append(skills, budget.Skill{Name: name, Content: content})
+	}
+	agents := make([]string, 0, len(budget.AgentBudgets))
+	for agent := range budget.AgentBudgets {
+		agents = append(agents, agent)
+	}
+	sort.Strings(agents)
+	results := make(map[string]budget.Result, len(agents))
+	for _, agent := range agents {
+		results[agent] = budget.CheckBudget(skills, agent)
+	}
+	return results, nil
+}

--- a/internal/projectmigrate/budget.go
+++ b/internal/projectmigrate/budget.go
@@ -1,28 +1,32 @@
 package projectmigrate
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 
 	"github.com/Naoray/scribe/internal/budget"
+	"github.com/Naoray/scribe/internal/paths"
 )
 
 func BudgetForProjectChange(change ProjectChange, links []GlobalSymlink) (map[string]budget.Result, error) {
+	storeDir, err := paths.StoreDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve store dir: %w", err)
+	}
 	pathBySkill := map[string]string{}
 	for _, link := range links {
 		if _, ok := pathBySkill[link.Skill]; !ok {
 			pathBySkill[link.Skill] = link.CanonicalPath
 		}
 	}
-	skills := make([]budget.Skill, 0, len(change.Skills))
-	for _, name := range change.Skills {
-		dir, ok := pathBySkill[name]
+	names := append([]string(nil), change.Skills...)
+	sort.Strings(names)
+	skills := make([]budget.Skill, 0, len(names))
+	for _, name := range names {
+		content, ok := readBudgetSkillContent(name, pathBySkill[name], storeDir)
 		if !ok {
-			continue
-		}
-		content, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
-		if err != nil {
 			continue
 		}
 		skills = append(skills, budget.Skill{Name: name, Content: content})
@@ -37,4 +41,19 @@ func BudgetForProjectChange(change ProjectChange, links []GlobalSymlink) (map[st
 		results[agent] = budget.CheckBudget(skills, agent)
 	}
 	return results, nil
+}
+
+func readBudgetSkillContent(name, linkedDir, storeDir string) ([]byte, bool) {
+	dirs := []string{}
+	if linkedDir != "" {
+		dirs = append(dirs, linkedDir)
+	}
+	dirs = append(dirs, filepath.Join(storeDir, name))
+	for _, dir := range dirs {
+		content, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+		if err == nil {
+			return content, true
+		}
+	}
+	return nil, false
 }

--- a/internal/projectmigrate/migrate.go
+++ b/internal/projectmigrate/migrate.go
@@ -177,7 +177,7 @@ func recordMigrationProjections(plan MigrationPlan) error {
 	if err != nil {
 		return err
 	}
-	if !applyMigrationProjections(st, plan, false) {
+	if !applyMigrationProjections(st, plan, true) {
 		return nil
 	}
 	return st.Save()

--- a/internal/projectmigrate/migrate.go
+++ b/internal/projectmigrate/migrate.go
@@ -96,11 +96,28 @@ func Apply(plan MigrationPlan, candidates []ProjectCandidate) (MigrationResult, 
 		return result, nil
 	}
 
+	snapshot := ""
+	if len(plan.GlobalLinks) > 0 || len(plan.ProjectFiles) > 0 {
+		captured, err := captureSnapshot(Discovery{
+			GlobalSymlinks: append([]GlobalSymlink(nil), plan.GlobalLinks...),
+			Projects:       append([]ProjectCandidate(nil), candidates...),
+			Skills:         uniqueSkills(plan.GlobalLinks),
+		}, plan)
+		if err != nil {
+			return result, err
+		}
+		snapshot, err = WriteSnapshot(captured)
+		if err != nil {
+			return result, err
+		}
+	}
+
 	for _, change := range plan.ProjectFiles {
 		if !change.Changed {
 			continue
 		}
 		if err := writeProjectChange(change); err != nil {
+			deleteSnapshot(snapshot)
 			return result, err
 		}
 		result.WroteProjectFiles++
@@ -109,6 +126,7 @@ func Apply(plan MigrationPlan, candidates []ProjectCandidate) (MigrationResult, 
 	for _, link := range plan.RemovedLinks {
 		removed, err := removeGlobalSymlink(link)
 		if err != nil {
+			deleteSnapshot(snapshot)
 			return result, err
 		}
 		if removed {
@@ -121,6 +139,13 @@ func Apply(plan MigrationPlan, candidates []ProjectCandidate) (MigrationResult, 
 	}
 
 	return result, nil
+}
+
+func deleteSnapshot(path string) {
+	if path == "" {
+		return
+	}
+	_ = os.Remove(path)
 }
 
 func prepareProjectChange(project string, skills []string) (ProjectChange, error) {

--- a/internal/projectmigrate/migrate.go
+++ b/internal/projectmigrate/migrate.go
@@ -8,16 +8,19 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/Naoray/scribe/internal/budget"
 	"github.com/Naoray/scribe/internal/projectfile"
+	"github.com/Naoray/scribe/internal/state"
 )
 
 // ProjectChange describes the .scribe.yaml update for one selected project.
 type ProjectChange struct {
-	Project     string   `json:"project"`
-	File        string   `json:"file"`
-	AddedSkills []string `json:"added_skills"`
-	Skills      []string `json:"skills"`
-	Changed     bool     `json:"changed"`
+	Project        string                   `json:"project"`
+	File           string                   `json:"file"`
+	AddedSkills    []string                 `json:"added_skills"`
+	Skills         []string                 `json:"skills"`
+	Changed        bool                     `json:"changed"`
+	BudgetPerAgent map[string]budget.Result `json:"budget_per_agent,omitempty"`
 }
 
 // MigrationPlan is the complete set of writes/removals for the migration.
@@ -48,11 +51,12 @@ type MigrationResult struct {
 }
 
 // BuildPlan creates an idempotent migration plan for selected projects.
-func BuildPlan(discovery Discovery, selectedProjects []string, dryRun bool) (MigrationPlan, error) {
+func BuildPlan(discovery Discovery, selectedProjects []string, dryRun bool, force ...bool) (MigrationPlan, error) {
 	skills := discovery.Skills
 	if len(skills) == 0 {
 		return MigrationPlan{DryRun: dryRun, GlobalLinks: discovery.GlobalSymlinks}, nil
 	}
+	forceBudget := len(force) > 0 && force[0]
 
 	selected := normalizeSelectedProjects(selectedProjects)
 	projectFiles := make([]ProjectChange, 0, len(selected))
@@ -60,6 +64,18 @@ func BuildPlan(discovery Discovery, selectedProjects []string, dryRun bool) (Mig
 		change, err := prepareProjectChange(project, skills)
 		if err != nil {
 			return MigrationPlan{}, err
+		}
+		budgetPerAgent, err := BudgetForProjectChange(change, discovery.GlobalSymlinks)
+		if err != nil {
+			return MigrationPlan{}, err
+		}
+		change.BudgetPerAgent = budgetPerAgent
+		if !dryRun && !forceBudget {
+			for agent, result := range budgetPerAgent {
+				if result.Status == budget.StatusRefuse {
+					return MigrationPlan{}, fmt.Errorf("project %s exceeds %s budget by %d bytes; pass --force to proceed", change.Project, agent, result.Used-result.Limit)
+				}
+			}
 		}
 		projectFiles = append(projectFiles, change)
 	}
@@ -138,6 +154,11 @@ func Apply(plan MigrationPlan, candidates []ProjectCandidate) (MigrationResult, 
 		}
 	}
 
+	if err := recordMigrationProjections(plan); err != nil {
+		deleteSnapshot(snapshot)
+		return result, err
+	}
+
 	return result, nil
 }
 
@@ -146,6 +167,85 @@ func deleteSnapshot(path string) {
 		return
 	}
 	_ = os.Remove(path)
+}
+
+func recordMigrationProjections(plan MigrationPlan) error {
+	if len(plan.ProjectFiles) == 0 || len(plan.GlobalLinks) == 0 {
+		return nil
+	}
+	st, err := state.Load()
+	if err != nil {
+		return err
+	}
+	if !applyMigrationProjections(st, plan, false) {
+		return nil
+	}
+	return st.Save()
+}
+
+func applyMigrationProjections(st *state.State, plan MigrationPlan, clearLegacy bool) bool {
+	changed := false
+	toolsBySkill := toolsBySkill(plan.GlobalLinks)
+	for skill, tools := range toolsBySkill {
+		installed, ok := st.Installed[skill]
+		if !ok {
+			continue
+		}
+		if clearLegacy {
+			installed.Projections = removeLegacyProjectionTools(installed.Projections, tools)
+		}
+		for _, change := range plan.ProjectFiles {
+			installed.Projections = mergeMigrationProjection(installed.Projections, change.Project, tools)
+		}
+		st.Installed[skill] = installed
+		changed = true
+	}
+	return changed
+}
+
+func toolsBySkill(links []GlobalSymlink) map[string][]string {
+	bySkill := map[string][]string{}
+	for _, link := range links {
+		if !containsString(bySkill[link.Skill], link.Tool) {
+			bySkill[link.Skill] = append(bySkill[link.Skill], link.Tool)
+		}
+	}
+	for skill := range bySkill {
+		sort.Strings(bySkill[skill])
+	}
+	return bySkill
+}
+
+func mergeMigrationProjection(projections []state.ProjectionEntry, project string, tools []string) []state.ProjectionEntry {
+	next := state.ProjectionEntry{
+		Project: project,
+		Tools:   append([]string(nil), tools...),
+		Source:  state.SourceMigration,
+	}
+	for i, projection := range projections {
+		if projection.Project == project {
+			projections[i] = next
+			return projections
+		}
+	}
+	return append(projections, next)
+}
+
+func removeLegacyProjectionTools(projections []state.ProjectionEntry, tools []string) []state.ProjectionEntry {
+	out := projections[:0]
+	for _, projection := range projections {
+		if projection.Project != "" {
+			out = append(out, projection)
+			continue
+		}
+		remaining := removeStrings(projection.Tools, tools)
+		if len(remaining) == 0 {
+			continue
+		}
+		projection.Tools = remaining
+		out = append(out, projection)
+	}
+	return out
 }
 
 func prepareProjectChange(project string, skills []string) (ProjectChange, error) {
@@ -276,4 +376,27 @@ func sameStrings(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func removeStrings(values []string, remove []string) []string {
+	removeSet := map[string]bool{}
+	for _, value := range remove {
+		removeSet[value] = true
+	}
+	out := values[:0]
+	for _, value := range values {
+		if !removeSet[value] {
+			out = append(out, value)
+		}
+	}
+	return out
 }

--- a/internal/projectmigrate/migrate_test.go
+++ b/internal/projectmigrate/migrate_test.go
@@ -241,6 +241,76 @@ func TestApply_SetsMigrationSource(t *testing.T) {
 	}
 }
 
+func TestApply_ClearsLegacyGlobalProjections(t *testing.T) {
+	home, project, link := setupBudgetMigrationFixture(t, "claude", "tdd", 10)
+	t.Setenv("HOME", home)
+	st := &state.State{
+		SchemaVersion: 5,
+		Installed: map[string]state.InstalledSkill{
+			"tdd": {Projections: []state.ProjectionEntry{{Project: "", Tools: []string{"claude"}}}},
+		},
+		Kits:               map[string]state.InstalledKit{},
+		Snippets:           map[string]state.InstalledSnippet{},
+		Migrations:         map[string]bool{},
+		RegistryFailures:   map[string]state.RegistryFailure{},
+		BinaryUpdateChecks: map[string]state.BinaryUpdateCheck{},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatal(err)
+	}
+	discovery := undoDiscovery(home, project, link, "claude", "tdd")
+	plan, err := BuildPlan(discovery, []string{project}, false)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	if _, err := Apply(plan, discovery.Projects); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, projection := range loaded.Installed["tdd"].Projections {
+		if projection.Project == "" {
+			t.Fatalf("legacy projection still present: %#v", loaded.Installed["tdd"].Projections)
+		}
+	}
+}
+
+func TestApply_RecordsProjectScopedProjections(t *testing.T) {
+	home, project, link := setupBudgetMigrationFixture(t, "codex", "review", 10)
+	t.Setenv("HOME", home)
+	st := &state.State{
+		SchemaVersion: 5,
+		Installed: map[string]state.InstalledSkill{
+			"review": {Projections: []state.ProjectionEntry{{Project: "", Tools: []string{"codex"}}}},
+		},
+		Kits:               map[string]state.InstalledKit{},
+		Snippets:           map[string]state.InstalledSnippet{},
+		Migrations:         map[string]bool{},
+		RegistryFailures:   map[string]state.RegistryFailure{},
+		BinaryUpdateChecks: map[string]state.BinaryUpdateCheck{},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatal(err)
+	}
+	discovery := undoDiscovery(home, project, link, "codex", "review")
+	plan, err := BuildPlan(discovery, []string{project}, false)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	if _, err := Apply(plan, discovery.Projects); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(loaded.Installed["review"].Projections, []state.ProjectionEntry{{Project: project, Tools: []string{"codex"}, Source: state.SourceMigration}}) {
+		t.Fatalf("projections = %#v, want project migration projection", loaded.Installed["review"].Projections)
+	}
+}
+
 func setupBudgetMigrationFixture(t *testing.T, tool, skill string, descriptionBytes int) (home, project, link string) {
 	t.Helper()
 	home = t.TempDir()

--- a/internal/projectmigrate/migrate_test.go
+++ b/internal/projectmigrate/migrate_test.go
@@ -201,6 +201,34 @@ func TestBuildPlan_FailsBudget_PassesWithForce(t *testing.T) {
 	}
 }
 
+func TestBuildPlan_BudgetIncludesExistingProjectSkills(t *testing.T) {
+	home, project, link := setupBudgetMigrationFixture(t, "claude", "migrated", 10)
+	t.Setenv("HOME", home)
+	existing := filepath.Join(home, ".scribe", "skills", "existing")
+	mustMkdir(t, existing)
+	if err := os.WriteFile(filepath.Join(existing, "SKILL.md"), []byte("---\nname: existing\ndescription: "+strings.Repeat("x", 20)+"\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, projectfile.Filename), []byte("add:\n  - existing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := budget.AgentBudgets
+	budget.AgentBudgets = map[string]int{"claude": 25}
+	t.Cleanup(func() { budget.AgentBudgets = old })
+	discovery := undoDiscovery(home, project, link, "claude", "migrated")
+	_, err := BuildPlan(discovery, []string{project}, false)
+	if err == nil {
+		t.Fatal("BuildPlan() error = nil, want budget refusal")
+	}
+	plan, err := BuildPlan(discovery, []string{project}, false, true)
+	if err != nil {
+		t.Fatalf("BuildPlan() with force error = %v", err)
+	}
+	if got := plan.ProjectFiles[0].BudgetPerAgent["claude"].Status; got != budget.StatusRefuse {
+		t.Fatalf("budget status = %s, want refuse", got)
+	}
+}
+
 func TestApply_SetsMigrationSource(t *testing.T) {
 	home, project, link := setupBudgetMigrationFixture(t, "claude", "tdd", 10)
 	t.Setenv("HOME", home)

--- a/internal/projectmigrate/migrate_test.go
+++ b/internal/projectmigrate/migrate_test.go
@@ -4,9 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/Naoray/scribe/internal/budget"
 	"github.com/Naoray/scribe/internal/projectfile"
+	"github.com/Naoray/scribe/internal/state"
 )
 
 func TestApplyWritesProjectFileRemovesGlobalSymlinksAndIsIdempotent(t *testing.T) {
@@ -164,4 +167,97 @@ func TestApplyDryRunDoesNotMutateFilesystem(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(project, projectfile.Filename)); !os.IsNotExist(err) {
 		t.Fatalf(".scribe.yaml should not exist after dry-run, stat err = %v", err)
 	}
+}
+
+func TestBuildPlan_FailsBudget_NoForce(t *testing.T) {
+	home, project, link := setupBudgetMigrationFixture(t, "claude", "oversized", 200)
+	t.Setenv("HOME", home)
+	old := budget.AgentBudgets
+	budget.AgentBudgets = map[string]int{"claude": 20}
+	t.Cleanup(func() { budget.AgentBudgets = old })
+	discovery := undoDiscovery(home, project, link, "claude", "oversized")
+	_, err := BuildPlan(discovery, []string{project}, false)
+	if err == nil {
+		t.Fatal("BuildPlan() error = nil, want budget refusal")
+	}
+	if !strings.Contains(err.Error(), "project "+project+" exceeds claude budget") || !strings.Contains(err.Error(), "pass --force to proceed") {
+		t.Fatalf("error = %q, want budget refusal", err.Error())
+	}
+}
+
+func TestBuildPlan_FailsBudget_PassesWithForce(t *testing.T) {
+	home, project, link := setupBudgetMigrationFixture(t, "claude", "oversized", 200)
+	t.Setenv("HOME", home)
+	old := budget.AgentBudgets
+	budget.AgentBudgets = map[string]int{"claude": 20}
+	t.Cleanup(func() { budget.AgentBudgets = old })
+	discovery := undoDiscovery(home, project, link, "claude", "oversized")
+	plan, err := BuildPlan(discovery, []string{project}, false, true)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	if got := plan.ProjectFiles[0].BudgetPerAgent["claude"].Status; got != budget.StatusRefuse {
+		t.Fatalf("budget status = %s, want refuse", got)
+	}
+}
+
+func TestApply_SetsMigrationSource(t *testing.T) {
+	home, project, link := setupBudgetMigrationFixture(t, "claude", "tdd", 10)
+	t.Setenv("HOME", home)
+	st := &state.State{
+		SchemaVersion: 5,
+		Installed: map[string]state.InstalledSkill{
+			"tdd": {Projections: []state.ProjectionEntry{{Project: "", Tools: []string{"claude"}}}},
+		},
+		Kits:               map[string]state.InstalledKit{},
+		Snippets:           map[string]state.InstalledSnippet{},
+		Migrations:         map[string]bool{},
+		RegistryFailures:   map[string]state.RegistryFailure{},
+		BinaryUpdateChecks: map[string]state.BinaryUpdateCheck{},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatal(err)
+	}
+	discovery := undoDiscovery(home, project, link, "claude", "tdd")
+	plan, err := BuildPlan(discovery, []string{project}, false)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	if _, err := Apply(plan, discovery.Projects); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, projection := range loaded.Installed["tdd"].Projections {
+		if projection.Project == project && projection.Source == state.SourceMigration {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("projections = %#v, want migration source for project", loaded.Installed["tdd"].Projections)
+	}
+}
+
+func setupBudgetMigrationFixture(t *testing.T, tool, skill string, descriptionBytes int) (home, project, link string) {
+	t.Helper()
+	home = t.TempDir()
+	project = filepath.Join(home, "project")
+	storeSkill := filepath.Join(home, ".scribe", "skills", skill)
+	link = filepath.Join(home, "."+tool, "skills", skill)
+	for _, dir := range []string{project, storeSkill, filepath.Dir(link)} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	content := []byte("---\nname: " + skill + "\ndescription: " + strings.Repeat("x", descriptionBytes) + "\n---\n")
+	if err := os.WriteFile(filepath.Join(storeSkill, "SKILL.md"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(storeSkill, link); err != nil {
+		t.Fatal(err)
+	}
+	return home, project, link
 }

--- a/internal/projectmigrate/snapshot.go
+++ b/internal/projectmigrate/snapshot.go
@@ -99,16 +99,18 @@ func captureSnapshot(discovery Discovery, plan MigrationPlan) (Snapshot, error) 
 		previousFiles[change.File] = data
 	}
 
-	previousProjections := map[string][]state.ProjectionEntry{}
 	st, err := state.Load()
 	if err != nil {
 		return Snapshot{}, err
 	}
+	previousProjections := map[string][]state.ProjectionEntry{}
 	for _, skill := range uniqueSkills(plan.GlobalLinks) {
 		if installed, ok := st.Installed[skill]; ok {
 			previousProjections[skill] = append([]state.ProjectionEntry(nil), installed.Projections...)
 		}
 	}
+	expected := cloneState(st)
+	applyMigrationProjections(expected, plan, false)
 
 	return Snapshot{
 		Version:              snapshotVersion,
@@ -117,8 +119,15 @@ func captureSnapshot(discovery Discovery, plan MigrationPlan) (Snapshot, error) 
 		Plan:                 plan,
 		PreviousProjectFiles: previousFiles,
 		PreviousProjections:  previousProjections,
-		StateHash:            hashProjections(previousProjections),
+		StateHash:            hashCurrentProjections(expected, &Snapshot{PreviousProjections: previousProjections}),
 	}, nil
+}
+
+func cloneState(st *state.State) *state.State {
+	data, _ := json.Marshal(st)
+	var cloned state.State
+	_ = json.Unmarshal(data, &cloned)
+	return &cloned
 }
 
 func hashCurrentProjections(st *state.State, snapshot *Snapshot) string {

--- a/internal/projectmigrate/snapshot.go
+++ b/internal/projectmigrate/snapshot.go
@@ -1,6 +1,7 @@
 package projectmigrate
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,6 +25,7 @@ type Snapshot struct {
 	Plan                 MigrationPlan                      `json:"plan"`
 	PreviousProjectFiles map[string][]byte                  `json:"previous_project_files"`
 	PreviousProjections  map[string][]state.ProjectionEntry `json:"previous_projections"`
+	StateHash            string                             `json:"state_hash,omitempty"`
 }
 
 func WriteSnapshot(snapshot Snapshot) (string, error) {
@@ -115,7 +117,24 @@ func captureSnapshot(discovery Discovery, plan MigrationPlan) (Snapshot, error) 
 		Plan:                 plan,
 		PreviousProjectFiles: previousFiles,
 		PreviousProjections:  previousProjections,
+		StateHash:            hashProjections(previousProjections),
 	}, nil
+}
+
+func hashCurrentProjections(st *state.State, snapshot *Snapshot) string {
+	projections := map[string][]state.ProjectionEntry{}
+	for skill := range snapshot.PreviousProjections {
+		if installed, ok := st.Installed[skill]; ok {
+			projections[skill] = installed.Projections
+		}
+	}
+	return hashProjections(projections)
+}
+
+func hashProjections(projections map[string][]state.ProjectionEntry) string {
+	data, _ := json.Marshal(projections)
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum[:])
 }
 
 func snapshotPaths(dir string) ([]string, error) {

--- a/internal/projectmigrate/snapshot.go
+++ b/internal/projectmigrate/snapshot.go
@@ -110,7 +110,7 @@ func captureSnapshot(discovery Discovery, plan MigrationPlan) (Snapshot, error) 
 		}
 	}
 	expected := cloneState(st)
-	applyMigrationProjections(expected, plan, false)
+	applyMigrationProjections(expected, plan, true)
 
 	return Snapshot{
 		Version:              snapshotVersion,

--- a/internal/projectmigrate/snapshot.go
+++ b/internal/projectmigrate/snapshot.go
@@ -1,0 +1,152 @@
+package projectmigrate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/Naoray/scribe/internal/state"
+)
+
+const snapshotVersion = 1
+const snapshotTimeLayout = "2006-01-02T15:04:05.000Z07:00"
+const snapshotRetention = 10
+
+type Snapshot struct {
+	Version              int                                `json:"version"`
+	Timestamp            time.Time                          `json:"timestamp"`
+	Discovery            Discovery                          `json:"discovery"`
+	Plan                 MigrationPlan                      `json:"plan"`
+	PreviousProjectFiles map[string][]byte                  `json:"previous_project_files"`
+	PreviousProjections  map[string][]state.ProjectionEntry `json:"previous_projections"`
+}
+
+func WriteSnapshot(snapshot Snapshot) (string, error) {
+	if snapshot.Version == 0 {
+		snapshot.Version = snapshotVersion
+	}
+	if snapshot.Timestamp.IsZero() {
+		snapshot.Timestamp = time.Now().UTC()
+	} else {
+		snapshot.Timestamp = snapshot.Timestamp.UTC()
+	}
+	dir, err := state.MigrationSnapshotsDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create migration history dir: %w", err)
+	}
+	path := filepath.Join(dir, snapshot.Timestamp.Format(snapshotTimeLayout)+".json")
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal migration snapshot: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return "", fmt.Errorf("write migration snapshot: %w", err)
+	}
+	if err := pruneSnapshots(dir); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func LoadSnapshot(path string) (*Snapshot, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read migration snapshot: %w", err)
+	}
+	var snapshot Snapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return nil, fmt.Errorf("parse migration snapshot: %w", err)
+	}
+	return &snapshot, nil
+}
+
+func LatestSnapshotPath() (string, error) {
+	dir, err := state.MigrationSnapshotsDir()
+	if err != nil {
+		return "", err
+	}
+	paths, err := snapshotPaths(dir)
+	if err != nil {
+		return "", err
+	}
+	if len(paths) == 0 {
+		return "", fmt.Errorf("no migration to undo")
+	}
+	return paths[len(paths)-1], nil
+}
+
+func captureSnapshot(discovery Discovery, plan MigrationPlan) (Snapshot, error) {
+	previousFiles := make(map[string][]byte, len(plan.ProjectFiles))
+	for _, change := range plan.ProjectFiles {
+		data, err := os.ReadFile(change.File)
+		if errors.Is(err, fs.ErrNotExist) {
+			previousFiles[change.File] = nil
+			continue
+		}
+		if err != nil {
+			return Snapshot{}, fmt.Errorf("read previous project file %s: %w", change.File, err)
+		}
+		previousFiles[change.File] = data
+	}
+
+	previousProjections := map[string][]state.ProjectionEntry{}
+	st, err := state.Load()
+	if err != nil {
+		return Snapshot{}, err
+	}
+	for _, skill := range uniqueSkills(plan.GlobalLinks) {
+		if installed, ok := st.Installed[skill]; ok {
+			previousProjections[skill] = append([]state.ProjectionEntry(nil), installed.Projections...)
+		}
+	}
+
+	return Snapshot{
+		Version:              snapshotVersion,
+		Timestamp:            time.Now().UTC(),
+		Discovery:            discovery,
+		Plan:                 plan,
+		PreviousProjectFiles: previousFiles,
+		PreviousProjections:  previousProjections,
+	}, nil
+}
+
+func snapshotPaths(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read migration history dir: %w", err)
+	}
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		paths = append(paths, filepath.Join(dir, entry.Name()))
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func pruneSnapshots(dir string) error {
+	paths, err := snapshotPaths(dir)
+	if err != nil {
+		return err
+	}
+	for len(paths) > snapshotRetention {
+		if err := os.Remove(paths[0]); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("prune migration snapshot: %w", err)
+		}
+		paths = paths[1:]
+	}
+	return nil
+}

--- a/internal/projectmigrate/snapshot_test.go
+++ b/internal/projectmigrate/snapshot_test.go
@@ -1,0 +1,200 @@
+package projectmigrate
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Naoray/scribe/internal/state"
+)
+
+func TestWriteAndLoadSnapshot_RoundTrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	project := filepath.Join(home, "project")
+	file := filepath.Join(project, ".scribe.yaml")
+	snapshot := Snapshot{
+		Version:   1,
+		Timestamp: time.Date(2026, 5, 2, 12, 34, 56, 789000000, time.UTC),
+		Discovery: Discovery{
+			GlobalSymlinks: []GlobalSymlink{{
+				Tool:          "claude",
+				Skill:         "tdd",
+				Path:          filepath.Join(home, ".claude", "skills", "tdd"),
+				CanonicalPath: filepath.Join(home, ".scribe", "skills", "tdd"),
+			}},
+			Projects: []ProjectCandidate{{Path: project, Source: "search_root"}},
+			Skills:   []string{"tdd"},
+		},
+		Plan: MigrationPlan{
+			ProjectFiles: []ProjectChange{{
+				Project: project,
+				File:    file,
+				Skills:  []string{"tdd"},
+				Changed: true,
+			}},
+		},
+		PreviousProjectFiles: map[string][]byte{
+			file: []byte("add:\n  - old\n"),
+		},
+		PreviousProjections: map[string][]state.ProjectionEntry{
+			"tdd": {{Project: "", Tools: []string{"claude"}}},
+		},
+	}
+
+	path, err := WriteSnapshot(snapshot)
+	if err != nil {
+		t.Fatalf("WriteSnapshot() error = %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode = %o, want 0600", info.Mode().Perm())
+	}
+	loaded, err := LoadSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadSnapshot() error = %v", err)
+	}
+	if !reflect.DeepEqual(*loaded, snapshot) {
+		t.Fatalf("snapshot = %#v, want %#v", *loaded, snapshot)
+	}
+}
+
+func TestSnapshotRetention_KeepsLatest10(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	base := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 12; i++ {
+		if _, err := WriteSnapshot(Snapshot{
+			Version:   1,
+			Timestamp: base.Add(time.Duration(i) * time.Millisecond),
+		}); err != nil {
+			t.Fatalf("WriteSnapshot(%d) error = %v", i, err)
+		}
+	}
+	dir, err := state.MigrationSnapshotsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 10 {
+		t.Fatalf("snapshot count = %d, want 10", len(entries))
+	}
+	latest, err := LatestSnapshotPath()
+	if err != nil {
+		t.Fatalf("LatestSnapshotPath() error = %v", err)
+	}
+	if filepath.Base(latest) != "2026-05-02T12:00:00.011Z.json" {
+		t.Fatalf("latest = %s, want final snapshot", filepath.Base(latest))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "2026-05-02T12:00:00.000Z.json")); !os.IsNotExist(err) {
+		t.Fatalf("oldest snapshot should be pruned, stat err = %v", err)
+	}
+}
+
+func TestApplyWritesSnapshot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	project := filepath.Join(home, "project")
+	store := filepath.Join(home, ".scribe", "skills")
+	link := filepath.Join(home, ".claude", "skills", "tdd")
+	mustMkdir(t, filepath.Join(store, "tdd"))
+	mustMkdir(t, filepath.Dir(link))
+	mustMkdir(t, project)
+	mustSymlink(t, filepath.Join(store, "tdd"), link)
+	st := &state.State{
+		SchemaVersion: 5,
+		Installed: map[string]state.InstalledSkill{
+			"tdd": {Projections: []state.ProjectionEntry{{Project: "", Tools: []string{"claude"}}}},
+		},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatal(err)
+	}
+	discovery := Discovery{
+		GlobalSymlinks: []GlobalSymlink{{
+			Tool:          "claude",
+			Skill:         "tdd",
+			Path:          link,
+			CanonicalPath: filepath.Join(store, "tdd"),
+		}},
+		Projects: []ProjectCandidate{{Path: project, Source: "search_root"}},
+		Skills:   []string{"tdd"},
+	}
+	plan, err := BuildPlan(discovery, []string{project}, false)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	if _, err := Apply(plan, discovery.Projects); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	path, err := LatestSnapshotPath()
+	if err != nil {
+		t.Fatalf("LatestSnapshotPath() error = %v", err)
+	}
+	snapshot, err := LoadSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadSnapshot() error = %v", err)
+	}
+	file := filepath.Join(project, ".scribe.yaml")
+	if _, ok := snapshot.PreviousProjectFiles[file]; !ok {
+		t.Fatalf("snapshot missing previous project file entry for %s", file)
+	}
+	if got := snapshot.PreviousProjections["tdd"]; !reflect.DeepEqual(got, []state.ProjectionEntry{{Project: "", Tools: []string{"claude"}}}) {
+		t.Fatalf("previous projections = %#v, want legacy projection", got)
+	}
+}
+
+func TestApplyDeletesSnapshotOnFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	project := filepath.Join(home, "project")
+	store := filepath.Join(home, ".scribe", "skills")
+	linkDir := filepath.Join(home, ".claude", "skills")
+	link := filepath.Join(linkDir, "tdd")
+	mustMkdir(t, filepath.Join(store, "tdd"))
+	mustMkdir(t, linkDir)
+	mustMkdir(t, project)
+	mustSymlink(t, filepath.Join(store, "tdd"), link)
+	if err := os.Chmod(linkDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Chmod(linkDir, 0o700)
+	})
+	discovery := Discovery{
+		GlobalSymlinks: []GlobalSymlink{{
+			Tool:          "claude",
+			Skill:         "tdd",
+			Path:          link,
+			CanonicalPath: filepath.Join(store, "tdd"),
+		}},
+		Projects: []ProjectCandidate{{Path: project, Source: "search_root"}},
+		Skills:   []string{"tdd"},
+	}
+	plan, err := BuildPlan(discovery, []string{project}, false)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	if _, err := Apply(plan, discovery.Projects); err == nil {
+		t.Fatal("Apply() error = nil, want remove failure")
+	}
+	dir, err := state.MigrationSnapshotsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("snapshot count = %d, want 0 after failed apply", len(entries))
+	}
+}

--- a/internal/projectmigrate/undo.go
+++ b/internal/projectmigrate/undo.go
@@ -1,0 +1,78 @@
+package projectmigrate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Naoray/scribe/internal/state"
+)
+
+type UndoResult struct {
+	RestoredLinks        int    `json:"restored_links"`
+	RestoredProjectFiles int    `json:"restored_project_files"`
+	DeletedProjectFiles  int    `json:"deleted_project_files"`
+	Snapshot             string `json:"snapshot"`
+}
+
+func Undo(snapshot *Snapshot, snapshotPath string) (UndoResult, error) {
+	result := UndoResult{Snapshot: snapshotPath}
+	if snapshot == nil {
+		return result, fmt.Errorf("no migration to undo")
+	}
+	st, err := state.Load()
+	if err != nil {
+		return result, err
+	}
+	if snapshot.StateHash != "" && hashCurrentProjections(st, snapshot) != snapshot.StateHash {
+		return result, fmt.Errorf("state changed since migration; resolve manually")
+	}
+
+	for _, link := range snapshot.Discovery.GlobalSymlinks {
+		if err := os.MkdirAll(filepath.Dir(link.Path), 0o755); err != nil {
+			return result, fmt.Errorf("create global link dir: %w", err)
+		}
+		if err := os.Remove(link.Path); err != nil && !os.IsNotExist(err) {
+			return result, fmt.Errorf("remove current global path %s: %w", link.Path, err)
+		}
+		if err := os.Symlink(link.CanonicalPath, link.Path); err != nil {
+			return result, fmt.Errorf("restore global symlink %s: %w", link.Path, err)
+		}
+		result.RestoredLinks++
+	}
+
+	for path, data := range snapshot.PreviousProjectFiles {
+		if data == nil {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return result, fmt.Errorf("delete project file %s: %w", path, err)
+			}
+			result.DeletedProjectFiles++
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return result, fmt.Errorf("create project file dir: %w", err)
+		}
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			return result, fmt.Errorf("restore project file %s: %w", path, err)
+		}
+		result.RestoredProjectFiles++
+	}
+
+	for skill, projections := range snapshot.PreviousProjections {
+		installed, ok := st.Installed[skill]
+		if !ok {
+			continue
+		}
+		installed.Projections = append([]state.ProjectionEntry(nil), projections...)
+		st.Installed[skill] = installed
+	}
+	if err := st.Save(); err != nil {
+		return result, err
+	}
+	if snapshotPath != "" {
+		if err := os.Remove(snapshotPath); err != nil && !os.IsNotExist(err) {
+			return result, fmt.Errorf("delete migration snapshot: %w", err)
+		}
+	}
+	return result, nil
+}

--- a/internal/projectmigrate/undo_test.go
+++ b/internal/projectmigrate/undo_test.go
@@ -1,0 +1,163 @@
+package projectmigrate
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/projectfile"
+	"github.com/Naoray/scribe/internal/state"
+)
+
+func TestUndo_RoundTrip_ByteEqual(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	project, link := setupUndoFixture(t, home, "claude", "tdd", []byte("add:\n  - old\n"))
+	beforeState, err := os.ReadFile(filepath.Join(home, ".scribe", "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeProject, err := os.ReadFile(filepath.Join(project, projectfile.Filename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	discovery := undoDiscovery(home, project, link, "claude", "tdd")
+	plan, err := BuildPlan(discovery, []string{project}, false)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	if _, err := Apply(plan, discovery.Projects); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	snapshotPath, err := LatestSnapshotPath()
+	if err != nil {
+		t.Fatalf("LatestSnapshotPath() error = %v", err)
+	}
+	snapshot, err := LoadSnapshot(snapshotPath)
+	if err != nil {
+		t.Fatalf("LoadSnapshot() error = %v", err)
+	}
+	result, err := Undo(snapshot, snapshotPath)
+	if err != nil {
+		t.Fatalf("Undo() error = %v", err)
+	}
+	afterState, err := os.ReadFile(filepath.Join(home, ".scribe", "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterProject, err := os.ReadFile(filepath.Join(project, projectfile.Filename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(afterState, beforeState) {
+		t.Fatalf("state bytes changed after undo\nbefore=%s\nafter=%s", beforeState, afterState)
+	}
+	if !bytes.Equal(afterProject, beforeProject) {
+		t.Fatalf("project bytes changed after undo\nbefore=%s\nafter=%s", beforeProject, afterProject)
+	}
+	if _, err := os.Lstat(link); err != nil {
+		t.Fatalf("global symlink should be restored: %v", err)
+	}
+	if result.RestoredLinks != 1 || result.RestoredProjectFiles != 1 {
+		t.Fatalf("result = %#v, want restored link and project file", result)
+	}
+}
+
+func TestUndo_NoSnapshot_Errors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if _, err := LatestSnapshotPath(); err == nil {
+		t.Fatal("LatestSnapshotPath() error = nil, want no migration to undo")
+	}
+}
+
+func TestUndo_RestoresMissingProjectFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	project, link := setupUndoFixture(t, home, "claude", "tdd", nil)
+	discovery := undoDiscovery(home, project, link, "claude", "tdd")
+	plan, err := BuildPlan(discovery, []string{project}, false)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	if _, err := Apply(plan, discovery.Projects); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	snapshotPath, err := LatestSnapshotPath()
+	if err != nil {
+		t.Fatalf("LatestSnapshotPath() error = %v", err)
+	}
+	snapshot, err := LoadSnapshot(snapshotPath)
+	if err != nil {
+		t.Fatalf("LoadSnapshot() error = %v", err)
+	}
+	result, err := Undo(snapshot, snapshotPath)
+	if err != nil {
+		t.Fatalf("Undo() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(project, projectfile.Filename)); !os.IsNotExist(err) {
+		t.Fatalf("project file should be deleted after undo, stat err = %v", err)
+	}
+	if result.DeletedProjectFiles != 1 {
+		t.Fatalf("DeletedProjectFiles = %d, want 1", result.DeletedProjectFiles)
+	}
+}
+
+func setupUndoFixture(t *testing.T, home, tool, skill string, projectFile []byte) (project, link string) {
+	t.Helper()
+	project = filepath.Join(home, "project")
+	storeSkill := filepath.Join(home, ".scribe", "skills", skill)
+	link = filepath.Join(home, "."+tool, "skills", skill)
+	for _, dir := range []string{project, storeSkill, filepath.Dir(link)} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if projectFile != nil {
+		if err := os.WriteFile(filepath.Join(project, projectfile.Filename), projectFile, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(storeSkill, "SKILL.md"), []byte("---\nname: "+skill+"\ndescription: Test\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(storeSkill, link); err != nil {
+		t.Fatal(err)
+	}
+	st := &state.State{
+		SchemaVersion: 5,
+		Installed: map[string]state.InstalledSkill{
+			skill: {Projections: []state.ProjectionEntry{{Project: "", Tools: []string{tool}}}},
+		},
+		Kits:               map[string]state.InstalledKit{},
+		Snippets:           map[string]state.InstalledSnippet{},
+		RemovedByUser:      []state.RemovedSkill{},
+		Migrations:         map[string]bool{},
+		RegistryFailures:   map[string]state.RegistryFailure{},
+		BinaryUpdateChecks: map[string]state.BinaryUpdateCheck{},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := loaded.Save(); err != nil {
+		t.Fatal(err)
+	}
+	return project, link
+}
+
+func undoDiscovery(home, project, link, tool, skill string) Discovery {
+	return Discovery{
+		GlobalSymlinks: []GlobalSymlink{{
+			Tool:          tool,
+			Skill:         skill,
+			Path:          link,
+			CanonicalPath: filepath.Join(home, ".scribe", "skills", skill),
+		}},
+		Projects: []ProjectCandidate{{Path: project, Source: "search_root"}},
+		Skills:   []string{skill},
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -35,7 +35,13 @@ type State struct {
 type ProjectionEntry struct {
 	Project string   `json:"project"`
 	Tools   []string `json:"tools"`
+	Source  string   `json:"source,omitempty"`
 }
+
+const (
+	SourceSync      = "sync"
+	SourceMigration = "migration"
+)
 
 // InstalledKit indexes an installed kit definition in the local state file.
 type InstalledKit struct {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -725,6 +725,14 @@ func statePath() (string, error) {
 	return paths.StatePath()
 }
 
+func MigrationSnapshotsDir() (string, error) {
+	dir, err := paths.ScribeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "migration-history"), nil
+}
+
 func FileExists() (bool, error) {
 	path, err := statePath()
 	if err != nil {

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -881,6 +881,9 @@ func selectEffectiveTools(global []tools.Tool, installed *state.InstalledSkill) 
 }
 
 func (s *Syncer) checkBudgetBeforeProjection(st *state.State, incomingName string, files []tools.SkillFile, effectiveTools []tools.Tool) error {
+	if migrationProjection(st, incomingName, s.ProjectRoot) {
+		return nil
+	}
 	incomingContent, ok := skillMDContent(files)
 	if !ok {
 		return nil
@@ -905,6 +908,22 @@ func (s *Syncer) checkBudgetBeforeProjection(st *state.State, incomingName strin
 		}
 	}
 	return nil
+}
+
+func migrationProjection(st *state.State, name, projectRoot string) bool {
+	if st == nil {
+		return false
+	}
+	installed, ok := st.Installed[name]
+	if !ok {
+		return false
+	}
+	for _, projection := range installed.Projections {
+		if projection.Project == projectRoot && projection.Source == state.SourceMigration {
+			return true
+		}
+	}
+	return false
 }
 
 func skillMDContent(files []tools.SkillFile) ([]byte, bool) {

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Naoray/scribe/internal/budget"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/state"
@@ -655,6 +656,46 @@ func TestRunWithDiff_EmitsBudgetWarningForPostChangeProjection(t *testing.T) {
 		}
 	}
 	t.Fatal("expected BudgetWarningMsg")
+}
+
+func TestRunWithDiff_SkipsBudgetOnMigrationSource(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	old := budget.AgentBudgets
+	budget.AgentBudgets = map[string]int{"codex": 20}
+	t.Cleanup(func() { budget.AgentBudgets = old })
+	projectRoot := t.TempDir()
+	var events []any
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{
+			files: []tools.SkillFile{{Path: "SKILL.md", Content: skillContent("incoming", strings.Repeat("y", 200))}},
+		},
+		Tools:       []tools.Tool{tools.CodexTool{}},
+		ProjectRoot: projectRoot,
+		Emit:        func(msg any) { events = append(events, msg) },
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"incoming": {
+			Projections: []state.ProjectionEntry{{
+				Project: projectRoot,
+				Tools:   []string{"codex"},
+				Source:  state.SourceMigration,
+			}},
+		},
+	}}
+	statuses := []sync.SkillStatus{{
+		Name:   "incoming",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "incoming", Source: "github:acme/skills@main"},
+	}}
+	if err := syncer.RunWithDiff(context.Background(), "acme/skills", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+	for _, event := range events {
+		if msg, ok := event.(sync.SkillErrorMsg); ok {
+			t.Fatalf("unexpected SkillErrorMsg: %v", msg.Err)
+		}
+	}
 }
 
 // TestApply_RealDirectoryAtProjectionPath verifies that sync emits an actionable

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "0f906d8e",
+      "content_hash": "16f7a7ab",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe",


### PR DESCRIPTION
## Summary

Implements the 8-phase `scribe migrate global-to-projects` v1.0.5 fix:

1. Refuses global-to-projects without `--project` when global symlinks exist, and adds `--yes`.
2. Persists JSON pre-apply migration snapshots in `~/.scribe/migration-history/` with latest-10 retention.
3. Adds latest-only `--undo` with project file, symlink, and state projection restoration.
4. Adds budget preflight, `--force`, migration-derived projection tagging, and sync budget bypass for migration-sourced projections.
5. Enriches dry-run text with `.scribe.yaml` file paths, symlink samples, and per-agent budget lines.
6. Clears legacy global projection state, records project-scoped migration entries, and adds `migration_budget_overflow` doctor warnings.
7. Registers the `scribe migrate global-to-projects` output schema and updates the agent command table.
8. Adds the v1.0.5 CHANGELOG entry and help text documenting the contract and examples.

## Test plan

- `go test ./...` before every phase commit
- `go build ./...` after Phase 8

## Notes

- The only remaining untracked file in the worktree is Anvil local metadata: `.anvil.local`.
