### PR TITLE
fix(budget): exclude pinned-tool-disabled skills from agent budget

### DIFF
--- a/cmd/budget_helpers.go
+++ b/cmd/budget_helpers.go
@@ -104,6 +104,30 @@ func budgetAgents(_ *config.Config) []string {
 	return agents
 }
 
+func budgetSkillsForAgent(set resolvedBudgetSet, st *state.State, agent string) []budget.Skill {
+	if st == nil {
+		return append([]budget.Skill(nil), set.Skills...)
+	}
+	skills := make([]budget.Skill, 0, len(set.Skills))
+	for _, skill := range set.Skills {
+		installed, ok := st.Installed[skill.Name]
+		if ok && installed.ToolsMode == state.ToolsModePinned && !containsBudgetTool(installed.Tools, agent) {
+			continue
+		}
+		skills = append(skills, skill)
+	}
+	return skills
+}
+
+func containsBudgetTool(tools []string, agent string) bool {
+	for _, tool := range tools {
+		if tool == agent {
+			return true
+		}
+	}
+	return false
+}
+
 func enforceCurrentBudget(factory *app.Factory, force bool) error {
 	cfg, err := factory.Config()
 	if err != nil {
@@ -118,7 +142,7 @@ func enforceCurrentBudget(factory *app.Factory, force bool) error {
 		return err
 	}
 	for _, agent := range budgetAgents(cfg) {
-		result := budget.CheckBudget(set.Skills, agent)
+		result := budget.CheckBudget(budgetSkillsForAgent(set, st, agent), agent)
 		switch result.Status {
 		case budget.StatusRefuse:
 			if !force {

--- a/cmd/budget_helpers_test.go
+++ b/cmd/budget_helpers_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/budget"
+	"github.com/Naoray/scribe/internal/state"
+)
+
+func TestBudgetSkillsForAgentExcludesPinnedSkillWithoutAgent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wd := t.TempDir()
+	t.Chdir(wd)
+
+	writeBudgetSkill(t, home, "claude-only", "claude")
+	writeBudgetSkill(t, home, "shared", "shared")
+
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"claude-only": {
+			ToolsMode: state.ToolsModePinned,
+			Tools:     []string{"claude"},
+		},
+		"shared": {
+			Tools: []string{"claude", "codex"},
+		},
+	}}
+
+	set, err := resolveBudgetSet(st)
+	if err != nil {
+		t.Fatalf("resolveBudgetSet: %v", err)
+	}
+
+	codex := budgetSkillsForAgent(set, st, "codex")
+	claude := budgetSkillsForAgent(set, st, "claude")
+
+	if skillNames(codex).has("claude-only") {
+		t.Fatal("codex budget should exclude claude-only")
+	}
+	if !skillNames(claude).has("claude-only") {
+		t.Fatal("claude budget should include claude-only")
+	}
+}
+
+func writeBudgetSkill(t *testing.T, home, name, content string) {
+	t.Helper()
+
+	dir := filepath.Join(home, ".scribe", "skills", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+}
+
+type testBudgetSkillNames map[string]bool
+
+func skillNames(skills []budget.Skill) testBudgetSkillNames {
+	names := make(testBudgetSkillNames, len(skills))
+	for _, skill := range skills {
+		names[skill.Name] = true
+	}
+	return names
+}
+
+func (names testBudgetSkillNames) has(name string) bool {
+	return names[name]
+}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -50,7 +50,7 @@ func runShow(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintln(os.Stdout, "Budgets:")
 	for _, agent := range budgetAgents(cfg) {
-		result := budget.CheckBudget(set.Skills, agent)
+		result := budget.CheckBudget(budgetSkillsForAgent(set, st, agent), agent)
 		line := budget.FormatResult(result)
 		if line == "" {
 			continue

--- a/internal/sync/budget_projection_internal_test.go
+++ b/internal/sync/budget_projection_internal_test.go
@@ -1,0 +1,85 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	ibudget "github.com/Naoray/scribe/internal/budget"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+func TestBudgetSkillsForProjectionExcludesPinnedSkillWithoutAgent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		t.Fatalf("store dir: %v", err)
+	}
+	writeProjectionBudgetSkill(t, storeDir, "claude-only", "claude")
+	writeProjectionBudgetSkill(t, storeDir, "codex-skill", "codex")
+
+	projectRoot := t.TempDir()
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"claude-only": {
+			ToolsMode: state.ToolsModePinned,
+			Tools:     []string{"claude"},
+			Projections: []state.ProjectionEntry{{
+				Project: projectRoot,
+				Tools:   []string{"codex"},
+			}},
+		},
+		"codex-skill": {
+			ToolsMode: state.ToolsModePinned,
+			Tools:     []string{"codex"},
+			Projections: []state.ProjectionEntry{{
+				Project: projectRoot,
+				Tools:   []string{"codex"},
+			}},
+		},
+	}}
+
+	skills, err := budgetSkillsForProjection(st, "incoming", []byte("incoming"), projectRoot, "codex")
+	if err != nil {
+		t.Fatalf("budgetSkillsForProjection: %v", err)
+	}
+
+	names := projectionBudgetSkillNames(skills)
+	if names.has("claude-only") {
+		t.Fatal("codex budget should exclude claude-only")
+	}
+	if !names.has("codex-skill") {
+		t.Fatal("codex budget should include codex-skill")
+	}
+	if !names.has("incoming") {
+		t.Fatal("codex budget should include incoming")
+	}
+}
+
+func writeProjectionBudgetSkill(t *testing.T, storeDir, name, content string) {
+	t.Helper()
+
+	dir := filepath.Join(storeDir, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+}
+
+type projectionBudgetSkillNameSet map[string]bool
+
+func projectionBudgetSkillNames(skills []ibudget.Skill) projectionBudgetSkillNameSet {
+	names := make(projectionBudgetSkillNameSet, len(skills))
+	for _, skill := range skills {
+		names[skill.Name] = true
+	}
+	return names
+}
+
+func (names projectionBudgetSkillNameSet) has(name string) bool {
+	return names[name]
+}

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -961,7 +961,7 @@ func budgetSkillsForProjection(st *state.State, incomingName string, incomingCon
 		if installed.Kind == state.KindPackage {
 			continue
 		}
-		if name == incomingName || !projectedToAgent(installed, projectRoot, agent) {
+		if name == incomingName || !projectedToAgent(installed, projectRoot, agent) || !pinnedToAgent(installed, agent) {
 			continue
 		}
 		seen[name] = true
@@ -999,6 +999,10 @@ func projectedToAgent(installed state.InstalledSkill, projectRoot, agent string)
 		return false
 	}
 	return containsString(installed.Tools, agent)
+}
+
+func pinnedToAgent(installed state.InstalledSkill, agent string) bool {
+	return installed.ToolsMode != state.ToolsModePinned || containsString(installed.Tools, agent)
 }
 
 func containsString(values []string, want string) bool {


### PR DESCRIPTION
## Summary\n- filter show/enforcement budget checks per agent when a skill is tools_mode=pinned\n- exclude pinned-out skills from sync projection budget calculations\n- add regression coverage for command and sync budget paths\n\n## Tests\n- go test ./...