### PR TITLE
Fix upgrade version verification

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -136,7 +136,7 @@ func doUpgrade(ctx context.Context, method upgrade.Method, release *gogithub.Rep
 			spin.stop()
 		}
 		// Brew has its own progress output — don't wrap with spinner.
-		_, upgradeErr = upgrade.UpgradeHomebrew(ctx)
+		_, upgradeErr = upgrade.UpgradeHomebrew(ctx, release.GetTagName())
 	case upgrade.MethodGoInstall:
 		_, upgradeErr = upgrade.UpgradeGoInstall(ctx)
 		if spin != nil {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 
 	gogithub "github.com/google/go-github/v69/github"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/github"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/upgrade"
@@ -29,6 +32,8 @@ var upgradeCheck bool
 var currentVersion = func() string {
 	return resolveVersion(Version, readBuildInfo())
 }
+
+var installedBinaryVersion = queryInstalledBinaryVersion
 
 func newUpgradeCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -116,10 +121,15 @@ func runUpgradeWithDeps(ctx context.Context, st *state.State, client upgradeClie
 		return err
 	}
 
+	if err := verifyInstalledBinaryVersion(ctx, latestTag); err != nil {
+		return err
+	}
+
 	st.RecordScribeBinaryUpdateSuccess()
 	if err := st.Save(); err != nil {
 		return fmt.Errorf("save state: %w", err)
 	}
+	fmt.Printf("Successfully upgraded to %s\n", latestTag)
 	return nil
 }
 
@@ -153,6 +163,48 @@ func doUpgrade(ctx context.Context, method upgrade.Method, release *gogithub.Rep
 		return fmt.Errorf("upgrade failed: %w", upgradeErr)
 	}
 
-	fmt.Printf("Successfully upgraded to %s\n", release.GetTagName())
 	return nil
+}
+
+func verifyInstalledBinaryVersion(ctx context.Context, releaseTag string) error {
+	out, err := installedBinaryVersion(ctx)
+	if err != nil {
+		return clierrors.Wrap(
+			fmt.Errorf("verify installed scribe version: %w", err),
+			"UPGRADE_VERSION_MISMATCH",
+			clierrors.ExitConflict,
+			clierrors.WithRemediation("ensure `scribe` is on PATH and retry"),
+		)
+	}
+	if versionOutputMatchesTag(out, releaseTag) {
+		return nil
+	}
+	return clierrors.Wrap(
+		fmt.Errorf("installed scribe version does not match %s (%s)", releaseTag, strings.TrimSpace(out)),
+		"UPGRADE_VERSION_MISMATCH",
+		clierrors.ExitConflict,
+		clierrors.WithRemediation("ensure `which scribe` points to the upgraded binary and retry"),
+	)
+}
+
+func queryInstalledBinaryVersion(ctx context.Context) (string, error) {
+	path, err := exec.LookPath("scribe")
+	if err != nil {
+		return "", err
+	}
+	out, err := exec.CommandContext(ctx, path, "--version").CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("%s --version: %s: %w", path, string(out), err)
+	}
+	return string(out), nil
+}
+
+func versionOutputMatchesTag(out, releaseTag string) bool {
+	want := strings.TrimPrefix(strings.TrimSpace(releaseTag), "v")
+	for _, field := range strings.Fields(out) {
+		if strings.TrimPrefix(field, "v") == want {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	gogithub "github.com/google/go-github/v69/github"
 
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/upgrade"
 )
@@ -67,8 +69,15 @@ func TestRunUpgradeWithDepsRecordsTimestampOnSuccessfulUpgrade(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	origVersion := Version
+	origInstalledBinaryVersion := installedBinaryVersion
 	Version = "1.2.3"
-	t.Cleanup(func() { Version = origVersion })
+	installedBinaryVersion = func(context.Context) (string, error) {
+		return "scribe version 1.2.4\n", nil
+	}
+	t.Cleanup(func() {
+		Version = origVersion
+		installedBinaryVersion = origInstalledBinaryVersion
+	})
 
 	st := &state.State{
 		Installed:          map[string]state.InstalledSkill{},
@@ -130,6 +139,51 @@ func TestRunUpgradeWithDepsDoesNotRecordTimestampOnFailure(t *testing.T) {
 	}
 	if loaded.ScribeBinaryUpdateCooldownFresh(time.Now().UTC()) {
 		t.Fatal("failed upgrade should not refresh the scribe cooldown")
+	}
+}
+
+func TestRunUpgradeWithDepsFailsWhenInstalledBinaryVersionDoesNotMatchRelease(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	origVersion := Version
+	Version = "1.2.3"
+	t.Cleanup(func() { Version = origVersion })
+
+	binDir := t.TempDir()
+	scribePath := filepath.Join(binDir, "scribe")
+	if err := os.WriteFile(scribePath, []byte("#!/bin/sh\necho 'scribe version 1.2.3'\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	st := &state.State{
+		Installed:          map[string]state.InstalledSkill{},
+		BinaryUpdateChecks: map[string]state.BinaryUpdateCheck{},
+	}
+
+	err := runUpgradeWithDeps(context.Background(), st, fakeUpgradeClient{
+		tag: "v1.2.4",
+	}, upgrade.MethodGoInstall, func(context.Context, upgrade.Method, *gogithub.RepositoryRelease, bool) error {
+		return nil
+	}, false)
+	if err == nil {
+		t.Fatal("runUpgradeWithDeps() error = nil, want version mismatch")
+	}
+
+	var ce *clierrors.Error
+	if !errors.As(err, &ce) {
+		t.Fatalf("runUpgradeWithDeps() error = %T, want *clierrors.Error", err)
+	}
+	if ce.Code != "UPGRADE_VERSION_MISMATCH" {
+		t.Fatalf("code = %q, want UPGRADE_VERSION_MISMATCH", ce.Code)
+	}
+
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load after version mismatch: %v", err)
+	}
+	if loaded.ScribeBinaryUpdateCooldownFresh(time.Now().UTC()) {
+		t.Fatal("version mismatch should not refresh the scribe cooldown")
 	}
 }
 

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/google/go-github/v69/github"
 )
 
@@ -22,7 +23,7 @@ import (
 type Method int
 
 const (
-	MethodHomebrew  Method = iota
+	MethodHomebrew Method = iota
 	MethodGoInstall
 	MethodCurlBinary
 )
@@ -206,14 +207,54 @@ func ReplaceBinary(targetPath string, newContent []byte) error {
 	return nil
 }
 
-// UpgradeHomebrew runs `brew upgrade scribe`.
-func UpgradeHomebrew(ctx context.Context) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "brew", "upgrade", "scribe")
-	out, err := cmd.CombinedOutput()
+// UpgradeHomebrew refreshes Homebrew metadata, runs `brew upgrade scribe`,
+// and verifies the installed formula version matches releaseTag.
+func UpgradeHomebrew(ctx context.Context, releaseTag string) ([]byte, error) {
+	var combined []byte
+
+	updateCmd := exec.CommandContext(ctx, "brew", "update")
+	updateOut, err := updateCmd.CombinedOutput()
+	combined = append(combined, updateOut...)
 	if err != nil {
-		return out, fmt.Errorf("brew upgrade: %s: %w", string(out), err)
+		return combined, fmt.Errorf("brew update: %s: %w", string(updateOut), err)
 	}
-	return out, nil
+
+	upgradeCmd := exec.CommandContext(ctx, "brew", "upgrade", "scribe")
+	upgradeOut, err := upgradeCmd.CombinedOutput()
+	combined = append(combined, upgradeOut...)
+	if err != nil {
+		return combined, fmt.Errorf("brew upgrade: %s: %w", string(upgradeOut), err)
+	}
+
+	listCmd := exec.CommandContext(ctx, "brew", "list", "--versions", "scribe")
+	listOut, err := listCmd.CombinedOutput()
+	combined = append(combined, listOut...)
+	if err != nil {
+		return combined, fmt.Errorf("brew list --versions scribe: %s: %w", string(listOut), err)
+	}
+	if !brewVersionsContain(listOut, releaseTag) {
+		installed := strings.TrimSpace(string(listOut))
+		if installed == "" {
+			installed = "scribe not listed"
+		}
+		return combined, clierrors.Wrap(
+			fmt.Errorf("installed Homebrew scribe version does not match %s (%s)", releaseTag, installed),
+			"UPGRADE_VERSION_MISMATCH",
+			clierrors.ExitConflict,
+			clierrors.WithRemediation("brew tap is stale; run 'brew update' and retry"),
+		)
+	}
+	return combined, nil
+}
+
+func brewVersionsContain(out []byte, releaseTag string) bool {
+	want := strings.TrimPrefix(strings.TrimSpace(releaseTag), "v")
+	for _, field := range strings.Fields(string(out)) {
+		if strings.TrimPrefix(field, "v") == want {
+			return true
+		}
+	}
+	return false
 }
 
 // UpgradeGoInstall runs `go install github.com/Naoray/scribe/cmd/scribe@latest`.

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -4,9 +4,15 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 )
 
 func TestDetectMethod(t *testing.T) {
@@ -221,6 +227,65 @@ func TestNeedsUpgrade(t *testing.T) {
 				t.Errorf("NeedsUpgrade() upgrade = %v, want %v", upgrade, tt.wantUpgrade)
 			}
 		})
