### PR TITLE
fix: model Codex projection budget with shortened descriptions

### DIFF
--- a/cmd/budget_helpers.go
+++ b/cmd/budget_helpers.go
@@ -139,10 +139,12 @@ func enforceCurrentBudget(factory *app.Factory, force bool) error {
 	}
 	set, err := resolveBudgetSet(st)
 	if err != nil {
-		return err
+		// Budget preflight should not mask the sync workflow's authoritative
+		// validation, fetch, or auth errors.
+		return nil
 	}
 	for _, agent := range budgetAgents(cfg) {
-		result := budget.CheckBudget(budgetSkillsForAgent(set, st, agent), agent)
+		result := budget.CheckProjectionBudget(budgetSkillsForAgent(set, st, agent), agent)
 		switch result.Status {
 		case budget.StatusRefuse:
 			if !force {

--- a/cmd/budget_helpers_test.go
+++ b/cmd/budget_helpers_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Naoray/scribe/internal/budget"
@@ -44,6 +45,57 @@ func TestBudgetSkillsForAgentExcludesPinnedSkillWithoutAgent(t *testing.T) {
 	}
 }
 
+func TestProjectLocalBudgetUsesShortCodexDescriptions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wd := t.TempDir()
+	t.Chdir(wd)
+
+	writeBudgetSkill(t, home, "review-triage", longBudgetSkillContent("review-triage", 3000))
+	writeBudgetSkill(t, home, "solo-orchestration", longBudgetSkillContent("solo-orchestration", 3000))
+	writeBudgetSkill(t, home, "not-in-project", longBudgetSkillContent("not-in-project", 3000))
+	writeBudgetKit(t, home, "orchestrator", []string{"review-triage", "solo-orchestration"})
+	if err := os.WriteFile(filepath.Join(wd, ".scribe.yaml"), []byte("kits:\n - orchestrator\n"), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"review-triage": {
+			Tools: []string{"codex"},
+		},
+		"solo-orchestration": {
+			Tools: []string{"codex"},
+		},
+		"not-in-project": {
+			Tools: []string{"codex"},
+		},
+	}}
+
+	set, err := resolveBudgetSet(st)
+	if err != nil {
+		t.Fatalf("resolveBudgetSet: %v", err)
+	}
+	if set.ProjectRoot != wd {
+		t.Fatalf("ProjectRoot = %q, want %q", set.ProjectRoot, wd)
+	}
+	names := skillNames(set.Skills)
+	if !names.has("review-triage") || !names.has("solo-orchestration") {
+		t.Fatalf("skills = %#v, want project kit skills", names)
+	}
+	if names.has("not-in-project") {
+		t.Fatal("project-local budget should not include skills outside the project kit")
+	}
+
+	raw := budget.CheckBudget(budgetSkillsForAgent(set, st, "codex"), "codex")
+	if raw.Status != budget.StatusRefuse {
+		t.Fatalf("raw Status = %s, want %s", raw.Status, budget.StatusRefuse)
+	}
+	projected := budget.CheckProjectionBudget(budgetSkillsForAgent(set, st, "codex"), "codex")
+	if projected.Status == budget.StatusRefuse {
+		t.Fatalf("projected Status = %s, want non-refuse; used %d", projected.Status, projected.Used)
+	}
+}
+
 func writeBudgetSkill(t *testing.T, home, name, content string) {
 	t.Helper()
 
@@ -54,6 +106,31 @@ func writeBudgetSkill(t *testing.T, home, name, content string) {
 	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
 		t.Fatalf("write SKILL.md: %v", err)
 	}
+}
+
+func writeBudgetKit(t *testing.T, home, name string, skills []string) {
+	t.Helper()
+
+	dir := filepath.Join(home, ".scribe", "kits")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir kit dir: %v", err)
+	}
+	var content strings.Builder
+	content.WriteString("name: " + name + "\n")
+	content.WriteString("skills:\n")
+	for _, skill := range skills {
+		content.WriteString(" - " + skill + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".yaml"), []byte(content.String()), 0o644); err != nil {
+		t.Fatalf("write kit: %v", err)
+	}
+}
+
+func longBudgetSkillContent(name string, descriptionBytes int) string {
+	return "---\n" +
+		"name: " + name + "\n" +
+		"description: " + strings.Repeat("x", descriptionBytes) + "\n" +
+		"---\n"
 }
 
 type testBudgetSkillNames map[string]bool

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -57,6 +57,29 @@ func EstimateDescriptionBytes(skill Skill) int {
 }
 
 func CheckBudget(skills []Skill, agent string) Result {
+	return checkBudget(skills, agent, EstimateDescriptionBytes)
+}
+
+func CheckProjectionBudget(skills []Skill, agent string) Result {
+	estimator := EstimateDescriptionBytes
+	if strings.EqualFold(agent, "codex") {
+		estimator = EstimateCodexProjectionDescriptionBytes
+	}
+	return checkBudget(skills, agent, estimator)
+}
+
+func EstimateCodexProjectionDescriptionBytes(skill Skill) int {
+	description, body := splitSkill(skill.Content)
+	description = shortenDescription(strings.TrimSpace(description))
+	firstParagraph := shortenDescription(extractFirstParagraph(body))
+	used := len([]byte(description)) + len([]byte(firstParagraph))
+	if description != "" && firstParagraph != "" {
+		used += len("\n\n")
+	}
+	return used
+}
+
+func checkBudget(skills []Skill, agent string, estimate func(Skill) int) Result {
 	limit := AgentBudgets[strings.ToLower(agent)]
 	result := Result{
 		Agent:     strings.ToLower(agent),
@@ -74,7 +97,7 @@ func CheckBudget(skills []Skill, agent string) Result {
 	})
 
 	for _, skill := range ordered {
-		size := EstimateDescriptionBytes(skill)
+		size := estimate(skill)
 		before := result.Used
 		result.Used += size
 		if result.Used >= limit {
@@ -98,6 +121,24 @@ func CheckBudget(skills []Skill, agent string) Result {
 		result.Status = StatusSilent
 	}
 	return result
+}
+
+func shortenDescription(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if idx := strings.IndexAny(s, ".!"); idx > 0 && idx < 80 {
+		return s[:idx+1]
+	}
+	if len(s) <= 80 {
+		return s
+	}
+	cut := strings.LastIndex(s[:80], " ")
+	if cut > 40 {
+		return s[:cut] + "..."
+	}
+	return s[:80] + "..."
 }
 
 func FormatResult(result Result) string {

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -111,12 +111,54 @@ func TestCheckBudgetOverflowBreakdown(t *testing.T) {
 	}
 }
 
+func TestCheckProjectionBudgetShortensCodexDescriptions(t *testing.T) {
+	skills := []Skill{
+		skillWithSentenceDescription("a", strings.Repeat("a", 3000)+". "+strings.Repeat("ignored", 100)),
+		skillWithSentenceDescription("b", strings.Repeat("b", 3000)+". "+strings.Repeat("ignored", 100)),
+	}
+
+	raw := CheckBudget(skills, "codex")
+	if raw.Status != StatusRefuse {
+		t.Fatalf("raw Status = %s, want %s", raw.Status, StatusRefuse)
+	}
+
+	projected := CheckProjectionBudget(skills, "codex")
+	if projected.Status == StatusRefuse {
+		t.Fatalf("projected Status = %s, want non-refuse; used %d", projected.Status, projected.Used)
+	}
+	if projected.Used >= raw.Used {
+		t.Fatalf("projected Used = %d, want less than raw %d", projected.Used, raw.Used)
+	}
+}
+
+func TestCheckProjectionBudgetKeepsClaudeRawDescriptions(t *testing.T) {
+	skills := []Skill{
+		skillWithSentenceDescription("a", strings.Repeat("a", 3000)+". "+strings.Repeat("ignored", 100)),
+		skillWithSentenceDescription("b", strings.Repeat("b", 5200)+". "+strings.Repeat("ignored", 100)),
+	}
+
+	result := CheckProjectionBudget(skills, "claude")
+	if result.Status != StatusRefuse {
+		t.Fatalf("Status = %s, want %s", result.Status, StatusRefuse)
+	}
+}
+
 func skillWithDescription(name string, bytes int) Skill {
 	return Skill{
 		Name: name,
 		Content: []byte("---\n" +
 			"name: " + name + "\n" +
 			"description: " + strings.Repeat("x", bytes) + "\n" +
+			"---\n"),
+	}
+}
+
+func skillWithSentenceDescription(name, description string) Skill {
+	return Skill{
+		Name: name,
+		Content: []byte("---\n" +
+			"name: " + name + "\n" +
+			"description: " + description + "\n" +
 			"---\n"),
 	}
 }

--- a/internal/sync/budget_projection_internal_test.go
+++ b/internal/sync/budget_projection_internal_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	ibudget "github.com/Naoray/scribe/internal/budget"
@@ -91,6 +92,61 @@ func TestBudgetSkillsForProjectionUsesCurrentProjectToolsOverGlobalPin(t *testin
 	}
 }
 
+func TestCheckBudgetBeforeProjectionUsesShortCodexDescriptionsForProjectScope(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	storeDir, err := tools.StoreDir()
+	if err != nil {
+		t.Fatalf("store dir: %v", err)
+	}
+	longStoredSkill(t, storeDir, "same-project", 3000)
+	longStoredSkill(t, storeDir, "other-project", 3000)
+
+	projectRoot := t.TempDir()
+	otherProjectRoot := t.TempDir()
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"same-project": {
+			Tools: []string{"codex"},
+			Projections: []state.ProjectionEntry{{
+				Project: projectRoot,
+				Tools:   []string{"codex"},
+			}},
+		},
+		"other-project": {
+			Tools: []string{"codex"},
+			Projections: []state.ProjectionEntry{{
+				Project: otherProjectRoot,
+				Tools:   []string{"codex"},
+			}},
+		},
+	}}
+	incoming := longSkillContent("incoming", 3000)
+
+	skills, err := budgetSkillsForProjection(st, "incoming", incoming, projectRoot, "codex")
+	if err != nil {
+		t.Fatalf("budgetSkillsForProjection: %v", err)
+	}
+	names := projectionBudgetSkillNames(skills)
+	if !names.has("same-project") || !names.has("incoming") {
+		t.Fatalf("budget names = %#v, want same-project and incoming", names)
+	}
+	if names.has("other-project") {
+		t.Fatal("project budget should not include another project-local codex projection")
+	}
+
+	raw := ibudget.CheckBudget(skills, "codex")
+	if raw.Status != ibudget.StatusRefuse {
+		t.Fatalf("raw Status = %s, want %s", raw.Status, ibudget.StatusRefuse)
+	}
+
+	syncer := &Syncer{ProjectRoot: projectRoot}
+	err = syncer.checkBudgetBeforeProjection(st, "incoming", []tools.SkillFile{{Path: "SKILL.md", Content: incoming}}, []tools.Tool{tools.CodexTool{}})
+	if err != nil {
+		t.Fatalf("checkBudgetBeforeProjection: %v", err)
+	}
+}
+
 func writeProjectionBudgetSkill(t *testing.T, storeDir, name, content string) {
 	t.Helper()
 
@@ -101,6 +157,19 @@ func writeProjectionBudgetSkill(t *testing.T, storeDir, name, content string) {
 	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
 		t.Fatalf("write SKILL.md: %v", err)
 	}
+}
+
+func longStoredSkill(t *testing.T, storeDir, name string, descriptionBytes int) {
+	t.Helper()
+
+	writeProjectionBudgetSkill(t, storeDir, name, string(longSkillContent(name, descriptionBytes)))
+}
+
+func longSkillContent(name string, descriptionBytes int) []byte {
+	return []byte("---\n" +
+		"name: " + name + "\n" +
+		"description: " + strings.Repeat("x", descriptionBytes) + "\n" +
+		"---\n")
 }
 
 type projectionBudgetSkillNameSet map[string]bool

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -1042,7 +1042,7 @@ func (s *Syncer) checkBudgetBeforeProjection(st *state.State, incomingName strin
 		if err != nil {
 			return err
 		}
-		result := ibudget.CheckBudget(skills, agent)
+		result := ibudget.CheckProjectionBudget(skills, agent)
 		switch result.Status {
 		case ibudget.StatusRefuse:
 			return fmt.Errorf("%s\nTry removing one kit, or rerun with --force to project anyway.", ibudget.FormatOverflow(result))

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -859,23 +859,23 @@ func TestRunWithDiff_EmitsBudgetWarningForPostChangeProjection(t *testing.T) {
 		t.Fatalf("store dir: %v", err)
 	}
 	projectRoot := t.TempDir()
-	writeStoredSkill(t, storeDir, "existing", strings.Repeat("x", 3600))
+	writeStoredSkill(t, storeDir, "existing", strings.Repeat("x", 5600))
 
 	var events []any
 	syncer := &sync.Syncer{
 		Client: &syncTestFetcher{
-			files: []tools.SkillFile{{Path: "SKILL.md", Content: skillContent("incoming", strings.Repeat("y", 220))}},
+			files: []tools.SkillFile{{Path: "SKILL.md", Content: skillContent("incoming", strings.Repeat("y", 100))}},
 		},
-		Tools:       []tools.Tool{tools.CodexTool{}},
+		Tools:       []tools.Tool{tools.ClaudeTool{}},
 		ProjectRoot: projectRoot,
 		Emit:        func(msg any) { events = append(events, msg) },
 	}
 	st := &state.State{Installed: map[string]state.InstalledSkill{
 		"existing": {
-			Tools: []string{"codex"},
+			Tools: []string{"claude"},
 			Projections: []state.ProjectionEntry{{
 				Project: projectRoot,
-				Tools:   []string{"codex"},
+				Tools:   []string{"claude"},
 			}},
 		},
 	}}
@@ -891,11 +891,11 @@ func TestRunWithDiff_EmitsBudgetWarningForPostChangeProjection(t *testing.T) {
 
 	for _, event := range events {
 		if msg, ok := event.(sync.BudgetWarningMsg); ok {
-			if msg.Agent != "codex" {
-				t.Fatalf("Agent = %q, want codex", msg.Agent)
+			if msg.Agent != "claude" {
+				t.Fatalf("Agent = %q, want claude", msg.Agent)
 			}
-			if !strings.Contains(msg.Message, "Codex budget") {
-				t.Fatalf("Message = %q, want Codex budget warning", msg.Message)
+			if !strings.Contains(msg.Message, "Claude budget") {
+				t.Fatalf("Message = %q, want Claude budget warning", msg.Message)
 			}
 			return
 		}


### PR DESCRIPTION
## Summary
- add projection-aware budget checks that model shortened Codex descriptions
- use projection-aware checks in sync preflight and per-skill projection enforcement
- cover project-local Codex budget scoping so other project-local projections are not counted

## Verification
- go test ./internal/budget ./internal/sync ./cmd
- go test ./...
- go build ./...
- go run ./cmd/scribe sync