### PR TITLE
fix: strip conflict markers on resolve --ours

### DIFF
--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -83,6 +84,7 @@ func runResolve(cmd *cobra.Command, args []string) error {
 	}
 
 	// Write resolved content to SKILL.md.
+	content = stripConflictMarkerLines(content)
 	skillPath := filepath.Join(skillDir, "SKILL.md")
 	if err := os.WriteFile(skillPath, content, 0o644); err != nil {
 		return fmt.Errorf("write resolved skill: %w", err)
@@ -114,4 +116,18 @@ func runResolve(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Fprintf(os.Stderr, "Resolved %s → kept %s version (rev %d)\n", skillName, side, skill.Revision)
 	return nil
+}
+
+func stripConflictMarkerLines(content []byte) []byte {
+	lines := bytes.SplitAfter(content, []byte("\n"))
+	out := make([]byte, 0, len(content))
+	for _, line := range lines {
+		trimmed := bytes.TrimSuffix(line, []byte("\n"))
+		trimmed = bytes.TrimSuffix(trimmed, []byte("\r"))
+		if bytes.HasPrefix(trimmed, []byte("<<<<<<< ")) || bytes.HasPrefix(trimmed, []byte("=======")) || bytes.HasPrefix(trimmed, []byte(">>>>>>> ")) {
+			continue
+		}
+		out = append(out, line...)
+	}
+	return out
 }

--- a/cmd/resolve_test.go
+++ b/cmd/resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Naoray/scribe/internal/state"
@@ -92,6 +93,62 @@ func TestRunResolve_Ours(t *testing.T) {
 	}
 }
 
+func TestRunResolve_OursStripsNestedConflictMarkers(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	skillDir := filepath.Join(home, ".scribe", "skills", "cleanup")
+	versionsDir := filepath.Join(skillDir, "versions")
+	if err := os.MkdirAll(versionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	conflicted := []byte("<<<<<<< local\nlocal stuff\n=======\nupstream stuff\n>>>>>>> upstream\n")
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), conflicted, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, ".scribe-base.md"), []byte("upstream stuff\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oursContent := []byte("# Cleanup\n<<<<<<< local\nkeep this\n<<<<<<< nested\nnested local\n=======\nnested upstream\n>>>>>>> nested\n=======\nupstream copy\n>>>>>>> upstream\n")
+	if err := os.WriteFile(filepath.Join(versionsDir, "rev-1.md"), oursContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	st := &state.State{
+		SchemaVersion: 2,
+		Installed: map[string]state.InstalledSkill{
+			"cleanup": {Revision: 1, InstalledHash: sync.ComputeFileHash(conflicted), Tools: []string{"claude"}},
+		},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newResolveCommand()
+	cmd.SetArgs([]string{"cleanup", "--ours"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if containsConflictMarkerLine(string(got)) {
+		t.Fatalf("expected conflict marker lines to be stripped, got %q", string(got))
+	}
+
+	st2, err := state.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st2.Installed["cleanup"].InstalledHash != sync.ComputeFileHash(got) {
+		t.Errorf("expected state hash to use stripped content")
+	}
+}
+
 func TestRunResolve_Theirs(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -167,6 +224,15 @@ func TestRunResolve_Theirs(t *testing.T) {
 	if string(gotBase) != string(theirsContent) {
 		t.Errorf("expected base to equal upstream content, got %q", string(gotBase))
 	}
+}
+
+func containsConflictMarkerLine(content string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(line, "<<<<<<< ") || line == "=======" || strings.HasPrefix(line, ">>>>>>> ") {
+			return true
+		}
+	}
+	return false
 }
 
 func TestResolveFlags_MutuallyExclusive(t *testing.T) {


### PR DESCRIPTION
scribe resolve --ours wrote the chosen local snapshot directly back to SKILL.md. If that snapshot already had nested merge markers, resolve reported success but left the file conflicted.

This strips marker lines (<<<<<<< , =======, >>>>>>> ) before writing the resolved file and before updating the stored hash.

Tests:
- go test ./cmd -run TestRunResolve_OursStripsNestedConflictMarkers -count=1
- go test ./cmd -run Resolve -count=1

Note: go test ./cmd still hits the known pre-existing TestSemanticExitCodesSubprocessMatrix/auth_failure exit-code mismatch.