### PR TITLE
fix(reconcile): respect project-local skill projections

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -376,7 +376,7 @@ func snapshotDoctorSkill(cfg *config.Config, st *state.State, name string) (doct
 			if err != nil {
 				continue
 			}
-			path, err := tool.SkillPath(name)
+			path, err := tool.SkillPath(name, "")
 			if err != nil || strings.TrimSpace(path) == "" {
 				continue
 			}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -506,7 +506,7 @@ Keep daily notes and summaries.
 	}
 
 	codex := tools.CodexTool{}
-	codexPath, err := codex.SkillPath("recap")
+	codexPath, err := codex.SkillPath("recap", "")
 	if err != nil {
 		t.Fatalf("codex skill path: %v", err)
 	}
@@ -580,7 +580,7 @@ description: Keep daily notes and summaries.
 	}
 
 	codex := tools.CodexTool{}
-	codexPath, err := codex.SkillPath("recap")
+	codexPath, err := codex.SkillPath("recap", "")
 	if err != nil {
 		t.Fatalf("codex skill path: %v", err)
 	}

--- a/cmd/name_conflict_test.go
+++ b/cmd/name_conflict_test.go
@@ -166,8 +166,26 @@ func runScribeHelperWithTTYStdout(t *testing.T, home string, args []string) (str
 func scribeHelperCommand(t *testing.T, home string, args []string) *exec.Cmd {
 	t.Helper()
 	cmd := exec.Command(os.Args[0], append([]string{"-test.run=TestScribeHelperProcess", "--"}, args...)...)
-	cmd.Env = append(os.Environ(), "GO_WANT_SCRIBE_HELPER_PROCESS=1", "HOME="+home, partialFixtureEnv+"=1")
+	cmd.Dir = home
+	cmd.Env = withoutEnv(os.Environ(), "HOME", "PWD")
+	cmd.Env = append(cmd.Env, "GO_WANT_SCRIBE_HELPER_PROCESS=1", "HOME="+home, "PWD="+home, partialFixtureEnv+"=1")
 	return cmd
+}
+
+func withoutEnv(env []string, keys ...string) []string {
+	blocked := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		blocked[key] = true
+	}
+	out := env[:0]
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && blocked[key] {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 func waitExitCode(t *testing.T, cmd *exec.Cmd) int {

--- a/cmd/partial_success_test.go
+++ b/cmd/partial_success_test.go
@@ -80,7 +80,9 @@ func TestConnectInstallAllPartialSingleEnvelopeAndStateSave(t *testing.T) {
 func runScribeHelperWithHome(t *testing.T, home string, args []string) (string, string, int) {
 	t.Helper()
 	cmd := exec.Command(os.Args[0], append([]string{"-test.run=TestScribeHelperProcess", "--"}, args...)...)
-	cmd.Env = append(os.Environ(), "GO_WANT_SCRIBE_HELPER_PROCESS=1", "HOME="+home, partialFixtureEnv+"=1")
+	cmd.Dir = home
+	cmd.Env = withoutEnv(os.Environ(), "HOME", "PWD")
+	cmd.Env = append(cmd.Env, "GO_WANT_SCRIBE_HELPER_PROCESS=1", "HOME="+home, "PWD="+home, partialFixtureEnv+"=1")
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/cmd/skill_projection_repair.go
+++ b/cmd/skill_projection_repair.go
@@ -46,7 +46,7 @@ func repairSkillProjections(cfg *config.Config, st *state.State, name string) (s
 			return skillProjectionRepairResult{}, err
 		}
 		_ = tool.Uninstall(name)
-		if path, err := tool.SkillPath(name); err == nil {
+		if path, err := tool.SkillPath(name, ""); err == nil {
 			if err := os.RemoveAll(path); err != nil {
 				return skillProjectionRepairResult{}, fmt.Errorf("clear %s/%s: %w", toolName, name, err)
 			}

--- a/cmd/skill_repair.go
+++ b/cmd/skill_repair.go
@@ -30,7 +30,7 @@ func applySkillRepair(cfg *config.Config, st *state.State, name, toolName, sourc
 	if err != nil {
 		return skillRepairResult{}, err
 	}
-	path, err := tool.SkillPath(name)
+	path, err := tool.SkillPath(name, "")
 	if err != nil {
 		return skillRepairResult{}, err
 	}

--- a/cmd/skill_tools.go
+++ b/cmd/skill_tools.go
@@ -111,7 +111,7 @@ func applySkillToolSelection(cfg *config.Config, st *state.State, name string, m
 		if err := tool.Uninstall(name); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: uninstall from %s: %v\n", toolName, err)
 		}
-		skillPath, _ := tool.SkillPath(name)
+		skillPath, _ := tool.SkillPath(name, "")
 		if skillPath != "" {
 			for p := range newPathSet {
 				if strings.HasPrefix(p, skillPath) || p == skillPath {

--- a/internal/adopt/adopt_test.go
+++ b/internal/adopt/adopt_test.go
@@ -78,7 +78,7 @@ func (m *mockTool) Install(skillName, canonicalDir, projectRoot string) ([]strin
 	return []string{path}, nil
 }
 func (m *mockTool) Uninstall(skillName string) error { return m.uninstallErr }
-func (m *mockTool) SkillPath(skillName string) (string, error) {
+func (m *mockTool) SkillPath(skillName, projectRoot string) (string, error) {
 	return filepath.Join(m.name, skillName), nil
 }
 func (m *mockTool) CanonicalTarget(_ string) (string, bool) { return "", false }

--- a/internal/adopt/apply.go
+++ b/internal/adopt/apply.go
@@ -73,7 +73,7 @@ func (a *Adopter) applyOne(cand Candidate, result *Result) error {
 	// os.RemoveAll on a symlink removes the symlink, not the target — canonical
 	// store content written above is safe.
 	for _, tool := range targetTools {
-		skillPath, err := tool.SkillPath(cand.Name)
+		skillPath, err := tool.SkillPath(cand.Name, "")
 		if err != nil || skillPath == "" {
 			// Tool doesn't expose a predictable path (e.g. Gemini); skip.
 			continue

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -301,12 +301,12 @@ func inspectProjectionDrift(cfg *config.Config, skillName string, skill state.In
 		target, inspectable := tool.CanonicalTarget(canonicalDir)
 		if !inspectable {
 			opaqueTools[toolName] = true
-			if path, err := tool.SkillPath(skillName); err == nil {
+			if path, err := tool.SkillPath(skillName, ""); err == nil {
 				opaquePaths[path] = true
 			}
 			continue
 		}
-		path, err := tool.SkillPath(skillName)
+		path, err := tool.SkillPath(skillName, "")
 		if err != nil {
 			return Issue{
 				Skill:   skillName,
@@ -417,7 +417,7 @@ func inferToolName(path string, cfg *config.Config, skillName string) string {
 		if err != nil {
 			continue
 		}
-		toolPath, err := tool.SkillPath(skillName)
+		toolPath, err := tool.SkillPath(skillName, "")
 		if err == nil && toolPath == path {
 			return tool.Name()
 		}

--- a/internal/firstrun/adoption_test.go
+++ b/internal/firstrun/adoption_test.go
@@ -26,7 +26,7 @@ func (m *adoptMockTool) Name() string                             { return m.nam
 func (m *adoptMockTool) Detect() bool                             { return true }
 func (m *adoptMockTool) Install(_, _, _ string) ([]string, error) { return nil, nil }
 func (m *adoptMockTool) Uninstall(_ string) error                 { return nil }
-func (m *adoptMockTool) SkillPath(_ string) (string, error)       { return "", nil }
+func (m *adoptMockTool) SkillPath(_, _ string) (string, error)    { return "", nil }
 func (m *adoptMockTool) CanonicalTarget(_ string) (string, bool)  { return "", false }
 
 var _ tools.Tool = (*adoptMockTool)(nil)

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -42,8 +42,9 @@ type Summary struct {
 }
 
 type Engine struct {
-	Tools []tools.Tool
-	Now   func() time.Time
+	Tools       []tools.Tool
+	ProjectRoot string
+	Now         func() time.Time
 }
 
 func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
@@ -87,7 +88,7 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 						return summary, actions, err
 					}
 					summary.Removed++
-					actions = append(actions, Action{Kind: ActionRemoved, Name: name, Tool: inferToolName(path, byName, name), Path: path})
+					actions = append(actions, Action{Kind: ActionRemoved, Name: name, Tool: inferToolName(path, byName, name, e.ProjectRoot), Path: path})
 				}
 			}
 			// Wipe tracked paths — packages never project.
@@ -120,7 +121,7 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 			if !inspectable {
 				continue
 			}
-			path, err := tool.SkillPath(name, "")
+			path, err := tool.SkillPath(name, e.ProjectRoot)
 			if err != nil {
 				continue
 			}
@@ -128,7 +129,7 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 
 			if _, err := os.Lstat(path); err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
-					links, installErr := tool.Install(name, canonicalDir, "")
+					links, installErr := tool.Install(name, canonicalDir, e.ProjectRoot)
 					if installErr != nil {
 						return summary, actions, fmt.Errorf("install %s/%s: %w", toolName, name, installErr)
 					}
@@ -155,7 +156,7 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 					if err := os.RemoveAll(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
 						return summary, actions, err
 					}
-					links, installErr := tool.Install(name, canonicalDir, "")
+					links, installErr := tool.Install(name, canonicalDir, e.ProjectRoot)
 					if installErr != nil {
 						return summary, actions, fmt.Errorf("relink %s/%s: %w", toolName, name, installErr)
 					}
@@ -186,7 +187,7 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 			if path == "" {
 				continue
 			}
-			toolName := inferToolName(path, byName, name)
+			toolName := inferToolName(path, byName, name, e.ProjectRoot)
 			// A stale projection is safe to remove whenever it resolves
 			// back into the canonical store — that guarantees it was Scribe
 			// who put it there. Requiring a matching Tool in byName would
@@ -237,9 +238,9 @@ func projectionPaths(skill state.InstalledSkill) []string {
 	return append([]string(nil), skill.Paths...)
 }
 
-func inferToolName(path string, byName map[string]tools.Tool, skillName string) string {
+func inferToolName(path string, byName map[string]tools.Tool, skillName, projectRoot string) string {
 	for name, tool := range byName {
-		toolPath, err := tool.SkillPath(skillName, "")
+		toolPath, err := tool.SkillPath(skillName, projectRoot)
 		if err == nil && toolPath == path {
 			return name
 		}

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -120,7 +120,7 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 			if !inspectable {
 				continue
 			}
-			path, err := tool.SkillPath(name)
+			path, err := tool.SkillPath(name, "")
 			if err != nil {
 				continue
 			}
@@ -239,7 +239,7 @@ func projectionPaths(skill state.InstalledSkill) []string {
 
 func inferToolName(path string, byName map[string]tools.Tool, skillName string) string {
 	for name, tool := range byName {
-		toolPath, err := tool.SkillPath(skillName)
+		toolPath, err := tool.SkillPath(skillName, "")
 		if err == nil && toolPath == path {
 			return name
 		}

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -96,6 +96,50 @@ func TestReconcileUsesProjectRootForCodexProjection(t *testing.T) {
 	}
 }
 
+func TestReconcileUsesGlobalClaudeProjectionForBootstrapSkill(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	projectRoot := t.TempDir()
+
+	canonical, err := tools.WriteToStore("scribe", []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# scribe\n")}})
+	if err != nil {
+		t.Fatalf("WriteToStore: %v", err)
+	}
+	canonical, _ = filepath.EvalSymlinks(canonical)
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"scribe": {Revision: 1, Tools: []string{"claude"}, ToolsMode: state.ToolsModePinned},
+	}}
+
+	engine := reconcile.Engine{
+		Tools:       []tools.Tool{tools.ClaudeTool{}},
+		ProjectRoot: projectRoot,
+		Now:         func() time.Time { return time.Unix(1, 0).UTC() },
+	}
+	summary, actions, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Installed != 1 || summary.Removed != 0 || summary.Relinked != 0 || len(summary.Conflicts) != 0 {
+		t.Fatalf("summary = %+v, want one global install", summary)
+	}
+
+	globalPath := filepath.Join(home, ".claude", "skills", "scribe")
+	if len(actions) != 1 || actions[0].Kind != reconcile.ActionInstalled || actions[0].Path != globalPath {
+		t.Fatalf("actions = %+v, want installed global projection %s", actions, globalPath)
+	}
+	if resolved, err := filepath.EvalSymlinks(globalPath); err != nil || resolved != canonical {
+		t.Fatalf("global claude skill link = %q, %v; want %q", resolved, err, canonical)
+	}
+	projectPath := filepath.Join(projectRoot, ".claude", "skills", "scribe")
+	if _, err := os.Lstat(projectPath); !os.IsNotExist(err) {
+		t.Fatalf("project-local claude projection exists or stat failed: %v", err)
+	}
+	if got := st.Installed["scribe"].ManagedPaths; len(got) != 1 || got[0] != globalPath {
+		t.Fatalf("ManagedPaths = %v, want [%s]", got, globalPath)
+	}
+}
+
 func TestReconcileClaudeUnchangedOnSecondPass(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -44,6 +44,58 @@ func TestReconcileRepairsMissingCodexProjection(t *testing.T) {
 	}
 }
 
+func TestReconcileUsesProjectRootForCodexProjection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", os.Getenv("PATH"))
+	projectRoot := t.TempDir()
+
+	canonical, err := tools.WriteToStore("recap", []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}})
+	if err != nil {
+		t.Fatalf("WriteToStore: %v", err)
+	}
+	canonical, _ = filepath.EvalSymlinks(canonical)
+
+	projectPath := filepath.Join(projectRoot, ".codex", "skills", "recap")
+	if err := os.MkdirAll(filepath.Dir(projectPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(canonical, projectPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"recap": {
+			Revision:     1,
+			Tools:        []string{"codex"},
+			ToolsMode:    state.ToolsModePinned,
+			ManagedPaths: []string{projectPath},
+		},
+	}}
+
+	engine := reconcile.Engine{
+		Tools:       []tools.Tool{tools.CodexTool{}},
+		ProjectRoot: projectRoot,
+		Now:         func() time.Time { return time.Unix(1, 0).UTC() },
+	}
+	summary, actions, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Installed != 0 || summary.Removed != 0 || summary.Relinked != 0 || len(summary.Conflicts) != 0 {
+		t.Fatalf("summary = %+v, want no changes", summary)
+	}
+	if len(actions) != 1 || actions[0].Kind != reconcile.ActionUnchanged || actions[0].Path != projectPath {
+		t.Fatalf("actions = %+v, want unchanged project projection", actions)
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".codex", "skills", "recap")); !os.IsNotExist(err) {
+		t.Fatalf("global codex projection exists or stat failed: %v", err)
+	}
+	if got := st.Installed["recap"].ManagedPaths; len(got) != 1 || got[0] != projectPath {
+		t.Fatalf("ManagedPaths = %v, want [%s]", got, projectPath)
+	}
+}
+
 func TestReconcileClaudeUnchangedOnSecondPass(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -620,7 +620,7 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 				links, err := t.Install(installName, canonicalDir, s.ProjectRoot)
 				if err != nil {
 					if errors.Is(err, tools.ErrRealDirectoryExists) {
-						existing, pathErr := t.SkillPath(installName, "")
+						existing, pathErr := t.SkillPath(installName, s.ProjectRoot)
 						if pathErr != nil {
 							return &NameConflictError{
 								Conflict:   NameConflict{Name: installName, Tool: t.Name()},
@@ -837,7 +837,7 @@ func (s *Syncer) firstRealDirectoryConflict(name string, targetTools []tools.Too
 		if _, ok := t.CanonicalTarget(""); !ok {
 			continue
 		}
-		path, err := t.SkillPath(name, "")
+		path, err := t.SkillPath(name, s.ProjectRoot)
 		if err != nil {
 			continue
 		}

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -620,7 +620,7 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 				links, err := t.Install(installName, canonicalDir, s.ProjectRoot)
 				if err != nil {
 					if errors.Is(err, tools.ErrRealDirectoryExists) {
-						existing, pathErr := t.SkillPath(installName)
+						existing, pathErr := t.SkillPath(installName, "")
 						if pathErr != nil {
 							return &NameConflictError{
 								Conflict:   NameConflict{Name: installName, Tool: t.Name()},
@@ -837,7 +837,7 @@ func (s *Syncer) firstRealDirectoryConflict(name string, targetTools []tools.Too
 		if _, ok := t.CanonicalTarget(""); !ok {
 			continue
 		}
-		path, err := t.SkillPath(name)
+		path, err := t.SkillPath(name, "")
 		if err != nil {
 			continue
 		}

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -1015,7 +1015,7 @@ type testProjectionTool struct {
 func (t testProjectionTool) Name() string { return "test-tool" }
 
 func (t testProjectionTool) Install(skillName, canonicalDir, _ string) ([]string, error) {
-	path, err := t.SkillPath(skillName)
+	path, err := t.SkillPath(skillName, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1035,7 +1035,7 @@ func (t testProjectionTool) Install(skillName, canonicalDir, _ string) ([]string
 }
 
 func (t testProjectionTool) Uninstall(skillName string) error {
-	path, err := t.SkillPath(skillName)
+	path, err := t.SkillPath(skillName, "")
 	if err != nil {
 		return err
 	}
@@ -1044,7 +1044,7 @@ func (t testProjectionTool) Uninstall(skillName string) error {
 
 func (t testProjectionTool) Detect() bool { return true }
 
-func (t testProjectionTool) SkillPath(skillName string) (string, error) {
+func (t testProjectionTool) SkillPath(skillName, projectRoot string) (string, error) {
 	return filepath.Join(t.root, skillName), nil
 }
 

--- a/internal/tools/claude.go
+++ b/internal/tools/claude.go
@@ -62,6 +62,7 @@ func (t ClaudeTool) Uninstall(skillName string) error {
 }
 
 func (t ClaudeTool) SkillPath(skillName, projectRoot string) (string, error) {
+	projectRoot = projectionProjectRoot(skillName, projectRoot)
 	skillsDir, err := claudeSkillsDir(projectRoot)
 	if err != nil {
 		return "", err

--- a/internal/tools/claude.go
+++ b/internal/tools/claude.go
@@ -61,8 +61,8 @@ func (t ClaudeTool) Uninstall(skillName string) error {
 	return nil
 }
 
-func (t ClaudeTool) SkillPath(skillName string) (string, error) {
-	skillsDir, err := claudeSkillsDir("")
+func (t ClaudeTool) SkillPath(skillName, projectRoot string) (string, error) {
+	skillsDir, err := claudeSkillsDir(projectRoot)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/claude_test.go
+++ b/internal/tools/claude_test.go
@@ -13,7 +13,7 @@ func TestClaudeSkillPath(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	tool := ClaudeTool{}
-	got, err := tool.SkillPath("commit")
+	got, err := tool.SkillPath("commit", "")
 	if err != nil {
 		t.Fatalf("SkillPath: %v", err)
 	}

--- a/internal/tools/codex.go
+++ b/internal/tools/codex.go
@@ -61,8 +61,8 @@ func (t CodexTool) Uninstall(skillName string) error {
 	return nil
 }
 
-func (t CodexTool) SkillPath(skillName string) (string, error) {
-	skillsDir, err := codexSkillsDir("")
+func (t CodexTool) SkillPath(skillName, projectRoot string) (string, error) {
+	skillsDir, err := codexSkillsDir(projectRoot)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/codex.go
+++ b/internal/tools/codex.go
@@ -62,6 +62,7 @@ func (t CodexTool) Uninstall(skillName string) error {
 }
 
 func (t CodexTool) SkillPath(skillName, projectRoot string) (string, error) {
+	projectRoot = projectionProjectRoot(skillName, projectRoot)
 	skillsDir, err := codexSkillsDir(projectRoot)
 	if err != nil {
 		return "", err

--- a/internal/tools/command.go
+++ b/internal/tools/command.go
@@ -36,7 +36,7 @@ func (t CommandTool) Install(skillName, canonicalDir, projectRoot string) ([]str
 
 // SkillPath returns the path this tool would link for skillName, using PathTemplate.
 // Returns an error if no PathTemplate is configured (path is unknown).
-func (t CommandTool) SkillPath(skillName string) (string, error) {
+func (t CommandTool) SkillPath(skillName, projectRoot string) (string, error) {
 	if strings.TrimSpace(t.PathTemplate) == "" {
 		return "", fmt.Errorf("command tool %q: no path_template configured", t.ToolName)
 	}

--- a/internal/tools/cursor.go
+++ b/internal/tools/cursor.go
@@ -70,10 +70,14 @@ func (t CursorTool) Uninstall(skillName string) error {
 	return nil
 }
 
-func (t CursorTool) SkillPath(skillName string) (string, error) {
-	workDir, err := t.resolveWorkDir()
-	if err != nil {
-		return "", err
+func (t CursorTool) SkillPath(skillName, projectRoot string) (string, error) {
+	workDir := projectRoot
+	if workDir == "" {
+		var err error
+		workDir, err = t.resolveWorkDir()
+		if err != nil {
+			return "", err
+		}
 	}
 	mdcName := SlugifyRegistry(skillName) + ".mdc"
 	return filepath.Join(workDir, ".cursor", "rules", mdcName), nil

--- a/internal/tools/cursor.go
+++ b/internal/tools/cursor.go
@@ -71,7 +71,15 @@ func (t CursorTool) Uninstall(skillName string) error {
 }
 
 func (t CursorTool) SkillPath(skillName, projectRoot string) (string, error) {
+	projectRoot = projectionProjectRoot(skillName, projectRoot)
 	workDir := projectRoot
+	if skillName == bootstrapSkillName {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("home dir: %w", err)
+		}
+		workDir = home
+	}
 	if workDir == "" {
 		var err error
 		workDir, err = t.resolveWorkDir()

--- a/internal/tools/gemini.go
+++ b/internal/tools/gemini.go
@@ -30,7 +30,7 @@ func (t GeminiTool) Install(skillName, canonicalDir, projectRoot string) ([]stri
 
 // SkillPath is not applicable for GeminiTool — Gemini manages skill paths
 // internally via its CLI and does not expose a predictable filesystem location.
-func (t GeminiTool) SkillPath(skillName string) (string, error) {
+func (t GeminiTool) SkillPath(skillName, projectRoot string) (string, error) {
 	return "", fmt.Errorf("gemini: skill path not available (managed by gemini CLI)")
 }
 

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -29,7 +29,7 @@ type Tool interface {
 	// SkillPath returns the absolute path where this tool expects the skill
 	// symlink (or link file) to live. Used by adoption to remove the old
 	// real directory before Install replaces it with a symlink.
-	SkillPath(skillName string) (string, error)
+	SkillPath(skillName, projectRoot string) (string, error)
 	// CanonicalTarget returns the path inside canonicalDir that this tool's
 	// on-disk projection mirrors (e.g. claude → canonicalDir/SKILL.md; codex
 	// → canonicalDir itself). When ok is false, the tool manages its skills

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -55,7 +55,7 @@ func SyncTail() []Step {
 }
 
 func StepReconcileSystem(_ context.Context, b *Bag) error {
-	engine := reconcile.Engine{Tools: b.Tools}
+	engine := reconcile.Engine{Tools: b.Tools, ProjectRoot: b.ProjectRoot}
 	summary, actions, err := engine.Run(b.State)
 	if err != nil {
 		return fmt.Errorf("reconcile system: %w", err)

--- a/internal/workflow/sync_adopt_test.go
+++ b/internal/workflow/sync_adopt_test.go
@@ -117,7 +117,7 @@ func (m *mockAdoptTool) Install(skillName, _, _ string) ([]string, error) {
 	return []string{p}, nil
 }
 
-func (m *mockAdoptTool) SkillPath(skillName string) (string, error) {
+func (m *mockAdoptTool) SkillPath(skillName, projectRoot string) (string, error) {
 	return filepath.Join(m.name, skillName), nil
 }
 


### PR DESCRIPTION
## Summary
- thread projectRoot through SkillPath so Claude/Codex path lookups can resolve project-local projections
- make reconcile install/relink against the workflow project root instead of recreating global links
- add a regression test for project-local Codex reconcile and isolate subprocess tests from ambient project scope

## Tests
- go test ./...