### PR TITLE
Project kit MCP servers into Claude settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe guide` | --json | yes |
 | `scribe init` | --force, --json | yes |
 | `scribe install` | --alias, --all, --force, --json, --registry | no |
-| `scribe kit create` | --description, --force, --json, --registry, --skills | no |
+| `scribe kit create` | --description, --force, --json, --mcp-servers, --registry, --skills | no |
 | `scribe list` | --fields, --json, --registry, --remote | yes |
 | `scribe migrate global-to-projects` | --dry-run, --force, --json, --project, --undo, --yes | yes |
 | `scribe migrate` | --json | no |

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -151,9 +151,9 @@ If a project root has `.scribe.yaml`, it declares per-project intent — `kits`,
 
 ### Kits
 
-A Kit is a named YAML bundle of skills stored at `~/.scribe/kits/<name>.yaml`.
+A Kit is a named YAML bundle of skills and optional MCP server names stored at `~/.scribe/kits/<name>.yaml`.
 
-Schema: `{name, description?, skills[], source?{registry, rev?}}`
+Schema: `{name, description?, skills[], mcp_servers?, source?{registry, rev?}}`
 
 Example:
 
@@ -164,6 +164,8 @@ skills:
   - eloquent
   - queues
   - livewire
+mcp_servers:
+  - mempalace
 source:
   registry: my-org/scribe-registry
 ```
