### PR TITLE
fix(sync): kit-resolved set drives symlink emit (v1.0.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## v1.0.9 — 2026-05-03
+
+### Fixed
+- **`scribe sync` now projects only kit-resolved skills** — previously, all installed skills were symlinked into `project/.claude/skills/` and `project/.codex/skills/` regardless of kit membership, producing ~125 projections instead of the expected ~32. `scribe sync` now filters the skill set through the same kit resolver used by `scribe show` and the agent budget check. Skills installed globally but not listed in any project kit are no longer projected into that project.
+
 ## v1.0.5 — 2026-05-02
 
 ### Breaking

--- a/cmd/add_shared.go
+++ b/cmd/add_shared.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
+	"github.com/Naoray/scribe/internal/workflow"
 )
 
 var githubURLInDescriptionRE = regexp.MustCompile(`https?://github\.com/[^\s)]+`)
@@ -294,10 +295,19 @@ func finishAdd(ctx context.Context, results []addResult, targetRepo string, st *
 
 // autoSync runs a sync for the target registry after adding skills.
 func autoSync(ctx context.Context, targetRepo string, st *state.State, client *gh.Client, targets []tools.Tool, useJSON bool) bool {
+	projectRoot := resolveCurrentProjectRoot()
+	var kitFilter []string
+	var kitFilterEnabled bool
+	if projectRoot != "" && st != nil {
+		kitFilter, kitFilterEnabled = workflow.ResolveKitFilter(st)
+	}
+
 	syncer := &sync.Syncer{
-		Client:      sync.WrapGitHubClient(client),
-		Tools:       targets,
-		ProjectRoot: resolveCurrentProjectRoot(),
+		Client:           sync.WrapGitHubClient(client),
+		Tools:            targets,
+		ProjectRoot:      projectRoot,
+		KitFilter:        kitFilter,
+		KitFilterEnabled: kitFilterEnabled,
 		Emit: func(msg any) {
 			if useJSON {
 				return

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -42,9 +42,11 @@ type Summary struct {
 }
 
 type Engine struct {
-	Tools       []tools.Tool
-	ProjectRoot string
-	Now         func() time.Time
+	Tools            []tools.Tool
+	ProjectRoot      string
+	KitFilter        []string
+	KitFilterEnabled bool
+	Now              func() time.Time
 }
 
 func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
@@ -72,6 +74,18 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 		return summary, nil, pkgErr
 	}
 
+	kitAllowed := func(name string) bool {
+		if !e.KitFilterEnabled {
+			return true
+		}
+		for _, n := range e.KitFilter {
+			if n == name {
+				return true
+			}
+		}
+		return false
+	}
+
 	for name, skill := range st.Installed {
 		if skill.IsPackage() {
 			// Non-projection invariant: packages own their own wiring.
@@ -97,6 +111,10 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 				skill.ManagedPaths = nil
 				st.Installed[name] = skill
 			}
+			continue
+		}
+
+		if !kitAllowed(name) {
 			continue
 		}
 

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -370,6 +370,49 @@ func TestReconcileSkipsPackages(t *testing.T) {
 	}
 }
 
+func TestRun_KitFilterEnabled_BlocksNonKitProjection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	storeDir := filepath.Join(home, ".scribe", "skills")
+	for _, name := range []string{"recap", "debugger", "coder"} {
+		dir := filepath.Join(storeDir, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# "+name), 0o644); err != nil {
+			t.Fatalf("write skill: %v", err)
+		}
+	}
+
+	projectRoot := t.TempDir()
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"recap":    {Tools: []string{"claude"}},
+		"debugger": {Tools: []string{"claude"}},
+		"coder":    {Tools: []string{"claude"}},
+	}}
+
+	engine := &reconcile.Engine{
+		Tools:            []tools.Tool{tools.ClaudeTool{}},
+		ProjectRoot:      projectRoot,
+		KitFilter:        []string{"recap", "coder"},
+		KitFilterEnabled: true,
+	}
+	if _, _, err := engine.Run(st); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(projectRoot, ".claude", "skills", "recap")); err != nil {
+		t.Errorf("recap symlink missing: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(projectRoot, ".claude", "skills", "coder")); err != nil {
+		t.Errorf("coder symlink missing: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(projectRoot, ".claude", "skills", "debugger")); err == nil {
+		t.Error("debugger symlink should not exist (not in kit)")
+	}
+}
+
 func TestReconcileRemovesStalePackageProjection(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -53,6 +53,12 @@ type Syncer struct {
 	// Used by `scribe install` to install specific skills.
 	SkillFilter []string
 
+	// KitFilter, if non-nil, restricts symlink emission to skills resolved by
+	// the project's kit set. Empty/nil means no kit filtering (legacy behavior).
+	// Computed from the project file by StepResolveKitFilter so `scribe sync`
+	// matches `scribe show` output.
+	KitFilter []string
+
 	// SkipMissing prevents installing skills that are not yet locally installed.
 	// When true, StatusMissing skills are silently skipped — only updates and
 	// removals are processed. Set by `scribe sync` to implement the opt-in
@@ -284,6 +290,19 @@ func (s *Syncer) Run(ctx context.Context, teamRepo string, st *state.State) erro
 	if len(s.SkillFilter) > 0 {
 		allowed := make(map[string]bool, len(s.SkillFilter))
 		for _, n := range s.SkillFilter {
+			allowed[n] = true
+		}
+		filtered := statuses[:0]
+		for _, sk := range statuses {
+			if allowed[sk.Name] {
+				filtered = append(filtered, sk)
+			}
+		}
+		statuses = filtered
+	}
+	if len(s.KitFilter) > 0 {
+		allowed := make(map[string]bool, len(s.KitFilter))
+		for _, n := range s.KitFilter {
 			allowed[n] = true
 		}
 		filtered := statuses[:0]

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -57,7 +57,8 @@ type Syncer struct {
 	// the project's kit set. Empty/nil means no kit filtering (legacy behavior).
 	// Computed from the project file by StepResolveKitFilter so `scribe sync`
 	// matches `scribe show` output.
-	KitFilter []string
+	KitFilter        []string
+	KitFilterEnabled bool
 
 	// SkipMissing prevents installing skills that are not yet locally installed.
 	// When true, StatusMissing skills are silently skipped — only updates and
@@ -300,7 +301,7 @@ func (s *Syncer) Run(ctx context.Context, teamRepo string, st *state.State) erro
 		}
 		statuses = filtered
 	}
-	if len(s.KitFilter) > 0 {
+	if s.KitFilterEnabled {
 		allowed := make(map[string]bool, len(s.KitFilter))
 		for _, n := range s.KitFilter {
 			allowed[n] = true

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -84,12 +84,13 @@ func TestRun_KitFilterLimitsProjection(t *testing.T) {
 	}
 
 	syncer := &sync.Syncer{
-		Client:      &syncTestFetcher{},
-		Provider:    prov,
-		Tools:       []tools.Tool{tools.ClaudeTool{}},
-		ProjectRoot: projectRoot,
-		KitFilter:   []string{"recap", "coder"},
-		SkipMissing: false,
+		Client:           &syncTestFetcher{},
+		Provider:         prov,
+		Tools:            []tools.Tool{tools.ClaudeTool{}},
+		ProjectRoot:      projectRoot,
+		KitFilter:        []string{"recap", "coder"},
+		KitFilterEnabled: true,
+		SkipMissing:      false,
 	}
 	st := &state.State{Installed: make(map[string]state.InstalledSkill)}
 

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -51,6 +51,77 @@ func (f *syncTestFetcher) GetTree(ctx context.Context, owner, repo, ref string) 
 	return nil, nil
 }
 
+// mockProvider implements provider.Provider for tests.
+type mockProvider struct {
+	entries []manifest.Entry
+	files   []tools.SkillFile
+}
+
+func (m *mockProvider) Discover(_ context.Context, repo string) (*provider.DiscoverResult, error) {
+	return &provider.DiscoverResult{Entries: m.entries, IsTeam: true}, nil
+}
+
+func (m *mockProvider) Fetch(_ context.Context, entry manifest.Entry) ([]provider.File, error) {
+	out := make([]provider.File, len(m.files))
+	for i, f := range m.files {
+		out[i] = provider.File{Path: f.Path, Content: f.Content}
+	}
+	return out, nil
+}
+
+func TestRun_KitFilterLimitsProjection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	projectRoot := t.TempDir()
+
+	prov := &mockProvider{
+		entries: []manifest.Entry{
+			{Name: "recap", Source: "github:acme/skills@main"},
+			{Name: "debugger", Source: "github:acme/skills@main"},
+			{Name: "coder", Source: "github:acme/skills@main"},
+		},
+		files: []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# skill\n")}},
+	}
+
+	syncer := &sync.Syncer{
+		Client:      &syncTestFetcher{},
+		Provider:    prov,
+		Tools:       []tools.Tool{tools.ClaudeTool{}},
+		ProjectRoot: projectRoot,
+		KitFilter:   []string{"recap", "coder"},
+		SkipMissing: false,
+	}
+	st := &state.State{Installed: make(map[string]state.InstalledSkill)}
+
+	if err := syncer.Run(context.Background(), "acme/skills", st); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, ok := st.Installed["recap"]; !ok {
+		t.Error("recap should be installed (in kit)")
+	}
+	if _, ok := st.Installed["coder"]; !ok {
+		t.Error("coder should be installed (in kit)")
+	}
+	if _, ok := st.Installed["debugger"]; ok {
+		t.Error("debugger should NOT be installed (not in kit)")
+	}
+
+	recapLink := filepath.Join(projectRoot, ".claude", "skills", "recap")
+	coderLink := filepath.Join(projectRoot, ".claude", "skills", "coder")
+	debuggerLink := filepath.Join(projectRoot, ".claude", "skills", "debugger")
+
+	if _, err := os.Lstat(recapLink); err != nil {
+		t.Errorf("recap symlink missing: %v", err)
+	}
+	if _, err := os.Lstat(coderLink); err != nil {
+		t.Errorf("coder symlink missing: %v", err)
+	}
+	if _, err := os.Lstat(debuggerLink); err == nil {
+		t.Error("debugger symlink should not exist")
+	}
+}
+
 func TestRunWithDiff_DoesNotOverwriteTargetReadme(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -37,7 +37,8 @@ type Bag struct {
 	// KitFilter is populated by StepResolveKitFilter from the project's
 	// .scribe.yaml. When non-nil, StepSyncSkills passes it to the Syncer so
 	// only kit-resolved skills are projected into the project's tool dirs.
-	KitFilter []string
+	KitFilter        []string
+	KitFilterEnabled bool
 
 	// Populated by steps
 	Config      *config.Config

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -34,6 +34,11 @@ type Bag struct {
 	// are installed. Nil means no filter (all eligible skills processed).
 	SkillFilter []string
 
+	// KitFilter is populated by StepResolveKitFilter from the project's
+	// .scribe.yaml. When non-nil, StepSyncSkills passes it to the Syncer so
+	// only kit-resolved skills are projected into the project's tool dirs.
+	KitFilter []string
+
 	// Populated by steps
 	Config      *config.Config
 	State       *state.State

--- a/internal/workflow/connect.go
+++ b/internal/workflow/connect.go
@@ -56,6 +56,7 @@ func connectInstallAllTail() []Step {
 		{Name: "SetSingleRepo", Fn: StepSetSingleRepo},
 		{Name: "ResolveTools", Fn: StepResolveTools},
 		{Name: "ResolveProjectRoot", Fn: StepResolveProjectRoot},
+		{Name: "ResolveKitFilter", Fn: StepResolveKitFilter},
 		{Name: "SyncSkills", Fn: StepConnectSyncError},
 	}
 }

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -341,6 +341,7 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 		ForceBudget: b.ForceBudget,
 		AliasName:   b.AliasName,
 		SkillFilter: b.SkillFilter,
+		KitFilter:   b.KitFilter,
 		ProjectRoot: b.ProjectRoot,
 		// Skip missing skills when no explicit filter/--all: scribe sync only updates
 		// what's already installed. scribe install sets SkillFilter or InstallAllFlag

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"charm.land/huh/v2"
 	"github.com/mattn/go-isatty"
@@ -14,6 +15,8 @@ import (
 	"github.com/Naoray/scribe/internal/app"
 	"github.com/Naoray/scribe/internal/config"
 	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/kit"
+	"github.com/Naoray/scribe/internal/paths"
 	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/reconcile"
@@ -34,6 +37,7 @@ func SyncSteps() []Step {
 		{"ResolveFormatter", StepResolveFormatter},
 		{"ResolveTools", StepResolveTools},
 		{"ResolveProjectRoot", StepResolveProjectRoot},
+		{"ResolveKitFilter", StepResolveKitFilter},
 		{"EnsureScribeAgent", StepEnsureScribeAgent},
 		{"Adopt", StepAdopt},
 		{"ReconcilePre", StepReconcileSystem},
@@ -48,6 +52,7 @@ func SyncTail() []Step {
 		{"ResolveFormatter", StepResolveFormatter},
 		{"ResolveTools", StepResolveTools},
 		{"ResolveProjectRoot", StepResolveProjectRoot},
+		{"ResolveKitFilter", StepResolveKitFilter},
 		{"EnsureScribeAgent", StepEnsureScribeAgent},
 		{"SyncSkills", StepSyncSkills},
 		{"ReconcilePost", StepReconcileSystem},
@@ -90,6 +95,51 @@ func StepResolveProjectRoot(_ context.Context, b *Bag) error {
 		return nil
 	}
 	b.ProjectRoot = filepath.Dir(projectFile)
+	return nil
+}
+
+// StepResolveKitFilter loads the project's .scribe.yaml and resolves its kit
+// references against the user's kit library, leaving the resolved skill names
+// on b.KitFilter. All errors are non-fatal: a missing or malformed project
+// file leaves b.KitFilter nil so the syncer applies no kit filtering and
+// behaves like legacy global sync.
+func StepResolveKitFilter(_ context.Context, b *Bag) error {
+	if b.ProjectRoot == "" || b.State == nil {
+		return nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+	projectPath, err := projectfile.Find(wd)
+	if err != nil || projectPath == "" {
+		return nil
+	}
+	pf, err := projectfile.Load(projectPath)
+	if err != nil {
+		return nil
+	}
+	scribeDir, err := paths.ScribeDir()
+	if err != nil {
+		return nil
+	}
+	kits, err := kit.LoadAll(filepath.Join(scribeDir, "kits"))
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(b.State.Installed))
+	for name, installed := range b.State.Installed {
+		if installed.Kind == state.KindPackage {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	resolved, err := kit.Resolve(pf, kits, names)
+	if err != nil {
+		return nil
+	}
+	b.KitFilter = resolved
 	return nil
 }
 

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -60,7 +60,12 @@ func SyncTail() []Step {
 }
 
 func StepReconcileSystem(_ context.Context, b *Bag) error {
-	engine := reconcile.Engine{Tools: b.Tools, ProjectRoot: b.ProjectRoot}
+	engine := reconcile.Engine{
+		Tools:            b.Tools,
+		ProjectRoot:      b.ProjectRoot,
+		KitFilter:        b.KitFilter,
+		KitFilterEnabled: b.KitFilterEnabled,
+	}
 	summary, actions, err := engine.Run(b.State)
 	if err != nil {
 		return fmt.Errorf("reconcile system: %w", err)
@@ -140,6 +145,7 @@ func StepResolveKitFilter(_ context.Context, b *Bag) error {
 		return nil
 	}
 	b.KitFilter = resolved
+	b.KitFilterEnabled = true
 	return nil
 }
 
@@ -340,9 +346,10 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 		TrustAll:    b.TrustAllFlag,
 		ForceBudget: b.ForceBudget,
 		AliasName:   b.AliasName,
-		SkillFilter: b.SkillFilter,
-		KitFilter:   b.KitFilter,
-		ProjectRoot: b.ProjectRoot,
+		SkillFilter:      b.SkillFilter,
+		KitFilter:        b.KitFilter,
+		KitFilterEnabled: b.KitFilterEnabled,
+		ProjectRoot:      b.ProjectRoot,
 		// Skip missing skills when no explicit filter/--all: scribe sync only updates
 		// what's already installed. scribe install sets SkillFilter or InstallAllFlag
 		// to opt-in to installing new skills.

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -103,6 +103,46 @@ func StepResolveProjectRoot(_ context.Context, b *Bag) error {
 	return nil
 }
 
+// ResolveKitFilter resolves the kit-scoped skill set for the current working
+// directory. Returns the allowed skill names and whether a project file was
+// found. All errors are non-fatal; a missing or malformed project file returns
+// (nil, false) so callers fall back to global behavior.
+func ResolveKitFilter(st *state.State) (filter []string, enabled bool) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, false
+	}
+	projectPath, err := projectfile.Find(wd)
+	if err != nil || projectPath == "" {
+		return nil, false
+	}
+	pf, err := projectfile.Load(projectPath)
+	if err != nil {
+		return nil, false
+	}
+	scribeDir, err := paths.ScribeDir()
+	if err != nil {
+		return nil, false
+	}
+	kits, err := kit.LoadAll(filepath.Join(scribeDir, "kits"))
+	if err != nil {
+		return nil, false
+	}
+	names := make([]string, 0, len(st.Installed))
+	for name, installed := range st.Installed {
+		if installed.Kind == state.KindPackage {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	resolved, err := kit.Resolve(pf, kits, names)
+	if err != nil {
+		return nil, false
+	}
+	return resolved, true
+}
+
 // StepResolveKitFilter loads the project's .scribe.yaml and resolves its kit
 // references against the user's kit library, leaving the resolved skill names
 // on b.KitFilter. All errors are non-fatal: a missing or malformed project
@@ -112,40 +152,7 @@ func StepResolveKitFilter(_ context.Context, b *Bag) error {
 	if b.ProjectRoot == "" || b.State == nil {
 		return nil
 	}
-	wd, err := os.Getwd()
-	if err != nil {
-		return nil
-	}
-	projectPath, err := projectfile.Find(wd)
-	if err != nil || projectPath == "" {
-		return nil
-	}
-	pf, err := projectfile.Load(projectPath)
-	if err != nil {
-		return nil
-	}
-	scribeDir, err := paths.ScribeDir()
-	if err != nil {
-		return nil
-	}
-	kits, err := kit.LoadAll(filepath.Join(scribeDir, "kits"))
-	if err != nil {
-		return nil
-	}
-	names := make([]string, 0, len(b.State.Installed))
-	for name, installed := range b.State.Installed {
-		if installed.Kind == state.KindPackage {
-			continue
-		}
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	resolved, err := kit.Resolve(pf, kits, names)
-	if err != nil {
-		return nil
-	}
-	b.KitFilter = resolved
-	b.KitFilterEnabled = true
+	b.KitFilter, b.KitFilterEnabled = ResolveKitFilter(b.State)
 	return nil
 }
 

--- a/internal/workflow/sync_test.go
+++ b/internal/workflow/sync_test.go
@@ -110,6 +110,46 @@ func TestStepResolveKitFilter_WithProjectFile(t *testing.T) {
 	if len(b.KitFilter) != 1 || b.KitFilter[0] != "recap" {
 		t.Fatalf("KitFilter = %v, want [recap]", b.KitFilter)
 	}
+	if !b.KitFilterEnabled {
+		t.Fatal("KitFilterEnabled should be true after kit resolution")
+	}
+}
+
+func TestStepResolveKitFilter_EmptyKitResolvesZeroSkills(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projectDir := t.TempDir()
+	// .scribe.yaml lists a kit, but that kit has no skills
+	pfContent := "kits:\n  - empty-kit\n"
+	if err := os.WriteFile(filepath.Join(projectDir, projectfile.Filename), []byte(pfContent), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+	kitsDir := filepath.Join(home, ".scribe", "kits")
+	if err := os.MkdirAll(kitsDir, 0o755); err != nil {
+		t.Fatalf("mkdir kits: %v", err)
+	}
+	// Kit exists but has no skills
+	if err := os.WriteFile(filepath.Join(kitsDir, "empty-kit.yaml"), []byte("name: empty-kit\nskills: []\n"), 0o644); err != nil {
+		t.Fatalf("write kit: %v", err)
+	}
+	t.Chdir(projectDir)
+
+	b := &Bag{
+		ProjectRoot: projectDir,
+		State: &state.State{Installed: map[string]state.InstalledSkill{
+			"recap": {},
+		}},
+	}
+	if err := StepResolveKitFilter(context.Background(), b); err != nil {
+		t.Fatalf("StepResolveKitFilter: %v", err)
+	}
+	if !b.KitFilterEnabled {
+		t.Fatal("KitFilterEnabled should be true when project file exists")
+	}
+	if len(b.KitFilter) != 0 {
+		t.Fatalf("KitFilter = %v, want [] (empty kit)", b.KitFilter)
+	}
 }
 
 func TestStepResolveKitFilter_NoProjectFile(t *testing.T) {

--- a/internal/workflow/sync_test.go
+++ b/internal/workflow/sync_test.go
@@ -2,9 +2,13 @@ package workflow
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/projectfile"
+	"github.com/Naoray/scribe/internal/state"
 )
 
 func TestStepFilterRegistries_OnlyEnabled(t *testing.T) {
@@ -64,5 +68,69 @@ func TestStepFilterRegistries_WithFilterFunc(t *testing.T) {
 	}
 	if b.Repos[0] != "acme/team-skills" {
 		t.Errorf("repos[0]: got %q, want %q", b.Repos[0], "acme/team-skills")
+	}
+}
+
+func TestStepResolveKitFilter_WithProjectFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create project dir with .scribe.yaml referencing test-kit
+	projectDir := t.TempDir()
+	pfContent := "kits:\n  - test-kit\n"
+	if err := os.WriteFile(filepath.Join(projectDir, projectfile.Filename), []byte(pfContent), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+
+	// Create ~/.scribe/kits/test-kit.yaml with skills: [recap]
+	kitsDir := filepath.Join(home, ".scribe", "kits")
+	if err := os.MkdirAll(kitsDir, 0o755); err != nil {
+		t.Fatalf("mkdir kits: %v", err)
+	}
+	kitContent := "name: test-kit\nskills:\n  - recap\n"
+	if err := os.WriteFile(filepath.Join(kitsDir, "test-kit.yaml"), []byte(kitContent), 0o644); err != nil {
+		t.Fatalf("write kit file: %v", err)
+	}
+
+	// Change into the project dir so projectfile.Find(wd) finds .scribe.yaml
+	t.Chdir(projectDir)
+
+	b := &Bag{
+		ProjectRoot: projectDir,
+		State: &state.State{Installed: map[string]state.InstalledSkill{
+			"recap":    {},
+			"debugger": {},
+		}},
+	}
+
+	if err := StepResolveKitFilter(context.Background(), b); err != nil {
+		t.Fatalf("StepResolveKitFilter: %v", err)
+	}
+
+	if len(b.KitFilter) != 1 || b.KitFilter[0] != "recap" {
+		t.Fatalf("KitFilter = %v, want [recap]", b.KitFilter)
+	}
+}
+
+func TestStepResolveKitFilter_NoProjectFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	emptyDir := t.TempDir()
+	t.Chdir(emptyDir)
+
+	b := &Bag{
+		ProjectRoot: "", // no project scope
+		State: &state.State{Installed: map[string]state.InstalledSkill{
+			"recap": {},
+		}},
+	}
+
+	if err := StepResolveKitFilter(context.Background(), b); err != nil {
+		t.Fatalf("StepResolveKitFilter: %v", err)
+	}
+
+	if b.KitFilter != nil {
+		t.Fatalf("KitFilter = %v, want nil (no project scope)", b.KitFilter)
 	}
 }


### PR DESCRIPTION
## Summary
- `scribe sync` was writing symlinks for ALL installed skills into `project/.claude/skills/` and `project/.codex/skills/`, ignoring the kit-resolved set
- Root cause: `syncer.Run()` iterated the full registry manifest catalog; the kit filter used by `scribe show` and the budget check was never applied to the symlink emit loop
- Fix: add `KitFilter []string` to `Syncer`, computed in a new `StepResolveKitFilter` workflow step that reuses the same `kit.Resolve()` call as `scribe show`

## Repro (before fix)
1. cd to a project with `.scribe.yaml` listing 5 kits (~32 skills)
2. `rm -rf .claude/skills .codex/skills && scribe sync`
3. `ls .claude/skills | wc -l` -> 125 (wrong)
4. `scribe show | grep -c '^ '` -> 32 (correct)

## After fix
Step 3 produces 32, matching `scribe show`.

## Test plan
- [ ] `go test ./internal/sync/... -run TestRun_KitFilterLimitsProjection` passes
- [ ] `go test ./internal/workflow/... -run TestStepResolveKitFilter` passes
- [ ] `go test ./...` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)