### PR TITLE
Stop publishing checksums.txt in releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
-  name_template: "checksums.txt"
+  disable: true
 
 changelog:
   sort: asc

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -468,6 +468,25 @@ func (c *Client) DownloadReleaseAsset(ctx context.Context, owner, repo string, i
 	return rc, nil
 }
 
+// ReleaseAssetDigest returns GitHub's SHA-256 digest for a release asset.
+func (c *Client) ReleaseAssetDigest(ctx context.Context, owner, repo string, id int64) (string, error) {
+	req, err := c.gh.NewRequest(http.MethodGet, fmt.Sprintf("repos/%s/%s/releases/assets/%d", owner, repo, id), nil)
+	if err != nil {
+		return "", fmt.Errorf("build release asset request %d from %s/%s: %w", id, owner, repo, err)
+	}
+
+	var asset struct {
+		Digest *string `json:"digest"`
+	}
+	if _, err := c.gh.Do(ctx, req, &asset); err != nil {
+		return "", wrapErr(err, fmt.Sprintf("release asset %d from %s/%s", id, owner, repo))
+	}
+	if asset.Digest == nil {
+		return "", nil
+	}
+	return *asset.Digest, nil
+}
+
 // wrapErr produces user-friendly errors for common GitHub API failures.
 func wrapErr(err error, operation string) error {
 	if err == nil {

--- a/internal/github/push_test.go
+++ b/internal/github/push_test.go
@@ -75,3 +75,33 @@ func TestPushFilesAtomicClassifiesUpdateRefNonFastForwardAsConflict(t *testing.T
 		t.Fatalf("exit = %d, want conflict; err=%v", clierrors.ExitCode(err), err)
 	}
 }
+
+func TestReleaseAssetDigestFetchesGitHubDigest(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/scribe/releases/assets/123", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("ReleaseAssetDigest method = %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"digest":"sha256:abc123"}`))
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL + "/")
+	if err != nil {
+		t.Fatalf("parse test URL: %v", err)
+	}
+	ghClient := github.NewClient(server.Client())
+	ghClient.BaseURL = baseURL
+	client := &Client{gh: ghClient, authenticated: true}
+
+	got, err := client.ReleaseAssetDigest(context.Background(), "acme", "scribe", 123)
+	if err != nil {
+		t.Fatalf("ReleaseAssetDigest() error = %v", err)
+	}
+	if got != "sha256:abc123" {
+		t.Fatalf("ReleaseAssetDigest() = %q, want sha256:abc123", got)
+	}
+}

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -270,9 +270,10 @@ func UpgradeGoInstall(ctx context.Context) ([]byte, error) {
 // AssetDownloader downloads a release asset by ID.
 type AssetDownloader interface {
 	DownloadReleaseAsset(ctx context.Context, owner, repo string, id int64) (io.ReadCloser, error)
+	ReleaseAssetDigest(ctx context.Context, owner, repo string, id int64) (string, error)
 }
 
-// UpgradeBinary downloads the release asset, verifies its checksum, extracts
+// UpgradeBinary downloads the release asset, verifies its GitHub digest, extracts
 // the binary, and atomically replaces the current executable.
 func UpgradeBinary(ctx context.Context, release *github.RepositoryRelease, downloader AssetDownloader) error {
 	if runtime.GOOS == "windows" {
@@ -289,41 +290,28 @@ func UpgradeBinary(ctx context.Context, release *github.RepositoryRelease, downl
 	}
 
 	assetName := fmt.Sprintf("scribe_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
-	checksumName := "checksums.txt"
 
-	var assetID, checksumID int64
+	var asset *github.ReleaseAsset
 	for _, a := range release.Assets {
-		switch a.GetName() {
-		case assetName:
-			assetID = a.GetID()
-		case checksumName:
-			checksumID = a.GetID()
+		if a.GetName() == assetName {
+			asset = a
+			break
 		}
 	}
-	if assetID == 0 {
+	if asset == nil || asset.GetID() == 0 {
 		return fmt.Errorf("no release asset %q found for %s/%s", assetName, runtime.GOOS, runtime.GOARCH)
 	}
-	if checksumID == 0 {
-		return fmt.Errorf("no checksums.txt found in release")
-	}
-
-	// Download checksum file.
-	checksumRC, err := downloader.DownloadReleaseAsset(ctx, "Naoray", "scribe", checksumID)
+	digest, err := downloader.ReleaseAssetDigest(ctx, "Naoray", "scribe", asset.GetID())
 	if err != nil {
-		return fmt.Errorf("download checksums: %w", err)
+		return fmt.Errorf("fetch %s digest: %w", assetName, err)
 	}
-	checksumData, err := io.ReadAll(checksumRC)
-	checksumRC.Close()
+	expectedHash, err := releaseAssetSHA256(digest)
 	if err != nil {
-		return fmt.Errorf("read checksums: %w", err)
-	}
-	expectedHash, err := findChecksum(checksumData, assetName)
-	if err != nil {
-		return err
+		return fmt.Errorf("verify %s digest: %w", assetName, err)
 	}
 
 	// Download the archive.
-	assetRC, err := downloader.DownloadReleaseAsset(ctx, "Naoray", "scribe", assetID)
+	assetRC, err := downloader.DownloadReleaseAsset(ctx, "Naoray", "scribe", asset.GetID())
 	if err != nil {
 		return fmt.Errorf("download asset: %w", err)
 	}
@@ -353,14 +341,20 @@ func sha256sum(data []byte) string {
 	return hex.EncodeToString(h[:])
 }
 
-// findChecksum parses a goreleaser checksums.txt and returns the SHA256
-// for the named asset. Format: "<hash>  <filename>\n"
-func findChecksum(data []byte, assetName string) (string, error) {
-	for _, line := range strings.Split(string(data), "\n") {
-		parts := strings.Fields(line)
-		if len(parts) == 2 && parts[1] == assetName {
-			return parts[0], nil
-		}
+func releaseAssetSHA256(digest string) (string, error) {
+	if digest == "" {
+		return "", fmt.Errorf("release asset is missing GitHub digest")
 	}
-	return "", fmt.Errorf("checksum for %s not found in checksums.txt", assetName)
+
+	algorithm, value, ok := strings.Cut(digest, ":")
+	if !ok {
+		return "", fmt.Errorf("invalid digest %q", digest)
+	}
+	if algorithm != "sha256" {
+		return "", fmt.Errorf("unsupported digest algorithm %q", algorithm)
+	}
+	if _, err := hex.DecodeString(value); err != nil || len(value) != sha256.Size*2 {
+		return "", fmt.Errorf("invalid sha256 digest %q", digest)
+	}
+	return strings.ToLower(value), nil
 }

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -6,6 +6,8 @@ import (
 	"compress/gzip"
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,6 +15,7 @@ import (
 	"testing"
 
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/google/go-github/v69/github"
 )
 
 func TestDetectMethod(t *testing.T) {
@@ -326,4 +329,161 @@ func TestReplaceBinary(t *testing.T) {
 			t.Fatal("expected error for nonexistent target")
 		}
 	})
+}
+
+type fakeAssetDownloader struct {
+	data    map[int64][]byte
+	digests map[int64]string
+}
+
+func (f fakeAssetDownloader) DownloadReleaseAsset(_ context.Context, _, _ string, id int64) (io.ReadCloser, error) {
+	data, ok := f.data[id]
+	if !ok {
+		return nil, fmt.Errorf("missing asset %d", id)
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (f fakeAssetDownloader) ReleaseAssetDigest(_ context.Context, _, _ string, id int64) (string, error) {
+	return f.digests[id], nil
+}
+
+func TestUpgradeBinaryVerifiesGitHubAssetDigest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("self-upgrade is not supported on Windows")
+	}
+
+	archive := createTarGz(t, []tarEntry{
+		{Name: "scribe", Content: []byte("new-scribe")},
+	})
+	assetName := fmt.Sprintf("scribe_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	assetID := int64(123)
+	digest := "sha256:" + sha256sum(archive)
+	release := &github.RepositoryRelease{
+		Assets: []*github.ReleaseAsset{{
+			ID:   github.Ptr(assetID),
+			Name: github.Ptr(assetName),
+		}},
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "scribe")
+	if err := os.WriteFile(target, []byte("old-scribe"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origExec := executablePath
+	origSymlinks := evalSymlinks
+	t.Cleanup(func() {
+		executablePath = origExec
+		evalSymlinks = origSymlinks
+	})
+	executablePath = func() (string, error) { return target, nil }
+	evalSymlinks = func(path string) (string, error) { return path, nil }
+
+	err := UpgradeBinary(context.Background(), release, fakeAssetDownloader{
+		data:    map[int64][]byte{assetID: archive},
+		digests: map[int64]string{assetID: digest},
+	})
+	if err != nil {
+		t.Fatalf("UpgradeBinary() error = %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new-scribe" {
+		t.Fatalf("upgraded binary = %q, want new-scribe", got)
+	}
+}
+
+func TestUpgradeBinaryRejectsMissingGitHubAssetDigest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("self-upgrade is not supported on Windows")
+	}
+
+	assetName := fmt.Sprintf("scribe_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	release := &github.RepositoryRelease{
+		Assets: []*github.ReleaseAsset{{
+			ID:   github.Ptr(int64(123)),
+			Name: github.Ptr(assetName),
+		}},
+	}
+
+	err := UpgradeBinary(context.Background(), release, fakeAssetDownloader{})
+	if err == nil {
+		t.Fatal("UpgradeBinary() error = nil, want missing digest error")
+	}
+	if !strings.Contains(err.Error(), "missing GitHub digest") {
+		t.Fatalf("UpgradeBinary() error = %v, want missing GitHub digest", err)
+	}
+}
+
+func TestUpgradeBinaryRejectsInvalidGitHubAssetDigest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("self-upgrade is not supported on Windows")
+	}
+
+	tests := []struct {
+		name   string
+		digest string
+		want   string
+	}{
+		{name: "malformed", digest: "not-a-digest", want: "invalid digest"},
+		{name: "unsupported algorithm", digest: "sha512:" + strings.Repeat("0", 128), want: "unsupported digest algorithm"},
+		{name: "invalid sha256", digest: "sha256:not-hex", want: "invalid sha256 digest"},
+	}
+
+	assetName := fmt.Sprintf("scribe_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assetID := int64(123)
+			release := &github.RepositoryRelease{
+				Assets: []*github.ReleaseAsset{{
+					ID:   github.Ptr(assetID),
+					Name: github.Ptr(assetName),
+				}},
+			}
+
+			err := UpgradeBinary(context.Background(), release, fakeAssetDownloader{
+				digests: map[int64]string{assetID: tt.digest},
+			})
+			if err == nil {
+				t.Fatal("UpgradeBinary() error = nil, want digest error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("UpgradeBinary() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpgradeBinaryRejectsGitHubAssetDigestMismatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("self-upgrade is not supported on Windows")
+	}
+
+	archive := createTarGz(t, []tarEntry{
+		{Name: "scribe", Content: []byte("new-scribe")},
+	})
+	assetName := fmt.Sprintf("scribe_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	assetID := int64(123)
+	release := &github.RepositoryRelease{
+		Assets: []*github.ReleaseAsset{{
+			ID:   github.Ptr(assetID),
+			Name: github.Ptr(assetName),
+		}},
+	}
+
+	err := UpgradeBinary(context.Background(), release, fakeAssetDownloader{
+		data:    map[int64][]byte{assetID: archive},
+		digests: map[int64]string{assetID: "sha256:" + strings.Repeat("0", 64)},
+	})
+	if err == nil {
+		t.Fatal("UpgradeBinary() error = nil, want checksum mismatch")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("UpgradeBinary() error = %v, want checksum mismatch", err)
+	}
 }


### PR DESCRIPTION
Future releases should not upload checksums.txt. This disables GoReleaser checksum generation and moves direct-binary upgrades to GitHub release asset digests instead.

What changed:
- disable GoReleaser checksum output
- fetch the release asset digest from GitHub asset metadata
- verify the downloaded archive SHA-256 against that digest before extracting/replacing the binary
- cover success, missing/invalid digest, mismatch, and digest fetch behavior in tests

Tested:
- go test ./internal/upgrade
- go test ./internal/github
- go test ./cmd -run TestUpgrade
- go build ./...

Known local issues:
- go test ./... still fails in cmd on unrelated existing cases: auth_failure sees kit "generalist" missing, and read-only command tests see gh write .local/state/gh/device-id.
- goreleaser check is not installed locally.