### PR TITLE
fix(sync+migrate): promote global projections + guard kit YAMLs

### DIFF
--- a/cmd/migrate_global.go
+++ b/cmd/migrate_global.go
@@ -210,6 +210,11 @@ func printGlobalToProjectsResult(cmd *cobra.Command, result projectmigrate.Migra
 		}
 		fmt.Fprintf(out, "%swrote .scribe.yaml in %d project(s)\n", prefix, projectWrites)
 		for _, change := range result.ProjectFiles {
+			if change.SkippedWriteReason != "" {
+				fmt.Fprintf(out, "  %s\n", change.SkippedWriteReason)
+				printBudgetLines(out, change.BudgetPerAgent)
+				continue
+			}
 			action := "unchanged"
 			if change.Changed {
 				action = "write"

--- a/cmd/migrate_global_schema.go
+++ b/cmd/migrate_global_schema.go
@@ -27,6 +27,7 @@ var migrateGlobalToProjectsOutputSchema = `{
           "added_skills": {"type": "array", "items": {"type": "string"}},
           "skills": {"type": "array", "items": {"type": "string"}},
           "changed": {"type": "boolean"},
+          "skipped_write_reason": {"type": "string"},
           "budget_per_agent": {
             "type": "object",
             "additionalProperties": {

--- a/internal/projectmigrate/migrate.go
+++ b/internal/projectmigrate/migrate.go
@@ -1,6 +1,7 @@
 package projectmigrate
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -11,16 +12,18 @@ import (
 	"github.com/Naoray/scribe/internal/budget"
 	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/state"
+	"gopkg.in/yaml.v3"
 )
 
 // ProjectChange describes the .scribe.yaml update for one selected project.
 type ProjectChange struct {
-	Project        string                   `json:"project"`
-	File           string                   `json:"file"`
-	AddedSkills    []string                 `json:"added_skills"`
-	Skills         []string                 `json:"skills"`
-	Changed        bool                     `json:"changed"`
-	BudgetPerAgent map[string]budget.Result `json:"budget_per_agent,omitempty"`
+	Project            string                   `json:"project"`
+	File               string                   `json:"file"`
+	AddedSkills        []string                 `json:"added_skills"`
+	Skills             []string                 `json:"skills"`
+	Changed            bool                     `json:"changed"`
+	SkippedWriteReason string                   `json:"skipped_write_reason,omitempty"`
+	BudgetPerAgent     map[string]budget.Result `json:"budget_per_agent,omitempty"`
 }
 
 // MigrationPlan is the complete set of writes/removals for the migration.
@@ -56,12 +59,12 @@ func BuildPlan(discovery Discovery, selectedProjects []string, dryRun bool, forc
 	if len(skills) == 0 {
 		return MigrationPlan{DryRun: dryRun, GlobalLinks: discovery.GlobalSymlinks}, nil
 	}
-	forceBudget := len(force) > 0 && force[0]
+	forceMigration := len(force) > 0 && force[0]
 
 	selected := normalizeSelectedProjects(selectedProjects)
 	projectFiles := make([]ProjectChange, 0, len(selected))
 	for _, project := range selected {
-		change, err := prepareProjectChange(project, skills)
+		change, err := prepareProjectChange(project, skills, forceMigration)
 		if err != nil {
 			return MigrationPlan{}, err
 		}
@@ -70,7 +73,7 @@ func BuildPlan(discovery Discovery, selectedProjects []string, dryRun bool, forc
 			return MigrationPlan{}, err
 		}
 		change.BudgetPerAgent = budgetPerAgent
-		if !dryRun && !forceBudget {
+		if !dryRun && !forceMigration {
 			for agent, result := range budgetPerAgent {
 				if result.Status == budget.StatusRefuse {
 					return MigrationPlan{}, fmt.Errorf("project %s exceeds %s budget by %d bytes; pass --force to proceed", change.Project, agent, result.Used-result.Limit)
@@ -248,7 +251,7 @@ func removeLegacyProjectionTools(projections []state.ProjectionEntry, tools []st
 	return out
 }
 
-func prepareProjectChange(project string, skills []string) (ProjectChange, error) {
+func prepareProjectChange(project string, skills []string, force bool) (ProjectChange, error) {
 	abs, err := filepath.Abs(project)
 	if err != nil {
 		return ProjectChange{}, fmt.Errorf("resolve project path: %w", err)
@@ -257,6 +260,21 @@ func prepareProjectChange(project string, skills []string) (ProjectChange, error
 	pf, err := projectfile.Load(file)
 	if err != nil {
 		return ProjectChange{}, err
+	}
+	if !force {
+		userAuthored, err := hasKitOrSnippetKey(file)
+		if err != nil {
+			return ProjectChange{}, err
+		}
+		if userAuthored {
+			return ProjectChange{
+				Project:            abs,
+				File:               file,
+				Skills:             append([]string(nil), pf.Add...),
+				Changed:            false,
+				SkippedWriteReason: fmt.Sprintf("skipped writing %s: user-authored kit YAML detected", file),
+			}, nil
+		}
 	}
 
 	addSet := map[string]bool{}
@@ -295,6 +313,36 @@ func prepareProjectChange(project string, skills []string) (ProjectChange, error
 		Skills:      nextAdd,
 		Changed:     changed,
 	}, nil
+}
+
+func hasKitOrSnippetKey(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read project file: %w", err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return false, nil
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return false, fmt.Errorf("parse project file: %w", err)
+	}
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		doc = *doc.Content[0]
+	}
+	if doc.Kind != yaml.MappingNode {
+		return false, nil
+	}
+	for i := 0; i+1 < len(doc.Content); i += 2 {
+		key := doc.Content[i].Value
+		if key == "kits" || key == "snippets" {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func writeProjectChange(change ProjectChange) error {

--- a/internal/projectmigrate/migrate_test.go
+++ b/internal/projectmigrate/migrate_test.go
@@ -169,6 +169,101 @@ func TestApplyDryRunDoesNotMutateFilesystem(t *testing.T) {
 	}
 }
 
+func TestMigrate_SkipsKitYAMLOnExistingKitFile(t *testing.T) {
+	tmp := t.TempDir()
+	project := filepath.Join(tmp, "project")
+	store := filepath.Join(tmp, "home", ".scribe", "skills")
+	link := filepath.Join(tmp, "home", ".claude", "skills", "tdd")
+	mustMkdir(t, filepath.Join(store, "tdd"))
+	mustMkdir(t, filepath.Dir(link))
+	mustMkdir(t, project)
+	mustSymlink(t, filepath.Join(store, "tdd"), link)
+	projectFile := filepath.Join(project, projectfile.Filename)
+	original := []byte("kits:\n  - foo\nsnippets:\n  - commit-discipline\n")
+	if err := os.WriteFile(projectFile, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	discovery := Discovery{
+		GlobalSymlinks: []GlobalSymlink{{
+			Tool:          "claude",
+			Skill:         "tdd",
+			Path:          link,
+			CanonicalPath: filepath.Join(store, "tdd"),
+		}},
+		Projects: []ProjectCandidate{{Path: project, Source: "search_root"}},
+		Skills:   []string{"tdd"},
+	}
+
+	plan, err := BuildPlan(discovery, []string{project}, false)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	result, err := Apply(plan, discovery.Projects)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if result.WroteProjectFiles != 0 || result.RemovedGlobalLinks != 1 {
+		t.Fatalf("result = %#v, want skipped write and removed link", result)
+	}
+	got, err := os.ReadFile(projectFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("project file = %q, want unchanged %q", got, original)
+	}
+}
+
+func TestMigrate_ForceOverwritesKitYAML(t *testing.T) {
+	tmp := t.TempDir()
+	project := filepath.Join(tmp, "project")
+	store := filepath.Join(tmp, "home", ".scribe", "skills")
+	link := filepath.Join(tmp, "home", ".claude", "skills", "tdd")
+	mustMkdir(t, filepath.Join(store, "tdd"))
+	mustMkdir(t, filepath.Dir(link))
+	mustMkdir(t, project)
+	mustSymlink(t, filepath.Join(store, "tdd"), link)
+	projectFile := filepath.Join(project, projectfile.Filename)
+	original := []byte("kits:\n  - foo\n")
+	if err := os.WriteFile(projectFile, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	discovery := Discovery{
+		GlobalSymlinks: []GlobalSymlink{{
+			Tool:          "claude",
+			Skill:         "tdd",
+			Path:          link,
+			CanonicalPath: filepath.Join(store, "tdd"),
+		}},
+		Projects: []ProjectCandidate{{Path: project, Source: "search_root"}},
+		Skills:   []string{"tdd"},
+	}
+
+	plan, err := BuildPlan(discovery, []string{project}, false, true)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	result, err := Apply(plan, discovery.Projects)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if result.WroteProjectFiles != 1 {
+		t.Fatalf("WroteProjectFiles = %d, want 1", result.WroteProjectFiles)
+	}
+	got, err := os.ReadFile(projectFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) == string(original) {
+		t.Fatalf("project file = %q, want overwritten", got)
+	}
+	if !strings.Contains(string(got), "tdd") {
+		t.Fatalf("project file = %q, want migrated skill", got)
+	}
+}
+
 func TestBuildPlan_FailsBudget_NoForce(t *testing.T) {
 	home, project, link := setupBudgetMigrationFixture(t, "claude", "oversized", 200)
 	t.Setenv("HOME", home)

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -400,7 +400,15 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 
 	for _, sk := range statuses {
 		switch sk.Status {
-		case StatusCurrent, StatusExtra:
+		case StatusCurrent:
+			if s.needsProjectProjection(sk.Name, st) {
+				s.promoteProjectProjection(sk.Name, st, &summary)
+				continue
+			}
+			s.emit(SkillSkippedMsg{Name: sk.Name})
+			summary.Skipped++
+
+		case StatusExtra:
 			s.emit(SkillSkippedMsg{Name: sk.Name})
 			summary.Skipped++
 
@@ -710,6 +718,80 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 
 	s.emit(summary)
 	return nil
+}
+
+func (s *Syncer) needsProjectProjection(name string, st *state.State) bool {
+	if s.ProjectRoot == "" {
+		return false
+	}
+	installed := lookupInstalled(st, name)
+	if installed == nil || len(installed.Projections) == 0 {
+		return false
+	}
+	hasLegacy := false
+	for _, projection := range installed.Projections {
+		if projection.Project == s.ProjectRoot {
+			return false
+		}
+		if projection.Project != "" {
+			return false
+		}
+		hasLegacy = true
+	}
+	return hasLegacy
+}
+
+func (s *Syncer) promoteProjectProjection(name string, st *state.State, summary *SyncCompleteMsg) {
+	installed := lookupInstalled(st, name)
+	if installed == nil {
+		s.emit(SkillSkippedMsg{Name: name})
+		summary.Skipped++
+		return
+	}
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		s.emit(SkillErrorMsg{Name: name, Err: fmt.Errorf("resolve store dir: %w", err)})
+		summary.Failed++
+		return
+	}
+	canonicalDir := filepath.Join(storeDir, name)
+	content, err := os.ReadFile(filepath.Join(canonicalDir, "SKILL.md"))
+	if err != nil {
+		s.emit(SkillErrorMsg{Name: name, Err: fmt.Errorf("read stored skill: %w", err)})
+		summary.Failed++
+		return
+	}
+	effectiveTools := selectEffectiveTools(s.Tools, installed)
+	if !s.ForceBudget {
+		files := []tools.SkillFile{{Path: "SKILL.md", Content: content}}
+		if err := s.checkBudgetBeforeProjection(st, name, files, effectiveTools); err != nil {
+			s.emit(SkillErrorMsg{Name: name, Err: err})
+			summary.Failed++
+			return
+		}
+	}
+	var paths []string
+	var toolNames []string
+	for _, t := range effectiveTools {
+		links, err := t.Install(name, canonicalDir, s.ProjectRoot)
+		if err != nil {
+			s.emit(SkillErrorMsg{Name: name, Err: fmt.Errorf("link to %s: %w", t.Name(), err)})
+			summary.Failed++
+			return
+		}
+		paths = append(paths, links...)
+		toolNames = append(toolNames, t.Name())
+	}
+	next := *installed
+	next.Projections = mergeProjection(installed, s.ProjectRoot, toolNames)
+	next.ManagedPaths = mergeManagedPaths(installed, paths)
+	next.Paths = append([]string(nil), next.ManagedPaths...)
+	st.Installed[name] = next
+	if err := st.Save(); err != nil {
+		s.emit(SkillErrorMsg{Name: name, Err: fmt.Errorf("save state after %s: %w", name, err)})
+	}
+	s.emit(SkillInstalledMsg{Name: name, Updated: true})
+	summary.Updated++
 }
 
 func validateFetchedLockHash(sk SkillStatus, files []tools.SkillFile) error {

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -242,6 +243,69 @@ func TestRunWithDiff_RecordsGlobalProjectionWhenProjectRootEmpty(t *testing.T) {
 	wantPath := filepath.Join(home, ".claude", "skills", "recap")
 	if len(installed.ManagedPaths) != 1 || installed.ManagedPaths[0] != wantPath {
 		t.Fatalf("ManagedPaths = %v, want [%s]", installed.ManagedPaths, wantPath)
+	}
+}
+
+func TestSync_PromotesGlobalProjectionWhenProjectFileExists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		t.Fatalf("store dir: %v", err)
+	}
+	writeStoredSkill(t, storeDir, "recap", "project recap")
+
+	projectRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectRoot, ".scribe.yaml"), []byte("kits:\n  - core\n"), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+
+	syncer := &sync.Syncer{
+		Tools:       []tools.Tool{tools.ClaudeTool{}},
+		ProjectRoot: projectRoot,
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"recap": {
+			InstalledHash: sync.ComputeFileHash(skillContent("recap", "project recap")),
+			Tools:         []string{"claude"},
+			Projections: []state.ProjectionEntry{{
+				Project: "",
+				Tools:   []string{"claude"},
+			}},
+		},
+	}}
+	current := st.Installed["recap"]
+	statuses := []sync.SkillStatus{{
+		Name:      "recap",
+		Status:    sync.StatusCurrent,
+		Installed: &current,
+		Entry:     &manifest.Entry{Name: "recap", Source: "github:acme/skills@main"},
+	}}
+
+	if err := syncer.RunWithDiff(context.Background(), "acme/skills", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+
+	installed := st.Installed["recap"]
+	foundGlobal := false
+	foundProject := false
+	for _, projection := range installed.Projections {
+		if projection.Project == "" && reflect.DeepEqual(projection.Tools, []string{"claude"}) {
+			foundGlobal = true
+		}
+		if projection.Project == projectRoot && reflect.DeepEqual(projection.Tools, []string{"claude"}) {
+			foundProject = true
+		}
+	}
+	if !foundGlobal {
+		t.Fatalf("Projections = %#v, want retained global projection", installed.Projections)
+	}
+	if !foundProject {
+		t.Fatalf("Projections = %#v, want project projection", installed.Projections)
+	}
+	if _, err := os.Lstat(filepath.Join(projectRoot, ".claude", "skills", "recap")); err != nil {
+		t.Fatalf("project symlink missing: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- promote legacy global-only projections to project-local projections during project sync
- keep legacy global projections intact while adding project-local symlinks
- skip migrate writes for existing kit/snippet .scribe.yaml files unless --force is passed

## Tests
- go test ./...