### PR TITLE
fix: prune orphaned Codex globals during project sync

### DIFF
--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -273,42 +273,34 @@ func (e *Engine) removeOrphanedGlobalCodexProjections(st *state.State, storeDir 
 	if !ok {
 		return 0, nil, nil
 	}
-	skillsDir, err := codexGlobalSkillsDir()
-	if err != nil {
-		return 0, nil, err
-	}
-	entries, err := os.ReadDir(skillsDir)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return 0, nil, nil
-		}
-		return 0, nil, err
-	}
 
 	var removed int
 	var actions []Action
-	for _, entry := range entries {
-		name := entry.Name()
-		if name == "" || name == ".system" {
+	for name, skill := range st.Installed {
+		globalPath, err := codexTool.SkillPath(name, "")
+		if err != nil {
 			continue
 		}
-		path := filepath.Join(skillsDir, name)
-		if !isManagedProjection(path, filepath.Join(storeDir, name)) {
+		if hasTrackedGlobalToolProjection(skill, codexTool.Name()) {
 			continue
 		}
-		if hasTrackedGlobalToolProjection(st.Installed[name], codexTool.Name()) {
-			continue
-		}
-		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return removed, actions, err
-		}
-		if skill, ok := st.Installed[name]; ok {
+		for _, path := range projectionPaths(skill) {
+			if path != globalPath {
+				continue
+			}
+			if !isManagedProjection(path, filepath.Join(storeDir, name)) {
+				continue
+			}
+			if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				return removed, actions, err
+			}
 			skill.Paths = removePath(skill.Paths, path)
 			skill.ManagedPaths = removePath(skill.ManagedPaths, path)
 			st.Installed[name] = skill
+			removed++
+			actions = append(actions, Action{Kind: ActionRemoved, Name: name, Tool: codexTool.Name(), Path: path})
+			break
 		}
-		removed++
-		actions = append(actions, Action{Kind: ActionRemoved, Name: name, Tool: codexTool.Name(), Path: path})
 	}
 	return removed, actions, nil
 }
@@ -322,7 +314,7 @@ func (e *Engine) isOtherProjectProjection(path, skillName string, skill state.In
 			continue
 		}
 		for _, toolName := range projection.Tools {
-			tool, ok := byName[toolName]
+			tool, ok := supportedToolByName(toolName, byName)
 			if !ok {
 				continue
 			}
@@ -333,14 +325,6 @@ func (e *Engine) isOtherProjectProjection(path, skillName string, skill state.In
 		}
 	}
 	return false
-}
-
-func codexGlobalSkillsDir() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("home dir: %w", err)
-	}
-	return filepath.Join(home, ".agents", "skills"), nil
 }
 
 func hasTrackedGlobalToolProjection(skill state.InstalledSkill, toolName string) bool {
@@ -355,6 +339,18 @@ func hasTrackedGlobalToolProjection(skill state.InstalledSkill, toolName string)
 		}
 	}
 	return false
+}
+
+func supportedToolByName(toolName string, active map[string]tools.Tool) (tools.Tool, bool) {
+	if tool, ok := active[toolName]; ok {
+		return tool, true
+	}
+	for _, tool := range tools.DefaultTools() {
+		if tool.Name() == toolName {
+			return tool, true
+		}
+	}
+	return nil, false
 }
 
 func removePath(paths []string, path string) []string {

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -69,6 +69,15 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 		byName[tool.Name()] = tool
 	}
 
+	if e.ProjectRoot != "" {
+		removed, removedActions, err := e.removeOrphanedGlobalCodexProjections(st, storeDir, byName)
+		if err != nil {
+			return summary, actions, err
+		}
+		summary.Removed += removed
+		actions = append(actions, removedActions...)
+	}
+
 	pkgsDir, pkgErr := tools.PackagesDir()
 	if pkgErr != nil {
 		return summary, nil, pkgErr
@@ -205,6 +214,10 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 			if path == "" {
 				continue
 			}
+			if e.isOtherProjectProjection(path, name, skill, byName) {
+				newManaged[path] = true
+				continue
+			}
 			toolName := inferToolName(path, byName, name, e.ProjectRoot)
 			if _, err := os.Lstat(path); err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
@@ -253,6 +266,105 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 	}
 
 	return summary, actions, nil
