### PR TITLE
[agent] feat(kit): add scribe kit create command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe guide` | --json | yes |
 | `scribe init` | --force, --json | yes |
 | `scribe install` | --alias, --all, --force, --json, --registry | no |
+| `scribe kit create` | --description, --force, --json, --registry, --skills | no |
 | `scribe list` | --fields, --json, --registry, --remote | yes |
 | `scribe migrate global-to-projects` | --dry-run, --force, --json, --project, --undo, --yes | yes |
 | `scribe migrate` | --json | no |

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -147,7 +147,7 @@ Run `scribe schema <command> --json` before composing an unfamiliar call — ret
 
 ## Project file (`.scribe.yaml`)
 
-If a project root has `.scribe.yaml`, it declares per-project intent — `kits`, `snippets`, `add`, `remove`. Kits are first-class local skill bundles, and `scribe kit create` can scaffold them. Don't synthesize `.scribe.yaml` without being asked.
+If a project root has `.scribe.yaml`, it declares per-project intent — `kits`, `snippets`, `add`, `remove`. Kits are first-class local skill bundles, and `scribe kit create` can scaffold them.
 
 ### Kits
 

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -147,7 +147,45 @@ Run `scribe schema <command> --json` before composing an unfamiliar call — ret
 
 ## Project file (`.scribe.yaml`)
 
-If a project root has `.scribe.yaml`, it declares per-project intent — `kits`, `snippets`, `add`, `remove`. The schema and parser ship; CLI surfaces that act on it land per release. Don't synthesize one without being asked.
+If a project root has `.scribe.yaml`, it declares per-project intent — `kits`, `snippets`, `add`, `remove`. Kits are first-class local skill bundles, and `scribe kit create` can scaffold them. Don't synthesize `.scribe.yaml` without being asked.
+
+### Kits
+
+A Kit is a named YAML bundle of skills stored at `~/.scribe/kits/<name>.yaml`.
+
+Schema: `{name, description?, skills[], source?{registry, rev?}}`
+
+Example:
+
+```yaml
+name: laravel-stack
+description: Laravel project defaults
+skills:
+  - eloquent
+  - queues
+  - livewire
+source:
+  registry: my-org/scribe-registry
+```
+
+Suggest a Kit when the user repeats the same install list across projects, is onboarding a team, or describes a consistent stack such as "we use these defaults for every Laravel app."
+
+To consume a Kit, add it to `.scribe.yaml`:
+
+```yaml
+kits:
+  - laravel-stack
+```
+
+`scribe sync` resolves the final skill set as the union of `kit.Skills` plus `projectFile.Add`, then subtracts `projectFile.Remove`.
+
+To author a Kit, run:
+
+```bash
+scribe kit create laravel-stack --skills eloquent,queues,livewire --description "Laravel project defaults"
+```
+
+That scaffolds `~/.scribe/kits/laravel-stack.yaml`. Use `--registry my-org/scribe-registry` to record `source.registry`.
 
 ## JSON shapes
 

--- a/cmd/kit.go
+++ b/cmd/kit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -60,6 +61,10 @@ func runKitCreate(cmd *cobra.Command, name string, opts *kitCreateOptions) error
 		opts = &kitCreateOptions{}
 	}
 
+	if err := validateKitName(name); err != nil {
+		return err
+	}
+
 	scribeDir, err := paths.ScribeDir()
 	if err != nil {
 		return fmt.Errorf("resolve scribe dir: %w", err)
@@ -100,5 +105,15 @@ func runKitCreate(cmd *cobra.Command, name string, opts *kitCreateOptions) error
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Created kit %s at %s with %d skills\n", out.Name, out.Path, out.SkillsCount)
+	return nil
+}
+
+func validateKitName(name string) error {
+	if name == "" || filepath.IsAbs(name) || strings.ContainsRune(name, rune(os.PathSeparator)) || strings.Contains(name, "..") {
+		return clierrors.Wrap(fmt.Errorf("invalid kit name %q", name), "KIT_NAME_INVALID", clierrors.ExitValid,
+			clierrors.WithResource(name),
+			clierrors.WithRemediation("Use a simple kit name without path separators or parent directory segments."),
+		)
+	}
 	return nil
 }

--- a/cmd/kit.go
+++ b/cmd/kit.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/Naoray/scribe/internal/kit"
+	"github.com/Naoray/scribe/internal/paths"
+)
+
+type kitCreateOptions struct {
+	description string
+	skills      []string
+	registry    string
+	force       bool
+	json        bool
+}
+
+type kitCreateOutput struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	SkillsCount int    `json:"skills_count"`
+}
+
+func newKitCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kit",
+		Short: "Manage local skill kits",
+	}
+	cmd.AddCommand(newKitCreateCommand())
+	return cmd
+}
+
+func newKitCreateCommand() *cobra.Command {
+	opts := &kitCreateOptions{}
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a local skill kit",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.json = jsonFlagPassed(cmd)
+			return runKitCreate(cmd, args[0], opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.description, "description", "", "Kit description")
+	cmd.Flags().StringSliceVar(&opts.skills, "skills", nil, "Comma-separated skill names")
+	cmd.Flags().StringVar(&opts.registry, "registry", "", "Source registry for this kit")
+	cmd.Flags().BoolVar(&opts.force, "force", false, "Overwrite an existing kit")
+	cmd.Flags().BoolVar(&opts.json, "json", false, "Output machine-readable JSON")
+	return markJSONSupported(cmd)
+}
+
+func runKitCreate(cmd *cobra.Command, name string, opts *kitCreateOptions) error {
+	if opts == nil {
+		opts = &kitCreateOptions{}
+	}
+
+	scribeDir, err := paths.ScribeDir()
+	if err != nil {
+		return fmt.Errorf("resolve scribe dir: %w", err)
+	}
+	kitPath := filepath.Join(scribeDir, "kits", name+".yaml")
+
+	if !opts.force {
+		if _, err := os.Stat(kitPath); err == nil {
+			return clierrors.Wrap(fmt.Errorf("kit %q already exists", name), "KIT_EXISTS", clierrors.ExitConflict,
+				clierrors.WithResource(kitPath),
+				clierrors.WithRemediation("Use --force to overwrite the existing kit."),
+			)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("check kit path: %w", err)
+		}
+	}
+
+	k := kit.Kit{
+		Name:        name,
+		Description: opts.description,
+		Skills:      opts.skills,
+	}
+	if opts.registry != "" {
+		k.Source = &kit.Source{Registry: opts.registry}
+	}
+
+	if err := kit.Save(kitPath, &k); err != nil {
+		return err
+	}
+
+	out := kitCreateOutput{
+		Name:        name,
+		Path:        kitPath,
+		SkillsCount: len(opts.skills),
+	}
+	if opts.json {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Created kit %s at %s with %d skills\n", out.Name, out.Path, out.SkillsCount)
+	return nil
+}

--- a/cmd/kit_test.go
+++ b/cmd/kit_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/Naoray/scribe/internal/kit"
+)
+
+func TestKitCreateWritesKitYAML(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cmd := newKitCreateCommand()
+	cmd.SetArgs([]string{
+		"laravel-stack",
+		"--description", "Laravel project defaults",
+		"--skills", "eloquent,queues",
+		"--skills", "livewire",
+		"--registry", "my-org/scribe-registry",
+	})
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	kitPath := filepath.Join(home, ".scribe", "kits", "laravel-stack.yaml")
+	got, err := kit.Load(kitPath)
+	if err != nil {
+		t.Fatalf("load kit: %v", err)
+	}
+
+	if got.Name != "laravel-stack" {
+		t.Fatalf("name = %q, want laravel-stack", got.Name)
+	}
+	if got.Description != "Laravel project defaults" {
+		t.Fatalf("description = %q", got.Description)
+	}
+	if got.Source == nil || got.Source.Registry != "my-org/scribe-registry" {
+		t.Fatalf("source registry = %#v", got.Source)
+	}
+	wantSkills := []string{"eloquent", "queues", "livewire"}
+	if len(got.Skills) != len(wantSkills) {
+		t.Fatalf("skills = %#v, want %#v", got.Skills, wantSkills)
+	}
+	for i := range wantSkills {
+		if got.Skills[i] != wantSkills[i] {
+			t.Fatalf("skills = %#v, want %#v", got.Skills, wantSkills)
+		}
+	}
+
+	wantOutput := "Created kit laravel-stack at " + kitPath + " with 3 skills\n"
+	if out.String() != wantOutput {
+		t.Fatalf("output = %q, want %q", out.String(), wantOutput)
+	}
+}
+
+func TestKitCreateJSONOutput(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cmd := newKitCreateCommand()
+	cmd.SetArgs([]string{"core", "--skills", "one,two", "--json"})
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload struct {
+		Name        string `json:"name"`
+		Path        string `json:"path"`
+		SkillsCount int    `json:"skills_count"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse json output: %v\n%s", err, out.String())
+	}
+
+	if payload.Name != "core" {
+		t.Fatalf("name = %q, want core", payload.Name)
+	}
+	if payload.Path != filepath.Join(home, ".scribe", "kits", "core.yaml") {
+		t.Fatalf("path = %q", payload.Path)
+	}
+	if payload.SkillsCount != 2 {
+		t.Fatalf("skills_count = %d, want 2", payload.SkillsCount)
+	}
+}
+
+func TestKitCreateExistingFileRequiresForce(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	kitPath := filepath.Join(home, ".scribe", "kits", "core.yaml")
+	if err := os.MkdirAll(filepath.Dir(kitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(kitPath, []byte("name: core\nskills: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newKitCreateCommand()
+	cmd.SetArgs([]string{"core", "--skills", "one"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if got := clierrors.ExitCode(err); got != clierrors.ExitConflict {
+		t.Fatalf("exit = %d, want %d; err=%v", got, clierrors.ExitConflict, err)
+	}
+
+	data, err := os.ReadFile(kitPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "name: core\nskills: []\n" {
+		t.Fatalf("existing file was overwritten: %q", string(data))
+	}
+}

--- a/cmd/kit_test.go
+++ b/cmd/kit_test.go
@@ -127,3 +127,58 @@ func TestKitCreateExistingFileRequiresForce(t *testing.T) {
 		t.Fatalf("existing file was overwritten: %q", string(data))
 	}
 }
+
+func TestKitCreateForceOverwritesExistingFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	kitPath := filepath.Join(home, ".scribe", "kits", "core.yaml")
+	if err := os.MkdirAll(filepath.Dir(kitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(kitPath, []byte("name: core\nskills:\n  - old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newKitCreateCommand()
+	cmd.SetArgs([]string{"core", "--force", "--skills", "new,another"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := kit.Load(kitPath)
+	if err != nil {
+		t.Fatalf("load kit: %v", err)
+	}
+	wantSkills := []string{"new", "another"}
+	if len(got.Skills) != len(wantSkills) {
+		t.Fatalf("skills = %#v, want %#v", got.Skills, wantSkills)
+	}
+	for i := range wantSkills {
+		if got.Skills[i] != wantSkills[i] {
+			t.Fatalf("skills = %#v, want %#v", got.Skills, wantSkills)
+		}
+	}
+}
+
+func TestKitCreateRejectsInvalidNames(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tests := []string{"../outside", "/absolute", "has/slash"}
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := newKitCreateCommand()
+			cmd.SetArgs([]string{name, "--skills", "one"})
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if got := clierrors.ExitCode(err); got != clierrors.ExitValid {
+				t.Fatalf("exit = %d, want %d; err=%v", got, clierrors.ExitValid, err)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -272,6 +272,7 @@ func newRootCmd() *cobra.Command {
 		newResolveCommand(),
 		newRestoreCommand(),
 		newSkillCommand(),
+		newKitCommand(),
 		newToolsCommand(),
 		newGuideCommand(),
 		newConfigCommand(),

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "16f7a7ab",
+      "content_hash": "76923858",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe",

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "76923858",
+      "content_hash": "a2e24d4d",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe",

--- a/testdata/golden/list.legacy.json
+++ b/testdata/golden/list.legacy.json
@@ -2,7 +2,7 @@
   "packages": [],
   "skills": [
     {
-      "content_hash": "a2e24d4d",
+      "content_hash": "9b369ed6",
       "description": "Use when the user wants to install, list, sync, remove, or manage AI...",
       "managed": true,
       "name": "scribe",


### PR DESCRIPTION
## Summary
- add `scribe kit create` for scaffolding local kit YAML files
- document Kits in `SKILL.md.tmpl` and add command table coverage in `CLAUDE.md`
- update embedded skill golden hash fixtures for the docs changes

## Verification
- `go test ./...`
- `HOME=$(mktemp -d) go run ./cmd/scribe kit create core --skills one,two --json`