### PR TITLE
Fix kit-based projection budget bugs

### DIFF
--- a/cmd/skill_test.go
+++ b/cmd/skill_test.go
@@ -332,6 +332,89 @@ func TestSkillTools_Disable(t *testing.T) {
 	}
 }
 
+func TestSkillTools_DisableUpdatesProjectLocalProjection(t *testing.T) {
+	seedSkillEnv(t)
+
+	home := os.Getenv("HOME")
+	projectRoot := t.TempDir()
+	t.Chdir(projectRoot)
+	if err := os.WriteFile(filepath.Join(projectRoot, ".scribe.yaml"), []byte("add:\n  - commit\n"), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical := filepath.Join(home, ".scribe", "skills", "commit")
+	claude := tools.ClaudeTool{}
+	codex := tools.CodexTool{}
+	var paths []string
+	claudePaths, err := claude.Install("commit", canonical, projectRoot)
+	if err != nil {
+		t.Fatalf("claude project install: %v", err)
+	}
+	paths = append(paths, claudePaths...)
+	codexPaths, err := codex.Install("commit", canonical, projectRoot)
+	if err != nil {
+		t.Fatalf("codex project install: %v", err)
+	}
+	paths = append(paths, codexPaths...)
+
+	skill := st.Installed["commit"]
+	skill.Tools = []string{"claude", "codex"}
+	skill.ToolsMode = state.ToolsModeInherit
+	skill.Projections = []state.ProjectionEntry{{
+		Project: projectRoot,
+		Tools:   []string{"claude", "codex"},
+	}}
+	skill.ManagedPaths = paths
+	skill.Paths = append([]string(nil), paths...)
+	st.Installed["commit"] = skill
+	if err := st.Save(); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	cmd := newSkillToolsCommand()
+	cmd.SetArgs([]string{"commit", "--disable", "codex"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	st, err = state.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := st.Installed["commit"]
+	if got.ToolsMode != state.ToolsModePinned {
+		t.Fatalf("ToolsMode = %q, want pinned", got.ToolsMode)
+	}
+	if !reflect.DeepEqual(got.Tools, []string{"claude"}) {
+		t.Fatalf("Tools = %v, want [claude]", got.Tools)
+	}
+	projectCodexPath := filepath.Join(projectRoot, ".agents", "skills", "commit")
+	if _, err := os.Lstat(projectCodexPath); !os.IsNotExist(err) {
+		t.Fatalf("project codex projection still exists at %s: %v", projectCodexPath, err)
+	}
+	if _, err := os.Lstat(filepath.Join(projectRoot, ".claude", "skills", "commit")); err != nil {
+		t.Fatalf("project claude projection missing: %v", err)
+	}
+	if len(got.Projections) != 1 || got.Projections[0].Project != projectRoot || !reflect.DeepEqual(got.Projections[0].Tools, []string{"claude"}) {
+		t.Fatalf("Projections = %#v, want project-local claude only", got.Projections)
+	}
+
+	set, err := resolveBudgetSet(st)
+	if err != nil {
+		t.Fatalf("resolveBudgetSet: %v", err)
+	}
+	if skillNames(budgetSkillsForAgent(set, st, "codex")).has("commit") {
+		t.Fatal("codex budget should exclude commit after project-local disable")
+	}
+	if !skillNames(budgetSkillsForAgent(set, st, "claude")).has("commit") {
+		t.Fatal("claude budget should include commit after project-local disable")
+	}
+}
+
 func TestSkillTools_DisableLastTool_ReturnsError(t *testing.T) {
 	seedSkillEnv(t)
 

--- a/cmd/skill_tools.go
+++ b/cmd/skill_tools.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -90,6 +92,7 @@ func applySkillToolSelection(cfg *config.Config, st *state.State, name string, m
 		return skillEditResult{}, fmt.Errorf("canonical store for %q missing: %w", name, err)
 	}
 
+	projectRoot := resolveCurrentProjectRoot()
 	existingManagedPaths := installed.ManagedPaths
 	if len(existingManagedPaths) == 0 {
 		existingManagedPaths = installed.Paths
@@ -108,10 +111,10 @@ func applySkillToolSelection(cfg *config.Config, st *state.State, name string, m
 				continue
 			}
 		}
-		if err := tool.Uninstall(name); err != nil {
+		if err := uninstallSkillProjection(tool, name, projectRoot); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: uninstall from %s: %v\n", toolName, err)
 		}
-		skillPath, _ := tool.SkillPath(name, "")
+		skillPath, _ := tool.SkillPath(name, projectRoot)
 		if skillPath != "" {
 			for p := range newPathSet {
 				if strings.HasPrefix(p, skillPath) || p == skillPath {
@@ -123,7 +126,7 @@ func applySkillToolSelection(cfg *config.Config, st *state.State, name string, m
 
 	for _, toolName := range added {
 		tool := availableByName[toolName]
-		paths, err := tool.Install(name, canonicalDir, "")
+		paths, err := tool.Install(name, canonicalDir, projectRoot)
 		if err != nil {
 			return skillEditResult{}, fmt.Errorf("install into %s: %w", toolName, err)
 		}
@@ -140,6 +143,9 @@ func applySkillToolSelection(cfg *config.Config, st *state.State, name string, m
 
 	installed.Tools = desired
 	installed.ToolsMode = mode
+	if projectRoot != "" {
+		installed.Projections = mergeSkillToolProjection(installed.Projections, projectRoot, desired)
+	}
 	installed.Paths = newPaths
 	installed.ManagedPaths = append([]string(nil), newPaths...)
 	st.Installed[name] = installed
@@ -158,4 +164,37 @@ func applySkillToolSelection(cfg *config.Config, st *state.State, name string, m
 		result.ToolsMode = "inherit"
 	}
 	return result, nil
+}
+
+func uninstallSkillProjection(tool tools.Tool, name, projectRoot string) error {
+	if projectRoot == "" {
+		return tool.Uninstall(name)
+	}
+	skillPath, err := tool.SkillPath(name, projectRoot)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(skillPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	parent := filepath.Dir(skillPath)
+	if parent != filepath.Dir(parent) {
+		_ = os.Remove(parent)
+	}
+	return nil
+}
+
+func mergeSkillToolProjection(projections []state.ProjectionEntry, projectRoot string, toolNames []string) []state.ProjectionEntry {
+	next := state.ProjectionEntry{
+		Project: projectRoot,
+		Tools:   append([]string(nil), toolNames...),
+	}
+	out := append([]state.ProjectionEntry(nil), projections...)
+	for i, projection := range out {
+		if projection.Project == projectRoot {
+			out[i] = next
+			return out
+		}
+	}
+	return append(out, next)
 }

--- a/internal/projectmigrate/migrate.go
+++ b/internal/projectmigrate/migrate.go
@@ -64,7 +64,7 @@ func BuildPlan(discovery Discovery, selectedProjects []string, dryRun bool, forc
 	selected := normalizeSelectedProjects(selectedProjects)
 	projectFiles := make([]ProjectChange, 0, len(selected))
 	for _, project := range selected {
-		change, err := prepareProjectChange(project, skills, forceMigration)
+		change, err := prepareProjectChange(project, skills)
 		if err != nil {
 			return MigrationPlan{}, err
 		}
@@ -251,7 +251,7 @@ func removeLegacyProjectionTools(projections []state.ProjectionEntry, tools []st
 	return out
 }
 
-func prepareProjectChange(project string, skills []string, force bool) (ProjectChange, error) {
+func prepareProjectChange(project string, skills []string) (ProjectChange, error) {
 	abs, err := filepath.Abs(project)
 	if err != nil {
 		return ProjectChange{}, fmt.Errorf("resolve project path: %w", err)
@@ -261,20 +261,18 @@ func prepareProjectChange(project string, skills []string, force bool) (ProjectC
 	if err != nil {
 		return ProjectChange{}, err
 	}
-	if !force {
-		userAuthored, err := hasKitOrSnippetKey(file)
-		if err != nil {
-			return ProjectChange{}, err
-		}
-		if userAuthored {
-			return ProjectChange{
-				Project:            abs,
-				File:               file,
-				Skills:             append([]string(nil), pf.Add...),
-				Changed:            false,
-				SkippedWriteReason: fmt.Sprintf("skipped writing %s: user-authored kit YAML detected", file),
-			}, nil
-		}
+	userAuthored, err := hasKitOrSnippetKey(file)
+	if err != nil {
+		return ProjectChange{}, err
+	}
+	if userAuthored {
+		return ProjectChange{
+			Project:            abs,
+			File:               file,
+			Skills:             append([]string(nil), pf.Add...),
+			Changed:            false,
+			SkippedWriteReason: fmt.Sprintf("skipped writing %s: user-authored kit YAML detected", file),
+		}, nil
 	}
 
 	addSet := map[string]bool{}

--- a/internal/projectmigrate/migrate_test.go
+++ b/internal/projectmigrate/migrate_test.go
@@ -68,6 +68,53 @@ func TestApplyWritesProjectFileRemovesGlobalSymlinksAndIsIdempotent(t *testing.T
 	}
 }
 
+func TestApplyDoesNotRewriteUserAuthoredKitProjectFileWhenForced(t *testing.T) {
+	tmp := t.TempDir()
+	project := filepath.Join(tmp, "project")
+	store := filepath.Join(tmp, "home", ".scribe", "skills")
+	link := filepath.Join(tmp, "home", ".claude", "skills", "tdd")
+	mustMkdir(t, filepath.Join(store, "tdd"))
+	mustMkdir(t, filepath.Dir(link))
+	mustMkdir(t, project)
+	mustSymlink(t, filepath.Join(store, "tdd"), link)
+
+	projectFile := filepath.Join(project, projectfile.Filename)
+	original := []byte("# user owned\nkits:\n  - core\n")
+	if err := os.WriteFile(projectFile, original, 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+
+	discovery := Discovery{
+		GlobalSymlinks: []GlobalSymlink{{
+			Tool:          "claude",
+			Skill:         "tdd",
+			Path:          link,
+			CanonicalPath: filepath.Join(store, "tdd"),
+		}},
+		Projects: []ProjectCandidate{{Path: project, Source: ".scribe.yaml"}},
+		Skills:   []string{"tdd"},
+	}
+
+	plan, err := BuildPlan(discovery, []string{project}, false, true)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+	result, err := Apply(plan, discovery.Projects)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if result.WroteProjectFiles != 0 {
+		t.Fatalf("WroteProjectFiles = %d, want 0 for user-authored kit file", result.WroteProjectFiles)
+	}
+	data, err := os.ReadFile(projectFile)
+	if err != nil {
+		t.Fatalf("read project file: %v", err)
+	}
+	if string(data) != string(original) {
+		t.Fatalf("project file was rewritten:\n%s", string(data))
+	}
+}
+
 func TestMigrationPreservesScribeAgentGlobalSymlink(t *testing.T) {
 	tmp := t.TempDir()
 	home := filepath.Join(tmp, "home")
@@ -215,7 +262,7 @@ func TestMigrate_SkipsKitYAMLOnExistingKitFile(t *testing.T) {
 	}
 }
 
-func TestMigrate_ForceOverwritesKitYAML(t *testing.T) {
+func TestMigrate_ForcePreservesKitYAML(t *testing.T) {
 	tmp := t.TempDir()
 	project := filepath.Join(tmp, "project")
 	store := filepath.Join(tmp, "home", ".scribe", "skills")
@@ -249,18 +296,15 @@ func TestMigrate_ForceOverwritesKitYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Apply() error = %v", err)
 	}
-	if result.WroteProjectFiles != 1 {
-		t.Fatalf("WroteProjectFiles = %d, want 1", result.WroteProjectFiles)
+	if result.WroteProjectFiles != 0 {
+		t.Fatalf("WroteProjectFiles = %d, want 0", result.WroteProjectFiles)
 	}
 	got, err := os.ReadFile(projectFile)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(got) == string(original) {
-		t.Fatalf("project file = %q, want overwritten", got)
-	}
-	if !strings.Contains(string(got), "tdd") {
-		t.Fatalf("project file = %q, want migrated skill", got)
+	if string(got) != string(original) {
+		t.Fatalf("project file = %q, want unchanged", got)
 	}
 }
 

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Naoray/scribe/internal/lockfile"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/migrate"
+	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/tools"
@@ -273,6 +274,9 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 // Emits events throughout. Updates state incrementally — a failed skill
 // does not prevent successful skills from being recorded.
 func (s *Syncer) Run(ctx context.Context, teamRepo string, st *state.State) error {
+	if err := s.ensureProjectRoot(); err != nil {
+		return err
+	}
 	// First run after upgrading to the packages-store split: reclassify any
 	// legacy skills/<name>/ installs whose tree shape identifies them as
 	// packages. Idempotent — guarded by state.Migrations.
@@ -929,7 +933,28 @@ func (s *Syncer) resolveNameConflict(conflict NameConflict, st *state.State, tar
 // RunWithDiff applies a pre-computed diff (statuses) directly.
 // Used by tests and callers that already have statuses from Diff().
 func (s *Syncer) RunWithDiff(ctx context.Context, teamRepo string, statuses []SkillStatus, st *state.State) error {
+	if err := s.ensureProjectRoot(); err != nil {
+		return err
+	}
 	return s.apply(ctx, teamRepo, statuses, st)
+}
+
+func (s *Syncer) ensureProjectRoot() error {
+	if s.ProjectRoot != "" {
+		return nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get working directory: %w", err)
+	}
+	projectPath := filepath.Join(wd, projectfile.Filename)
+	if _, err := os.Stat(projectPath); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	s.ProjectRoot = wd
+	return nil
 }
 
 const defaultPackageTimeout = 5 * time.Minute

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -381,6 +381,62 @@ func TestSync_PromotesGlobalProjectionWhenProjectFileExists(t *testing.T) {
 	}
 }
 
+func TestSync_PromotesGlobalProjectionFromCurrentProjectFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		t.Fatalf("store dir: %v", err)
+	}
+	writeStoredSkill(t, storeDir, "recap", "project recap")
+
+	projectRoot := t.TempDir()
+	t.Chdir(projectRoot)
+	if err := os.WriteFile(filepath.Join(projectRoot, ".scribe.yaml"), []byte("add:\n  - recap\n"), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+
+	syncer := &sync.Syncer{
+		Tools: []tools.Tool{tools.ClaudeTool{}},
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"recap": {
+			InstalledHash: sync.ComputeFileHash(skillContent("recap", "project recap")),
+			Tools:         []string{"claude"},
+			Projections: []state.ProjectionEntry{{
+				Project: "",
+				Tools:   []string{"claude"},
+			}},
+		},
+	}}
+	current := st.Installed["recap"]
+	statuses := []sync.SkillStatus{{
+		Name:      "recap",
+		Status:    sync.StatusCurrent,
+		Installed: &current,
+		Entry:     &manifest.Entry{Name: "recap", Source: "github:acme/skills@main"},
+	}}
+
+	if err := syncer.RunWithDiff(context.Background(), "acme/skills", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+
+	installed := st.Installed["recap"]
+	foundProject := false
+	for _, projection := range installed.Projections {
+		if projection.Project == projectRoot && reflect.DeepEqual(projection.Tools, []string{"claude"}) {
+			foundProject = true
+		}
+	}
+	if !foundProject {
+		t.Fatalf("Projections = %#v, want project projection from cwd .scribe.yaml", installed.Projections)
+	}
+	if _, err := os.Lstat(filepath.Join(projectRoot, ".claude", "skills", "recap")); err != nil {
+		t.Fatalf("project symlink missing: %v", err)
+	}
+}
+
 func TestRunWithDiff_MultiProjectProjectionPathsAreIsolated(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	projectOne := t.TempDir()


### PR DESCRIPTION
## Summary
- scope per-skill tool enable/disable to the current .scribe.yaml project, updating project projections and removing project-local Codex links
- let sync promote legacy global projections when run from a project directory containing .scribe.yaml
- keep user-authored kit/snippet .scribe.yaml files unchanged during global-to-projects migration, even with --force

## Tests
- go test ./...