@@ -177,7 +179,7 @@ kits:
   - laravel-stack
 ```
 
-`scribe sync` resolves the final skill set as the union of `kit.Skills` plus `projectFile.Add`, then subtracts `projectFile.Remove`.
+`scribe sync` resolves the final skill set as the union of `kit.Skills` plus `projectFile.Add`, then subtracts `projectFile.Remove`. It also resolves kit-declared `mcp_servers` as read-only project workflow state for upcoming project-local MCP projection; it does not write agent MCP settings or enforce server startup yet.
 
 To author a Kit, run:
 

--- a/cmd/kit.go
+++ b/cmd/kit.go
@@ -17,15 +17,17 @@ import (
 type kitCreateOptions struct {
 	description string
 	skills      []string
+	mcpServers  []string
 	registry    string
 	force       bool
 	json        bool
 }
 
 type kitCreateOutput struct {
-	Name        string `json:"name"`
-	Path        string `json:"path"`
-	SkillsCount int    `json:"skills_count"`
+	Name            string `json:"name"`
+	Path            string `json:"path"`
+	SkillsCount     int    `json:"skills_count"`
+	MCPServersCount int    `json:"mcp_servers_count"`
 }
 
 func newKitCommand() *cobra.Command {
@@ -50,6 +52,7 @@ func newKitCreateCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&opts.description, "description", "", "Kit description")
 	cmd.Flags().StringSliceVar(&opts.skills, "skills", nil, "Comma-separated skill names")
+	cmd.Flags().StringSliceVar(&opts.mcpServers, "mcp-servers", nil, "Comma-separated MCP server names")
 	cmd.Flags().StringVar(&opts.registry, "registry", "", "Source registry for this kit")
 	cmd.Flags().BoolVar(&opts.force, "force", false, "Overwrite an existing kit")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output machine-readable JSON")
@@ -86,6 +89,7 @@ func runKitCreate(cmd *cobra.Command, name string, opts *kitCreateOptions) error
 		Name:        name,
 		Description: opts.description,
 		Skills:      opts.skills,
+		MCPServers:  opts.mcpServers,
 	}
 	if opts.registry != "" {
 		k.Source = &kit.Source{Registry: opts.registry}
@@ -96,15 +100,16 @@ func runKitCreate(cmd *cobra.Command, name string, opts *kitCreateOptions) error
 	}
 
 	out := kitCreateOutput{
-		Name:        name,
-		Path:        kitPath,
-		SkillsCount: len(opts.skills),
+		Name:            name,
+		Path:            kitPath,
+		SkillsCount:     len(opts.skills),
+		MCPServersCount: len(opts.mcpServers),
 	}
 	if opts.json {
 		return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "Created kit %s at %s with %d skills\n", out.Name, out.Path, out.SkillsCount)
+	fmt.Fprintf(cmd.OutOrStdout(), "Created kit %s at %s with %d skills and %d MCP servers\n", out.Name, out.Path, out.SkillsCount, out.MCPServersCount)
 	return nil
 }
 

--- a/cmd/kit_test.go
+++ b/cmd/kit_test.go
@@ -21,6 +21,8 @@ func TestKitCreateWritesKitYAML(t *testing.T) {
 		"--description", "Laravel project defaults",
 		"--skills", "eloquent,queues",
 		"--skills", "livewire",
+		"--mcp-servers", "mempalace",
+		"--mcp-servers", "playwright,github",
 		"--registry", "my-org/scribe-registry",
 	})
 
@@ -55,8 +57,17 @@ func TestKitCreateWritesKitYAML(t *testing.T) {
 			t.Fatalf("skills = %#v, want %#v", got.Skills, wantSkills)
 		}
 	}
+	wantMCPServers := []string{"mempalace", "playwright", "github"}
+	if len(got.MCPServers) != len(wantMCPServers) {
+		t.Fatalf("mcp_servers = %#v, want %#v", got.MCPServers, wantMCPServers)
+	}
+	for i := range wantMCPServers {
+		if got.MCPServers[i] != wantMCPServers[i] {
+			t.Fatalf("mcp_servers = %#v, want %#v", got.MCPServers, wantMCPServers)
+		}
+	}
 
-	wantOutput := "Created kit laravel-stack at " + kitPath + " with 3 skills\n"
+	wantOutput := "Created kit laravel-stack at " + kitPath + " with 3 skills and 3 MCP servers\n"
 	if out.String() != wantOutput {
 		t.Fatalf("output = %q, want %q", out.String(), wantOutput)
 	}
@@ -77,9 +88,10 @@ func TestKitCreateJSONOutput(t *testing.T) {
 	}
 
 	var payload struct {
-		Name        string `json:"name"`
-		Path        string `json:"path"`
-		SkillsCount int    `json:"skills_count"`
+		Name            string `json:"name"`
+		Path            string `json:"path"`
+		SkillsCount     int    `json:"skills_count"`
+		MCPServersCount int    `json:"mcp_servers_count"`
 	}
 	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
 		t.Fatalf("parse json output: %v\n%s", err, out.String())
@@ -93,6 +105,9 @@ func TestKitCreateJSONOutput(t *testing.T) {
 	}
 	if payload.SkillsCount != 2 {
 		t.Fatalf("skills_count = %d, want 2", payload.SkillsCount)
+	}
+	if payload.MCPServersCount != 0 {
+		t.Fatalf("mcp_servers_count = %d, want 0", payload.MCPServersCount)
 	}
 }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,7 +47,7 @@ For machine-readable details (input flags, output schema, exit codes), pair this
 | `scribe skill tools <name>` | Per-skill tool projection controls (`--enable`, `--disable`, `--reset`) |
 | `scribe tools` | List, enable, or disable detected tools machine-wide |
 | `scribe tools add` | Register a custom tool integration (`--detect`, `--install`, `--path`, `--uninstall`) |
-| `scribe kit create <name>` | Create a local kit — a named list of skills projected into a project (saved to `~/.scribe/kits/<name>.yaml`). Use `--skills` to populate it and `--registry` to scope it to one registry. Reference the kit by name in a project's `.scribe.yaml` under `kits:`. |
+| `scribe kit create <name>` | Create a local kit — a named list of skills and MCP servers scoped to a project (saved to `~/.scribe/kits/<name>.yaml`). Use `--skills`, `--mcp-servers`, and `--registry` to populate it. Reference the kit by name in a project's `.scribe.yaml` under `kits:`. |
 
 ## Conflicts and recovery
 

--- a/docs/projects-and-kits.md
+++ b/docs/projects-and-kits.md
@@ -54,7 +54,7 @@ skills:
   - debugger
 ```
 
-Projects list which kits they want via `kits:` in `.scribe.yaml`. Multiple kits union; the project may add or remove individual skills on top with `add:` / `remove:`.
+Projects list which kits they want via `kits:` in `.scribe.yaml`. Multiple kits union; the project may add or remove individual skills on top with `add:` / `remove:`. MCP servers can also be declared through kits; `scribe sync` resolves those names as read-only project workflow state for upcoming project-local MCP projection. It does not enforce runtime MCP startup or write agent MCP settings yet.
 
 ### Authoring kits and snippets (today)
 