+}
+
+func (e *Engine) removeOrphanedGlobalCodexProjections(st *state.State, storeDir string, byName map[string]tools.Tool) (int, []Action, error) {
+	codexTool, ok := byName["codex"]
+	if !ok {
+		return 0, nil, nil
+	}
+	skillsDir, err := codexGlobalSkillsDir()
+	if err != nil {
+		return 0, nil, err
+	}
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, nil, nil
+		}
+		return 0, nil, err
+	}
+
+	var removed int
+	var actions []Action
+	for _, entry := range entries {
+		name := entry.Name()
+		if name == "" || name == ".system" {
+			continue
+		}
+		path := filepath.Join(skillsDir, name)
+		if !isManagedProjection(path, filepath.Join(storeDir, name)) {
+			continue
+		}
+		if hasTrackedGlobalToolProjection(st.Installed[name], codexTool.Name()) {
+			continue
+		}
+		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return removed, actions, err
+		}
+		if skill, ok := st.Installed[name]; ok {
+			skill.Paths = removePath(skill.Paths, path)
+			skill.ManagedPaths = removePath(skill.ManagedPaths, path)
+			st.Installed[name] = skill
+		}
+		removed++
+		actions = append(actions, Action{Kind: ActionRemoved, Name: name, Tool: codexTool.Name(), Path: path})
+	}
+	return removed, actions, nil
+}
+
+func (e *Engine) isOtherProjectProjection(path, skillName string, skill state.InstalledSkill, byName map[string]tools.Tool) bool {
+	if e.ProjectRoot == "" {
+		return false
+	}
+	for _, projection := range skill.Projections {
+		if projection.Project == "" || projection.Project == e.ProjectRoot {
+			continue
+		}
+		for _, toolName := range projection.Tools {
+			tool, ok := byName[toolName]
+			if !ok {
+				continue
+			}
+			toolPath, err := tool.SkillPath(skillName, projection.Project)
+			if err == nil && toolPath == path {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func codexGlobalSkillsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, ".agents", "skills"), nil
+}
+
+func hasTrackedGlobalToolProjection(skill state.InstalledSkill, toolName string) bool {
+	for _, projection := range skill.Projections {
+		if projection.Project != "" {
+			continue
+		}
+		for _, tool := range projection.Tools {
+			if tool == toolName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func removePath(paths []string, path string) []string {
+	out := paths[:0]
+	for _, existing := range paths {
+		if existing != path {
+			out = append(out, existing)
+		}
+	}
+	return out
 }
 
 func projectionPaths(skill state.InstalledSkill) []string {

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -407,6 +407,54 @@ func TestReconcileDropsMissingRecordedProjection(t *testing.T) {
 	}
 }
 
+func TestReconcilePreservesOtherProjectCodexProjectionWhenCodexInactive(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	canonical, err := tools.WriteToStore("recap", []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}})
+	if err != nil {
+		t.Fatalf("WriteToStore: %v", err)
+	}
+
+	projectOne := t.TempDir()
+	projectTwo := t.TempDir()
+	projectTwoPath := filepath.Join(projectTwo, ".agents", "skills", "recap")
+	if err := os.MkdirAll(filepath.Dir(projectTwoPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll project two: %v", err)
+	}
+	if err := os.Symlink(canonical, projectTwoPath); err != nil {
+		t.Fatalf("Symlink project two: %v", err)
+	}
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"recap": {
+			Revision:     1,
+			Tools:        []string{"codex"},
+			ToolsMode:    state.ToolsModePinned,
+			ManagedPaths: []string{projectTwoPath},
+			Projections:  []state.ProjectionEntry{{Project: projectTwo, Tools: []string{"codex"}}},
+		},
+	}}
+	engine := reconcile.Engine{
+		Tools:       []tools.Tool{tools.ClaudeTool{}},
+		ProjectRoot: projectOne,
+		Now:         func() time.Time { return time.Unix(7, 0).UTC() },
+	}
+	summary, _, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Removed != 0 || len(summary.Conflicts) != 0 {
+		t.Fatalf("summary = %+v, want other-project projection preserved", summary)
+	}
+	if _, err := os.Lstat(projectTwoPath); err != nil {
+		t.Fatalf("project two projection missing: %v", err)
+	}
+	if got := st.Installed["recap"].ManagedPaths; len(got) != 1 || got[0] != projectTwoPath {
+		t.Fatalf("ManagedPaths = %v, want [%s]", got, projectTwoPath)
+	}
+}
+
 func TestReconcileSkipsPackages(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -496,6 +544,46 @@ func TestRun_KitFilterEnabled_BlocksNonKitProjection(t *testing.T) {
 	}
 	if _, err := os.Lstat(filepath.Join(projectRoot, ".claude", "skills", "debugger")); err == nil {
 		t.Error("debugger symlink should not exist (not in kit)")
+	}
+}
+
+func TestReconcileProjectRootPreservesUntrackedGlobalCodexSymlink(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	canonical, err := tools.WriteToStore("recap", []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}})
+	if err != nil {
+		t.Fatalf("WriteToStore recap: %v", err)
+	}
+	globalPath := filepath.Join(home, ".agents", "skills", "recap")
+	if err := os.MkdirAll(filepath.Dir(globalPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll global: %v", err)
+	}
+	if err := os.Symlink(canonical, globalPath); err != nil {
+		t.Fatalf("Symlink global: %v", err)
+	}
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"recap": {
+			Revision:  1,
+			Tools:     []string{"codex"},
+			ToolsMode: state.ToolsModePinned,
+		},
+	}}
+	engine := reconcile.Engine{
+		Tools:       []tools.Tool{tools.CodexTool{}},
+		ProjectRoot: t.TempDir(),
+		Now:         func() time.Time { return time.Unix(8, 0).UTC() },
+	}
+	summary, _, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Removed != 0 {
+		t.Fatalf("Removed = %d, want 0 for untracked global symlink", summary.Removed)
+	}
+	if _, err := os.Lstat(globalPath); err != nil {
+		t.Fatalf("untracked global symlink missing: %v", err)
 	}
 }
 

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -499,6 +499,122 @@ func TestRun_KitFilterEnabled_BlocksNonKitProjection(t *testing.T) {
 	}
 }
 
