### PR TITLE
fix: preserve project-local Codex projections

### DIFF
--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -119,7 +119,7 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 		}
 
 		canonicalDir := filepath.Join(storeDir, name)
-		expectedTools := skill.EffectiveTools(activeNames)
+		expectedTools := skill.EffectiveToolsForProject(activeNames, e.ProjectRoot)
 		expectedPaths := make(map[string]string, len(expectedTools))
 		newManaged := make(map[string]bool)
 		var conflicts []state.ProjectionConflict

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -96,6 +96,58 @@ func TestReconcileUsesProjectRootForCodexProjection(t *testing.T) {
 	}
 }
 
+func TestReconcileProjectProjectionOverridesGlobalPinnedTools(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	projectRoot := t.TempDir()
+
+	canonical, err := tools.WriteToStore("recap", []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}})
+	if err != nil {
+		t.Fatalf("WriteToStore: %v", err)
+	}
+	canonical, _ = filepath.EvalSymlinks(canonical)
+
+	projectPath := filepath.Join(projectRoot, ".agents", "skills", "recap")
+	if err := os.MkdirAll(filepath.Dir(projectPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(canonical, projectPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"recap": {
+			Revision:     1,
+			Tools:        []string{"claude"},
+			ToolsMode:    state.ToolsModePinned,
+			ManagedPaths: []string{projectPath},
+			Projections: []state.ProjectionEntry{{
+				Project: projectRoot,
+				Tools:   []string{"codex"},
+			}},
+		},
+	}}
+
+	engine := reconcile.Engine{
+		Tools:       []tools.Tool{tools.CodexTool{}},
+		ProjectRoot: projectRoot,
+		Now:         func() time.Time { return time.Unix(1, 0).UTC() },
+	}
+	summary, actions, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Installed != 0 || summary.Removed != 0 || summary.Relinked != 0 || len(summary.Conflicts) != 0 {
+		t.Fatalf("summary = %+v, want no changes", summary)
+	}
+	if len(actions) != 1 || actions[0].Kind != reconcile.ActionUnchanged || actions[0].Path != projectPath {
+		t.Fatalf("actions = %+v, want unchanged project codex projection", actions)
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".agents", "skills", "recap")); !os.IsNotExist(err) {
+		t.Fatalf("global codex projection exists or stat failed: %v", err)
+	}
+}
+
 func TestReconcileUsesGlobalClaudeProjectionForBootstrapSkill(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/state/tools_resolve.go
+++ b/internal/state/tools_resolve.go
@@ -17,17 +17,25 @@ func (s InstalledSkill) EffectiveTools(available []string) []string {
 	if s.ToolsMode != ToolsModePinned {
 		return append([]string(nil), available...)
 	}
-	availSet := make(map[string]bool, len(available))
-	for _, a := range available {
-		availSet[a] = true
+	return intersectTools(s.Tools, available)
+}
+
+// EffectiveToolsForProject returns the tool names a skill should be installed
+// into for a specific project scope.
+//
+// Project projections are more specific than the legacy/global Tools pin. This
+// lets one project's projected tool set survive unrelated per-skill trimming in
+// another scope.
+func (s InstalledSkill) EffectiveToolsForProject(available []string, projectRoot string) []string {
+	if s.IsPackage() {
+		return append([]string(nil), available...)
 	}
-	out := make([]string, 0, len(s.Tools))
-	for _, t := range s.Tools {
-		if availSet[t] {
-			out = append(out, t)
+	for _, projection := range s.Projections {
+		if projection.Project == projectRoot {
+			return intersectTools(projection.Tools, available)
 		}
 	}
-	return out
+	return s.EffectiveTools(available)
 }
 
 // NormalizeToolSelection dedupes a user-provided tool list while preserving
@@ -41,6 +49,20 @@ func NormalizeToolSelection(in []string) []string {
 		}
 		seen[t] = true
 		out = append(out, t)
+	}
+	return out
+}
+
+func intersectTools(selected, available []string) []string {
+	availSet := make(map[string]bool, len(available))
+	for _, a := range available {
+		availSet[a] = true
+	}
+	out := make([]string, 0, len(selected))
+	for _, t := range selected {
+		if availSet[t] {
+			out = append(out, t)
+		}
 	}
 	return out
 }

--- a/internal/state/tools_resolve_test.go
+++ b/internal/state/tools_resolve_test.go
@@ -59,6 +59,38 @@ func TestEffectiveTools_PinnedEmptyYieldsEmpty(t *testing.T) {
 	}
 }
 
+func TestEffectiveToolsForProject_ProjectionOverridesPinnedTools(t *testing.T) {
+	sk := InstalledSkill{
+		ToolsMode: ToolsModePinned,
+		Tools:     []string{"claude"},
+		Projections: []ProjectionEntry{{
+			Project: "/repo/project",
+			Tools:   []string{"codex"},
+		}},
+	}
+	got := sk.EffectiveToolsForProject([]string{"claude", "codex"}, "/repo/project")
+	want := []string{"codex"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestEffectiveToolsForProject_FallsBackToPinnedTools(t *testing.T) {
+	sk := InstalledSkill{
+		ToolsMode: ToolsModePinned,
+		Tools:     []string{"claude"},
+		Projections: []ProjectionEntry{{
+			Project: "/repo/other",
+			Tools:   []string{"codex"},
+		}},
+	}
+	got := sk.EffectiveToolsForProject([]string{"claude", "codex"}, "/repo/project")
+	want := []string{"claude"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
 func TestNormalizeToolSelection_DedupePreservesOrder(t *testing.T) {
 	got := NormalizeToolSelection([]string{"claude", "cursor", "claude", "", "codex"})
 	want := []string{"claude", "cursor", "codex"}

--- a/internal/sync/budget_projection_internal_test.go
+++ b/internal/sync/budget_projection_internal_test.go
@@ -28,7 +28,7 @@ func TestBudgetSkillsForProjectionExcludesPinnedSkillWithoutAgent(t *testing.T) 
 			Tools:     []string{"claude"},
 			Projections: []state.ProjectionEntry{{
 				Project: projectRoot,
-				Tools:   []string{"codex"},
+				Tools:   []string{"claude"},
 			}},
 		},
 		"codex-skill": {
@@ -55,6 +55,39 @@ func TestBudgetSkillsForProjectionExcludesPinnedSkillWithoutAgent(t *testing.T) 
 	}
 	if !names.has("incoming") {
 		t.Fatal("codex budget should include incoming")
+	}
+}
+
+func TestBudgetSkillsForProjectionUsesCurrentProjectToolsOverGlobalPin(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		t.Fatalf("store dir: %v", err)
+	}
+	writeProjectionBudgetSkill(t, storeDir, "project-codex", "codex")
+
+	projectRoot := t.TempDir()
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"project-codex": {
+			ToolsMode: state.ToolsModePinned,
+			Tools:     []string{"claude"},
+			Projections: []state.ProjectionEntry{{
+				Project: projectRoot,
+				Tools:   []string{"codex"},
+			}},
+		},
+	}}
+
+	skills, err := budgetSkillsForProjection(st, "incoming", []byte("incoming"), projectRoot, "codex")
+	if err != nil {
+		t.Fatalf("budgetSkillsForProjection: %v", err)
+	}
+
+	names := projectionBudgetSkillNames(skills)
+	if !names.has("project-codex") {
+		t.Fatal("codex budget should include current project codex projection despite global claude pin")
 	}
 }
 

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -598,7 +598,7 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 
 			// Filter to the skill's effective tools (pinned mode respects user
 			// selection; inherit mode uses every globally-enabled tool).
-			effectiveTools := selectEffectiveTools(s.Tools, installed)
+			effectiveTools := selectEffectiveTools(s.Tools, installed, s.ProjectRoot)
 
 			if !s.ForceBudget {
 				if err := s.checkBudgetBeforeProjection(st, sk.Name, tFiles, effectiveTools); err != nil {
@@ -693,20 +693,20 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 			sources := mergeSources(installed, newSource)
 
 			// Preserve pinned ToolsMode across re-syncs. New skills default to
-			// inherit; for pinned skills we still overwrite Tools with the
-			// resolved names so stale entries (tool uninstalled globally)
-			// don't linger in state.
+			// inherit. Project-scoped projections are tracked separately, so a
+			// project sync must not rewrite the legacy/global Tools pin.
 			toolsMode := state.ToolsModeInherit
 			if installed != nil {
 				toolsMode = installed.ToolsMode
 			}
 
 			managedPaths := mergeManagedPaths(installed, paths)
+			stateTools := stateToolsForProjection(installed, s.ProjectRoot, toolNames)
 			st.RecordInstall(installName, state.InstalledSkill{
 				Revision:      nextRevision(installed),
 				InstalledHash: installedHash,
 				Sources:       sources,
-				Tools:         toolNames,
+				Tools:         stateTools,
 				ToolsMode:     toolsMode,
 				Paths:         append([]string(nil), managedPaths...),
 				Projections:   mergeProjection(installed, s.ProjectRoot, toolNames),
@@ -785,7 +785,7 @@ func (s *Syncer) promoteProjectProjection(name string, st *state.State, summary 
 		summary.Failed++
 		return
 	}
-	effectiveTools := selectEffectiveTools(s.Tools, installed)
+	effectiveTools := selectEffectiveTools(s.Tools, installed, s.ProjectRoot)
 	if !s.ForceBudget {
 		files := []tools.SkillFile{{Path: "SKILL.md", Content: content}}
 		if err := s.checkBudgetBeforeProjection(st, name, files, effectiveTools); err != nil {
@@ -990,16 +990,32 @@ func resolveToolCmds(entry *manifest.Entry, activeTools []tools.Tool) []toolCmd 
 // that should receive this skill, honoring ToolsMode. Order comes from the
 // installed record for pinned mode (preserves user intent); from the global
 // list for inherit mode (preserves tool config order).
-func selectEffectiveTools(global []tools.Tool, installed *state.InstalledSkill) []tools.Tool {
-	if installed == nil || installed.ToolsMode != state.ToolsModePinned {
+func selectEffectiveTools(global []tools.Tool, installed *state.InstalledSkill, projectRoot string) []tools.Tool {
+	if installed == nil {
 		return global
 	}
+	globalNames := make([]string, 0, len(global))
 	byName := make(map[string]tools.Tool, len(global))
 	for _, t := range global {
-		byName[t.Name()] = t
+		name := t.Name()
+		globalNames = append(globalNames, name)
+		byName[name] = t
 	}
-	out := make([]tools.Tool, 0, len(installed.Tools))
-	for _, name := range installed.Tools {
+	effectiveNames := installed.EffectiveToolsForProject(globalNames, projectRoot)
+	if len(effectiveNames) == len(global) {
+		matchesGlobalOrder := true
+		for i, name := range effectiveNames {
+			if global[i].Name() != name {
+				matchesGlobalOrder = false
+				break
+			}
+		}
+		if matchesGlobalOrder {
+			return global
+		}
+	}
+	out := make([]tools.Tool, 0, len(effectiveNames))
+	for _, name := range effectiveNames {
 		if t, ok := byName[name]; ok {
 			out = append(out, t)
 		}
@@ -1088,7 +1104,7 @@ func budgetSkillsForProjection(st *state.State, incomingName string, incomingCon
 		if installed.Kind == state.KindPackage {
 			continue
 		}
-		if name == incomingName || !projectedToAgent(installed, projectRoot, agent) || !pinnedToAgent(installed, agent) {
+		if name == incomingName || !projectedToAgent(installed, projectRoot, agent) {
 			continue
 		}
 		seen[name] = true
@@ -1128,10 +1144,6 @@ func projectedToAgent(installed state.InstalledSkill, projectRoot, agent string)
 	return containsString(installed.Tools, agent)
 }
 
-func pinnedToAgent(installed state.InstalledSkill, agent string) bool {
-	return installed.ToolsMode != state.ToolsModePinned || containsString(installed.Tools, agent)
-}
-
 func containsString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
@@ -1157,6 +1169,13 @@ func mergeProjection(installed *state.InstalledSkill, projectRoot string, toolNa
 		}
 	}
 	return append(projections, next)
+}
+
+func stateToolsForProjection(installed *state.InstalledSkill, projectRoot string, toolNames []string) []string {
+	if installed != nil && installed.ToolsMode == state.ToolsModePinned && projectRoot != "" {
+		return append([]string(nil), installed.Tools...)
+	}
+	return append([]string(nil), toolNames...)
 }
 
 func mergeManagedPaths(installed *state.InstalledSkill, paths []string) []string {

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -287,6 +287,59 @@ func TestRunWithDiff_RecordsProjectProjection(t *testing.T) {
 	}
 }
 
+func TestRunWithDiff_ProjectProjectionOverridesGlobalPinnedTools(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	projectRoot := t.TempDir()
+
+	syncer := &sync.Syncer{
+		Client: &syncTestFetcher{
+			files: []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}},
+		},
+		Tools:       []tools.Tool{tools.CodexTool{}},
+		ProjectRoot: projectRoot,
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"recap": {
+			InstalledHash: sync.ComputeFileHash([]byte("# old recap\n")),
+			Tools:         []string{"claude"},
+			ToolsMode:     state.ToolsModePinned,
+			Projections: []state.ProjectionEntry{{
+				Project: projectRoot,
+				Tools:   []string{"codex"},
+			}},
+		},
+	}}
+	current := st.Installed["recap"]
+	statuses := []sync.SkillStatus{{
+		Name:      "recap",
+		Status:    sync.StatusOutdated,
+		Installed: &current,
+		Entry:     &manifest.Entry{Name: "recap", Source: "github:acme/skills@main"},
+	}}
+
+	if err := syncer.RunWithDiff(context.Background(), "acme/skills", statuses, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+
+	projectPath := filepath.Join(projectRoot, ".agents", "skills", "recap")
+	if _, err := os.Lstat(projectPath); err != nil {
+		t.Fatalf("project codex projection missing: %v", err)
+	}
+	installed := st.Installed["recap"]
+	if !reflect.DeepEqual(installed.Tools, []string{"claude"}) {
+		t.Fatalf("Tools = %v, want global pin [claude]", installed.Tools)
+	}
+	foundProject := false
+	for _, projection := range installed.Projections {
+		if projection.Project == projectRoot && reflect.DeepEqual(projection.Tools, []string{"codex"}) {
+			foundProject = true
+		}
+	}
+	if !foundProject {
+		t.Fatalf("Projections = %#v, want current project codex projection preserved", installed.Projections)
+	}
+}
+
 func TestRunWithDiff_RecordsGlobalProjectionWhenProjectRootEmpty(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
Project-local kit projections were still being filtered through the legacy/global per-skill Tools pin. That meant trimming a skill for Codex in one scope could make another project lose its .agents/skills projection even when its .scribe.yaml still resolved the skill.

This adds a project-aware effective tool resolver. Current-project ProjectionEntry.Tools wins over the global pin for sync, reconcile, and budget checks. Project-scoped sync also preserves an existing pinned global InstalledSkill.Tools value instead of replacing it with the project tool set.

Tests:
- go test ./internal/sync ./internal/reconcile ./internal/state

Note: go test ./... was run; the only failure was the known pre-existing cmd/TestSemanticExitCodesSubprocessMatrix/auth_failure exit-code mismatch.