--- a/docs/projects-and-kits.md
+++ b/docs/projects-and-kits.md
@@ -52,6 +52,9 @@ skills:
   - init-filament
   - tdd
   - debugger
+mcp_servers:
+  - mempalace
+  - laravel-boost
 ```
 
 Projects list which kits they want via `kits:` in `.scribe.yaml`. Multiple kits union; the project may add or remove individual skills on top with `add:` / `remove:`. MCP servers can also be declared through kits; `scribe sync` resolves those names as read-only project workflow state for upcoming project-local MCP projection. It does not enforce runtime MCP startup or write agent MCP settings yet.
@@ -63,7 +66,7 @@ A user-facing `scribe kit` / `scribe snippet` CLI is on the v1.1 roadmap. Until 
 Examples:
 
 ```text
-You: Create a kit called web-baseline with tdd, code-review, and commit-message.
+You: Create a kit called web-baseline with tdd, code-review, commit-message, and the mempalace MCP server.
 Agent: <writes ~/.scribe/kits/web-baseline.yaml, runs `scribe sync`>
 
 You: Add a snippet that enforces commit discipline, target Claude and Codex.

--- a/internal/kit/kit.go
+++ b/internal/kit/kit.go
@@ -16,6 +16,7 @@ type Kit struct {
 	Name        string   `yaml:"name"`
 	Description string   `yaml:"description,omitempty"`
 	Skills      []string `yaml:"skills"`
+	MCPServers  []string `yaml:"mcp_servers,omitempty"`
 	Source      *Source  `yaml:"source,omitempty"`
 }
 
@@ -41,6 +42,9 @@ func Load(path string) (*Kit, error) {
 	}
 	if kit.Skills == nil {
 		kit.Skills = []string{}
+	}
+	if kit.MCPServers == nil {
+		kit.MCPServers = []string{}
 	}
 	return &kit, nil
 }

--- a/internal/kit/kit_test.go
+++ b/internal/kit/kit_test.go
@@ -17,6 +17,9 @@ skills:
   - init-react
   - init-tailwind
   - init-*
+mcp_servers:
+  - mempalace
+  - playwright
 source:
   registry: core
   rev: abc123
@@ -34,6 +37,7 @@ source:
 		Name:        "frontend",
 		Description: "Frontend defaults",
 		Skills:      []string{"init-react", "init-tailwind", "init-*"},