+func TestReconcileProjectRootRemovesOrphanedGlobalCodexProjection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	canonical, err := tools.WriteToStore("recap", []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# recap\n")}})
+	if err != nil {
+		t.Fatalf("WriteToStore recap: %v", err)
+	}
+	globalPath := filepath.Join(home, ".agents", "skills", "recap")
+	if err := os.MkdirAll(filepath.Dir(globalPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll global: %v", err)
+	}
+	if err := os.Symlink(canonical, globalPath); err != nil {
+		t.Fatalf("Symlink global: %v", err)
+	}
+
+	projectOne := t.TempDir()
+	projectTwo := t.TempDir()
+	projectOnePath := filepath.Join(projectOne, ".agents", "skills", "recap")
+	projectTwoPath := filepath.Join(projectTwo, ".agents", "skills", "recap")
+	for _, path := range []string{projectOnePath, projectTwoPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll project: %v", err)
+		}
+		if err := os.Symlink(canonical, path); err != nil {
+			t.Fatalf("Symlink project: %v", err)
+		}
+	}
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"recap": {
+			Revision:     1,
+			Tools:        []string{"codex"},
+			ToolsMode:    state.ToolsModePinned,
+			ManagedPaths: []string{globalPath, projectOnePath, projectTwoPath},
+			Projections: []state.ProjectionEntry{
+				{Project: projectOne, Tools: []string{"codex"}},
+				{Project: projectTwo, Tools: []string{"codex"}},
+			},
+		},
+	}}
+
+	engine := reconcile.Engine{
+		Tools:       []tools.Tool{tools.CodexTool{}},
+		ProjectRoot: projectOne,
+		Now:         func() time.Time { return time.Unix(5, 0).UTC() },
+	}
+	summary, actions, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Removed != 1 {
+		t.Fatalf("Removed = %d, want 1", summary.Removed)
+	}
+	if len(actions) == 0 || actions[0].Kind != reconcile.ActionRemoved || actions[0].Path != globalPath {
+		t.Fatalf("actions = %+v, want first action removing %s", actions, globalPath)
+	}
+	if _, err := os.Lstat(globalPath); !os.IsNotExist(err) {
+		t.Fatalf("global projection still exists: %v", err)
+	}
+	if _, err := os.Lstat(projectOnePath); err != nil {
+		t.Fatalf("project one projection missing: %v", err)
+	}
+	if _, err := os.Lstat(projectTwoPath); err != nil {
+		t.Fatalf("project two projection affected: %v", err)
+	}
+	for _, path := range st.Installed["recap"].ManagedPaths {
+		if path == globalPath {
+			t.Fatalf("ManagedPaths retained removed global path: %v", st.Installed["recap"].ManagedPaths)
+		}
+	}
+}
+
+func TestReconcileProjectRootPreservesTrackedGlobalCodexProjection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	canonical, err := tools.WriteToStore("scribe", []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# scribe\n")}})
+	if err != nil {
+		t.Fatalf("WriteToStore scribe: %v", err)
+	}
+	globalPath := filepath.Join(home, ".agents", "skills", "scribe")
+	if err := os.MkdirAll(filepath.Dir(globalPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll global: %v", err)
+	}
+	if err := os.Symlink(canonical, globalPath); err != nil {
+		t.Fatalf("Symlink global: %v", err)
+	}
+
+	st := &state.State{SchemaVersion: 4, Installed: map[string]state.InstalledSkill{
+		"scribe": {
+			Revision:     1,
+			Tools:        []string{"codex"},
+			ToolsMode:    state.ToolsModePinned,
+			ManagedPaths: []string{globalPath},
+			Projections:  []state.ProjectionEntry{{Project: "", Tools: []string{"codex"}}},
+		},
+	}}
+
+	engine := reconcile.Engine{
+		Tools:       []tools.Tool{tools.CodexTool{}},
+		ProjectRoot: t.TempDir(),
+		Now:         func() time.Time { return time.Unix(6, 0).UTC() },
+	}
+	summary, _, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Removed != 0 {
+		t.Fatalf("Removed = %d, want 0", summary.Removed)
+	}
+	if _, err := os.Lstat(globalPath); err != nil {
+		t.Fatalf("tracked global projection missing: %v", err)
+	}
+}
+
 func TestReconcileRemovesStalePackageProjection(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary
- prune orphaned global Codex skill symlinks during project-root reconcile
- preserve other projects' local Codex projections while cleaning current project scope
- keep explicitly tracked global Codex projections intact

## Verification
- go test ./internal/reconcile
- go test ./internal/sync ./internal/reconcile ./internal/workflow
- go test ./... still fails in known pre-existing cmd/TestSemanticExitCodesSubprocessMatrix/auth_failure
- real Codex smoke: patched sync reduced global symlinks from 101 to 8; codex debug prompt-input from Scribe repo emitted zero skill-budget warnings