### PR TITLE
test: cover state schema migration compat banner

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -303,6 +303,27 @@ func TestRoot_LegacyCompatBannerThrottleFailureDoesNotBlockCommand(t *testing.T)
 	}
 }
 
+func TestRoot_LegacyCompatBannerEmitsOncePerDay(t *testing.T) {
+	home := setupLegacyCompatBannerHome(t)
+
+	stdout, stderr := executeRootForLegacyCompatBannerTest(t, home, []string{"list", "--json"})
+	if !strings.Contains(stderr, state.LegacyGlobalProjectionCompatBanner) {
+		t.Fatalf("first stderr missing compat banner:\n%s", stderr)
+	}
+	var anyJSON interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &anyJSON); err != nil {
+		t.Fatalf("first stdout not clean JSON: %v\nstdout=%q\nstderr=%q", err, stdout, stderr)
+	}
+
+	stdout, stderr = executeRootForLegacyCompatBannerTest(t, home, []string{"list", "--json"})
+	if strings.Contains(stderr, state.LegacyGlobalProjectionCompatBanner) {
+		t.Fatalf("second stderr should not repeat compat banner:\n%s", stderr)
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &anyJSON); err != nil {
+		t.Fatalf("second stdout not clean JSON: %v\nstdout=%q\nstderr=%q", err, stdout, stderr)
+	}
+}
+
 func TestRoot_LegacyCompatBannerCorruptTimestampDoesNotBlockCommand(t *testing.T) {
 	home := setupLegacyCompatBannerHome(t)
 	timestampPath := filepath.Join(home, ".scribe", "legacy-global-projection-banner.date")


### PR DESCRIPTION
## Summary
- Adds CLI coverage that legacy global-projection compat mode emits the deprecation banner only once per day.
- Confirms repeated `list --json` invocations keep stdout clean JSON while throttling the banner on stderr.

## Verification
- `go test ./cmd -run "TestRoot_LegacyCompatBanner"`
- `go test ./internal/state ./internal/projectmigrate ./internal/sync ./cmd -run "TestStateMigrateLegacyToolsPathsToProjectionsRoundTrip|TestStateMigrateV5DenyListPreservedWhileAddingProjections|TestDetectLegacyGlobalProjectionCompat|TestShouldEmitLegacyGlobalProjectionCompatBannerAt|TestGlobalToProjects|TestRoot_LegacyCompatBanner|TestApplyDeletesSnapshotOnFailure|TestUndo"`

## Note
- `go test ./...` currently fails in `cmd/TestSemanticExitCodesSubprocessMatrix/auth_failure` with exit 1 (`kit "generalist" not found`) instead of expected exit 4. This was present before the scoped #383 test change during this worker run.