+	}
+}
+
+func TestUpgradeHomebrewRefreshesTapAndRejectsVersionMismatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script test")
+	}
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "brew.log")
+	brewPath := filepath.Join(dir, "brew")
+	script := `#!/bin/sh
+echo "$*" >> "` + logPath + `"
+case "$1 $2" in
+  "update ")
+    exit 0
+    ;;
+  "upgrade scribe")
+    exit 0
+    ;;
+  "list --versions")
+    if [ "$3" = "scribe" ]; then
+      echo "scribe 1.2.3"
+      exit 0
+    fi
+    ;;
+esac
+echo "unexpected brew args: $*" >&2
+exit 64
+`
+	if err := os.WriteFile(brewPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := UpgradeHomebrew(context.Background(), "v1.2.4")
+	if err == nil {
+		t.Fatal("UpgradeHomebrew() error = nil, want version mismatch")
+	}
+
+	var ce *clierrors.Error
+	if !errors.As(err, &ce) {
+		t.Fatalf("UpgradeHomebrew() error = %T, want *clierrors.Error", err)
+	}
+	if ce.Code != "UPGRADE_VERSION_MISMATCH" {
+		t.Fatalf("code = %q, want UPGRADE_VERSION_MISMATCH", ce.Code)
+	}
+	if ce.Remediation != "brew tap is stale; run 'brew update' and retry" {
+		t.Fatalf("remediation = %q", ce.Remediation)
+	}
+
+	logBytes, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	got := strings.Split(strings.TrimSpace(string(logBytes)), "\n")
+	want := []string{"update", "upgrade scribe", "list --versions scribe"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("brew calls = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- refresh Homebrew metadata before upgrading and verify brew's installed scribe formula version against the release tag
- verify the on-PATH scribe binary reports the release tag before printing upgrade success or updating cooldown state
- return UPGRADE_VERSION_MISMATCH with actionable remediation when verification fails

## Tests
- go test ./...