+		MCPServers:  []string{"mempalace", "playwright"},
 		Source: &Source{
 			Registry: "core",
 			Rev:      "abc123",
@@ -80,6 +84,7 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 		Name:        "frontend",
 		Description: "Frontend defaults",
 		Skills:      []string{"init-react", "init-tailwind"},
+		MCPServers:  []string{"mempalace"},
 		Source: &Source{
 			Registry: "core",
 			Rev:      "abc123",

--- a/internal/kit/resolver.go
+++ b/internal/kit/resolver.go
@@ -53,6 +53,33 @@ func Resolve(pf *projectfile.ProjectFile, availableKits map[string]*Kit, install
 	return skills, nil
 }
 
+// ResolveMCPServers returns the final MCP server set for a project.
+// MCP servers are kit-scoped so projects only activate runtime tools declared
+// by their selected kits.
+func ResolveMCPServers(pf *projectfile.ProjectFile, availableKits map[string]*Kit) ([]string, error) {
+	if pf == nil {
+		pf = &projectfile.ProjectFile{}
+	}
+
+	result := make(map[string]struct{})
+	for _, kitName := range pf.Kits {
+		kit, ok := availableKits[kitName]
+		if !ok {
+			return nil, fmt.Errorf("kit %q not found", kitName)
+		}
+		for _, server := range kit.MCPServers {
+			result[server] = struct{}{}
+		}
+	}
+
+	servers := make([]string, 0, len(result))
+	for server := range result {
+		servers = append(servers, server)
+	}
+	sort.Strings(servers)
+	return servers, nil
+}
+
 func expandSkillPattern(pattern string, installedSkills []string) ([]string, error) {
 	if !hasGlobMeta(pattern) {
 		return []string{pattern}, nil

--- a/internal/kit/resolver_test.go
+++ b/internal/kit/resolver_test.go
@@ -114,3 +114,65 @@ func TestResolve(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveMCPServers(t *testing.T) {
+	tests := []struct {
+		name          string
+		projectFile   *projectfile.ProjectFile
+		availableKits map[string]*Kit
+		want          []string
+		wantErr       string
+	}{
+		{
+			name:        "empty project file",
+			projectFile: &projectfile.ProjectFile{},
+			want:        []string{},
+		},
+		{
+			name: "single kit returns its MCP servers",
+			projectFile: &projectfile.ProjectFile{
+				Kits: []string{"agent-runtime"},
+			},
+			availableKits: map[string]*Kit{
+				"agent-runtime": {Name: "agent-runtime", MCPServers: []string{"mempalace", "playwright"}},
+			},
+			want: []string{"mempalace", "playwright"},
+		},
+		{
+			name: "multiple kits union without duplicates",
+			projectFile: &projectfile.ProjectFile{
+				Kits: []string{"memory", "browser"},
+			},
+			availableKits: map[string]*Kit{
+				"memory":  {Name: "memory", MCPServers: []string{"mempalace", "github"}},
+				"browser": {Name: "browser", MCPServers: []string{"playwright", "github"}},
+			},
+			want: []string{"github", "mempalace", "playwright"},
+		},
+		{
+			name: "missing kit returns error with name",
+			projectFile: &projectfile.ProjectFile{
+				Kits: []string{"missing"},
+			},
+			wantErr: "missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveMCPServers(tt.projectFile, tt.availableKits)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ResolveMCPServers() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveMCPServers() error = %v", err)
+			}
+			if strings.Join(got, "\x00") != strings.Join(tt.want, "\x00") {
+				t.Fatalf("ResolveMCPServers() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -40,6 +40,12 @@ type Bag struct {
 	KitFilter        []string
 	KitFilterEnabled bool
 
+	// ProjectMCPServers is populated by StepResolveMCPServers from kit-declared
+	// MCP server names. It is read-only workflow state for future projection;
+	// no agent settings are written from this value yet.
+	ProjectMCPServers        []string
+	ProjectMCPServersEnabled bool
+
 	// Populated by steps
 	Config      *config.Config
 	State       *state.State

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -2,7 +2,10 @@ package workflow
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -39,6 +42,7 @@ func SyncSteps() []Step {
 		{"ResolveProjectRoot", StepResolveProjectRoot},
 		{"ResolveKitFilter", StepResolveKitFilter},
 		{"ResolveMCPServers", StepResolveMCPServers},
+		{"ProjectClaudeMCPServers", StepProjectClaudeMCPServers},
 		{"EnsureScribeAgent", StepEnsureScribeAgent},
 		{"Adopt", StepAdopt},
 		{"ReconcilePre", StepReconcileSystem},
@@ -55,6 +59,7 @@ func SyncTail() []Step {
 		{"ResolveProjectRoot", StepResolveProjectRoot},
 		{"ResolveKitFilter", StepResolveKitFilter},
 		{"ResolveMCPServers", StepResolveMCPServers},
+		{"ProjectClaudeMCPServers", StepProjectClaudeMCPServers},
 		{"EnsureScribeAgent", StepEnsureScribeAgent},
 		{"SyncSkills", StepSyncSkills},
 		{"ReconcilePost", StepReconcileSystem},
@@ -198,6 +203,77 @@ func StepResolveMCPServers(_ context.Context, b *Bag) error {
 	}
 	b.ProjectMCPServers, b.ProjectMCPServersEnabled = ResolveProjectMCPServers()
 	return nil
+}
+
+// StepProjectClaudeMCPServers writes kit-resolved MCP server approvals into
+// shared project Claude settings. Server definitions remain in .mcp.json.
+func StepProjectClaudeMCPServers(_ context.Context, b *Bag) error {
+	if b.ProjectRoot == "" || !b.ProjectMCPServersEnabled || !hasTool(b.Tools, "claude") {
+		return nil
+	}
+	if err := projectClaudeMCPServers(b.ProjectRoot, b.ProjectMCPServers); err != nil {
+		return fmt.Errorf("project claude MCP servers: %w", err)
+	}
+	return nil
+}
+
+func projectClaudeMCPServers(projectRoot string, servers []string) error {
+	settingsDir := filepath.Join(projectRoot, ".claude")
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+
+	settings := map[string]any{}
+	data, err := os.ReadFile(settingsPath)
+	if err == nil {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return fmt.Errorf("parse %s: %w", settingsPath, err)
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("read %s: %w", settingsPath, err)
+	}
+
+	resolved := append([]string(nil), servers...)
+	sort.Strings(resolved)
+	settings["enableAllProjectMcpServers"] = false
+	settings["enabledMcpjsonServers"] = resolved
+
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		return fmt.Errorf("create claude settings dir: %w", err)
+	}
+	data, err = json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode claude settings: %w", err)
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(settingsDir, ".settings.json.*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp claude settings: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp claude settings: %w", err)
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp claude settings: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp claude settings: %w", err)
+	}
+	if err := os.Rename(tmpPath, settingsPath); err != nil {
+		return fmt.Errorf("save claude settings: %w", err)
+	}
+	return nil
+}
+
+func hasTool(tools []tools.Tool, name string) bool {
+	for _, tool := range tools {
+		if tool.Name() == name {
+			return true
+		}
+	}
+	return false
 }
 
 func StepLoadConfig(ctx context.Context, b *Bag) error {

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -38,6 +38,7 @@ func SyncSteps() []Step {
 		{"ResolveTools", StepResolveTools},
 		{"ResolveProjectRoot", StepResolveProjectRoot},
 		{"ResolveKitFilter", StepResolveKitFilter},
+		{"ResolveMCPServers", StepResolveMCPServers},
 		{"EnsureScribeAgent", StepEnsureScribeAgent},
 		{"Adopt", StepAdopt},
 		{"ReconcilePre", StepReconcileSystem},
@@ -53,6 +54,7 @@ func SyncTail() []Step {
 		{"ResolveTools", StepResolveTools},
 		{"ResolveProjectRoot", StepResolveProjectRoot},
 		{"ResolveKitFilter", StepResolveKitFilter},
+		{"ResolveMCPServers", StepResolveMCPServers},
 		{"EnsureScribeAgent", StepEnsureScribeAgent},
 		{"SyncSkills", StepSyncSkills},
 		{"ReconcilePost", StepReconcileSystem},
@@ -153,6 +155,48 @@ func StepResolveKitFilter(_ context.Context, b *Bag) error {
 		return nil
 	}
 	b.KitFilter, b.KitFilterEnabled = ResolveKitFilter(b.State)
+	return nil
+}
+
+// ResolveProjectMCPServers resolves kit-declared MCP server names for the
+// current project. All errors are non-fatal; a missing or malformed project
+// file returns (nil, false) so callers do not write runtime settings yet.
+func ResolveProjectMCPServers() (servers []string, enabled bool) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, false
+	}
+	projectPath, err := projectfile.Find(wd)
+	if err != nil || projectPath == "" {
+		return nil, false
+	}
+	pf, err := projectfile.Load(projectPath)
+	if err != nil {
+		return nil, false
+	}
+	scribeDir, err := paths.ScribeDir()
+	if err != nil {
+		return nil, false
+	}
+	kits, err := kit.LoadAll(filepath.Join(scribeDir, "kits"))
+	if err != nil {
+		return nil, false
+	}
+	resolved, err := kit.ResolveMCPServers(pf, kits)
+	if err != nil {
+		return nil, false
+	}
+	return resolved, true
+}
+
+// StepResolveMCPServers loads the project's .scribe.yaml and resolves
+// kit-declared MCP server names into read-only workflow state. It does not
+// write any agent runtime settings.
+func StepResolveMCPServers(_ context.Context, b *Bag) error {
+	if b.ProjectRoot == "" {
+		return nil
+	}
+	b.ProjectMCPServers, b.ProjectMCPServersEnabled = ResolveProjectMCPServers()
 	return nil
 }
 
@@ -346,13 +390,13 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 	resolved := map[string]sync.SkillStatus{}
 
 	syncer := &sync.Syncer{
-		Client:      sync.WrapGitHubClient(b.Client),
-		Provider:    b.Provider,
-		Tools:       b.Tools,
-		Executor:    &sync.ShellExecutor{},
-		TrustAll:    b.TrustAllFlag,
-		ForceBudget: b.ForceBudget,
-		AliasName:   b.AliasName,
+		Client:           sync.WrapGitHubClient(b.Client),
+		Provider:         b.Provider,
+		Tools:            b.Tools,
+		Executor:         &sync.ShellExecutor{},
+		TrustAll:         b.TrustAllFlag,
+		ForceBudget:      b.ForceBudget,
+		AliasName:        b.AliasName,
 		SkillFilter:      b.SkillFilter,
 		KitFilter:        b.KitFilter,
 		KitFilterEnabled: b.KitFilterEnabled,

--- a/internal/workflow/sync_test.go
+++ b/internal/workflow/sync_test.go
@@ -174,3 +174,84 @@ func TestStepResolveKitFilter_NoProjectFile(t *testing.T) {
 		t.Fatalf("KitFilter = %v, want nil (no project scope)", b.KitFilter)
 	}
 }
+
+func TestStepResolveMCPServers_WithProjectFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projectDir := t.TempDir()
+	pfContent := "kits:\n  - runtime-kit\n"
+	if err := os.WriteFile(filepath.Join(projectDir, projectfile.Filename), []byte(pfContent), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+
+	kitsDir := filepath.Join(home, ".scribe", "kits")
+	if err := os.MkdirAll(kitsDir, 0o755); err != nil {
+		t.Fatalf("mkdir kits: %v", err)
+	}
+	kitContent := "name: runtime-kit\nskills:\n  - recap\nmcp_servers:\n  - playwright\n  - mempalace\n"
+	if err := os.WriteFile(filepath.Join(kitsDir, "runtime-kit.yaml"), []byte(kitContent), 0o644); err != nil {
+		t.Fatalf("write kit file: %v", err)
+	}
+
+	t.Chdir(projectDir)
+
+	b := &Bag{ProjectRoot: projectDir}
+	if err := StepResolveMCPServers(context.Background(), b); err != nil {
+		t.Fatalf("StepResolveMCPServers: %v", err)
+	}
+
+	want := []string{"mempalace", "playwright"}
+	if len(b.ProjectMCPServers) != len(want) {
+		t.Fatalf("ProjectMCPServers = %v, want %v", b.ProjectMCPServers, want)
+	}
+	for i := range want {
+		if b.ProjectMCPServers[i] != want[i] {
+			t.Fatalf("ProjectMCPServers = %v, want %v", b.ProjectMCPServers, want)
+		}
+	}
+	if !b.ProjectMCPServersEnabled {
+		t.Fatal("ProjectMCPServersEnabled should be true after MCP server resolution")
+	}
+}
+
+func TestStepResolveMCPServers_NoProjectFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	emptyDir := t.TempDir()
+	t.Chdir(emptyDir)
+
+	b := &Bag{ProjectRoot: ""}
+	if err := StepResolveMCPServers(context.Background(), b); err != nil {
+		t.Fatalf("StepResolveMCPServers: %v", err)
+	}
+	if b.ProjectMCPServers != nil {
+		t.Fatalf("ProjectMCPServers = %v, want nil (no project scope)", b.ProjectMCPServers)
+	}
+	if b.ProjectMCPServersEnabled {
+		t.Fatal("ProjectMCPServersEnabled should be false without project scope")
+	}
+}
+
+func TestStepResolveMCPServers_MalformedProjectFileNonFatal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, projectfile.Filename), []byte("kits:\n  - [broken\n"), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+	t.Chdir(projectDir)
+
+	b := &Bag{ProjectRoot: projectDir}
+	if err := StepResolveMCPServers(context.Background(), b); err != nil {
+		t.Fatalf("StepResolveMCPServers: %v", err)
+	}
+	if b.ProjectMCPServers != nil {
+		t.Fatalf("ProjectMCPServers = %v, want nil after malformed project file", b.ProjectMCPServers)
+	}
+	if b.ProjectMCPServersEnabled {
+		t.Fatal("ProjectMCPServersEnabled should be false after malformed project file")
+	}
+}

--- a/internal/workflow/sync_test.go
+++ b/internal/workflow/sync_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
 )
 
 func TestStepFilterRegistries_OnlyEnabled(t *testing.T) {
@@ -253,5 +255,110 @@ func TestStepResolveMCPServers_MalformedProjectFileNonFatal(t *testing.T) {
 	}
 	if b.ProjectMCPServersEnabled {
 		t.Fatal("ProjectMCPServersEnabled should be false after malformed project file")
+	}
+}
+
+func TestStepProjectClaudeMCPServers_WritesProjectSettings(t *testing.T) {
+	projectDir := t.TempDir()
+	settingsDir := filepath.Join(projectDir, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("mkdir settings dir: %v", err)
+	}
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	existing := []byte(`{
+  "permissions": {
+    "allow": ["Bash(go test ./...)"]
+  },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": ["old-server"]
+}
+`)
+	if err := os.WriteFile(settingsPath, existing, 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	b := &Bag{
+		ProjectRoot:              projectDir,
+		ProjectMCPServers:        []string{"playwright", "mempalace"},
+		ProjectMCPServersEnabled: true,
+		Tools:                    []tools.Tool{tools.ClaudeTool{}},
+	}
+	if err := StepProjectClaudeMCPServers(context.Background(), b); err != nil {
+		t.Fatalf("StepProjectClaudeMCPServers: %v", err)
+	}
+
+	var got map[string]any
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse settings: %v", err)
+	}
+	if got["enableAllProjectMcpServers"] != false {
+		t.Fatalf("enableAllProjectMcpServers = %v, want false", got["enableAllProjectMcpServers"])
+	}
+	wantServers := []any{"mempalace", "playwright"}
+	servers, ok := got["enabledMcpjsonServers"].([]any)
+	if !ok {
+		t.Fatalf("enabledMcpjsonServers = %T, want array", got["enabledMcpjsonServers"])
+	}
+	if len(servers) != len(wantServers) {
+		t.Fatalf("enabledMcpjsonServers = %v, want %v", servers, wantServers)
+	}
+	for i := range wantServers {
+		if servers[i] != wantServers[i] {
+			t.Fatalf("enabledMcpjsonServers = %v, want %v", servers, wantServers)
+		}
+	}
+	permissions, ok := got["permissions"].(map[string]any)
+	if !ok || permissions["allow"] == nil {
+		t.Fatalf("permissions not preserved: %v", got["permissions"])
+	}
+}
+
+func TestStepProjectClaudeMCPServers_SkipsWhenClaudeInactive(t *testing.T) {
+	projectDir := t.TempDir()
+	b := &Bag{
+		ProjectRoot:              projectDir,
+		ProjectMCPServers:        []string{"mempalace"},
+		ProjectMCPServersEnabled: true,
+		Tools:                    nil,
+	}
+	if err := StepProjectClaudeMCPServers(context.Background(), b); err != nil {
+		t.Fatalf("StepProjectClaudeMCPServers: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".claude", "settings.json")); !os.IsNotExist(err) {
+		t.Fatalf("settings file was written or stat failed: %v", err)
+	}
+}
+
+func TestStepProjectClaudeMCPServers_MalformedSettingsFailsWithoutOverwrite(t *testing.T) {
+	projectDir := t.TempDir()
+	settingsDir := filepath.Join(projectDir, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("mkdir settings dir: %v", err)
+	}
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	original := []byte(`{"permissions":`)
+	if err := os.WriteFile(settingsPath, original, 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	b := &Bag{
+		ProjectRoot:              projectDir,
+		ProjectMCPServers:        []string{"mempalace"},
+		ProjectMCPServersEnabled: true,
+		Tools:                    []tools.Tool{tools.ClaudeTool{}},
+	}
+	if err := StepProjectClaudeMCPServers(context.Background(), b); err == nil {
+		t.Fatal("StepProjectClaudeMCPServers error = nil, want malformed settings error")
+	}
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if string(data) != string(original) {
+		t.Fatalf("settings overwritten: %q, want %q", data, original)
 	}
 }


### PR DESCRIPTION
## Summary
- project kit-scoped MCP server declarations into Claude settings during sync
- cover project Claude MCP server projection in workflow tests

## Test notes
- go test ./internal/workflow passed
- focused TestStepProjectClaudeMCPServers passed
- golangci-lint ./internal/workflow timed out/hung at 120s
- full go test ./... has known pre-existing cmd golden/fixture failures