### PR TITLE
Redesign doctor text output

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -68,6 +68,7 @@ type doctorFixResult struct {
 var (
 	doctorTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7C3AED"))
 	doctorOKStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#22C55E"))
+	doctorErrorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444"))
 	doctorDimStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#A3A3A3"))
 	doctorMutedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#555555"))
 	doctorBoldStyle  = lipgloss.NewStyle().Bold(true)
@@ -594,7 +595,7 @@ func buildDoctorReportJSON(skill string, report doctor.Report) doctorReportJSON 
 }
 
 func writeDoctorText(w io.Writer, skill string, report doctor.Report) error {
-	tty := term.IsTerminal(int(os.Stdout.Fd()))
+	tty := writerIsTerminal(w)
 	var buf strings.Builder
 	if err := writeDoctorTextWithOptions(&buf, skill, report, tty); err != nil {
 		return err
@@ -608,7 +609,7 @@ func writeDoctorText(w io.Writer, skill string, report doctor.Report) error {
 }
 
 func writeDoctorFixText(w io.Writer, skill string, results []doctorFixResult) error {
-	tty := term.IsTerminal(int(os.Stdout.Fd()))
+	tty := writerIsTerminal(w)
 	var buf strings.Builder
 	if err := writeDoctorFixTextStyled(&buf, skill, results); err != nil {
 		return err
@@ -715,6 +716,7 @@ type doctorIssueRow struct {
 	Kind    doctor.IssueKind
 	Skill   string
 	Tools   []string
+	Status  string
 	Message string
 }
 
@@ -766,6 +768,7 @@ func foldDoctorIssueRows(kind doctor.IssueKind, issues []doctor.Issue) []doctorI
 			rows = append(rows, doctorIssueRow{
 				Kind:    kind,
 				Skill:   tildePath(skill),
+				Status:  foldedDoctorStatus(skillIssues),
 				Message: strings.Join(migrationBudgetParts(skillIssues), doctorDimStyle.Render(" · ")),
 			})
 		default:
@@ -773,6 +776,7 @@ func foldDoctorIssueRows(kind doctor.IssueKind, issues []doctor.Issue) []doctorI
 				Kind:    kind,
 				Skill:   tildePath(skill),
 				Tools:   issueTools(skillIssues),
+				Status:  foldedDoctorStatus(skillIssues),
 				Message: summarizeDoctorIssueMessage(kind, skillIssues),
 			})
 		}
@@ -781,16 +785,57 @@ func foldDoctorIssueRows(kind doctor.IssueKind, issues []doctor.Issue) []doctorI
 }
 
 func renderDoctorIssueRow(row doctorIssueRow) string {
+	status := renderDoctorStatus(row.Status)
 	switch row.Kind {
 	case doctor.IssueMigrationBudgetOverflow:
-		return fmt.Sprintf("  %-42s %s", doctorDimStyle.Render(row.Skill), row.Message)
+		return "  " + renderDoctorColumn(row.Skill, 42, doctorDimStyle) + " " + status + " " + row.Message
 	default:
 		toolLabel := strings.Join(row.Tools, ", ")
 		if toolLabel == "" {
 			toolLabel = "-"
 		}
-		return fmt.Sprintf("  %-16s %-8s %s", doctorBoldStyle.Render(row.Skill), doctorMutedStyle.Render(toolLabel), row.Message)
+		return "  " + renderDoctorColumn(row.Skill, 16, doctorBoldStyle) + " " + renderDoctorColumn(toolLabel, 8, doctorMutedStyle) + " " + status + " " + row.Message
 	}
+}
+
+func renderDoctorColumn(value string, width int, style lipgloss.Style) string {
+	if len(value) < width {
+		value += strings.Repeat(" ", width-len(value))
+	}
+	return style.Render(value)
+}
+
+func renderDoctorStatus(status string) string {
+	if status == "" {
+		status = "warn"
+	}
+	label := "[" + status + "]"
+	if len(label) < 7 {
+		label += strings.Repeat(" ", 7-len(label))
+	}
+	switch status {
+	case "error":
+		return doctorErrorStyle.Render(label)
+	default:
+		return doctorMutedStyle.Render(label)
+	}
+}
+
+func foldedDoctorStatus(issues []doctor.Issue) string {
+	status := ""
+	for _, issue := range issues {
+		switch issue.Status {
+		case "error":
+			return "error"
+		case "warn":
+			status = "warn"
+		default:
+			if status == "" {
+				status = issue.Status
+			}
+		}
+	}
+	return status
 }
 
 func migrationBudgetParts(issues []doctor.Issue) []string {
@@ -934,6 +979,18 @@ func tildePath(s string) string {
 		return s
 	}
 	return strings.ReplaceAll(s, home, "~")
+}
+
+type fdWriter interface {
+	Fd() uintptr
+}
+
+func writerIsTerminal(w io.Writer) bool {
+	f, ok := w.(fdWriter)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
 }
 
 func stripANSI(s string) string {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -8,9 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
+	"charm.land/lipgloss/v2"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/config"
@@ -61,6 +64,14 @@ type doctorFixResult struct {
 	UpdatedCanonical bool     `json:"updated_canonical"`
 	RepairedTools    []string `json:"repaired_tools,omitempty"`
 }
+
+var (
+	doctorTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7C3AED"))
+	doctorOKStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#22C55E"))
+	doctorDimStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#A3A3A3"))
+	doctorMutedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#555555"))
+	doctorBoldStyle  = lipgloss.NewStyle().Bold(true)
+)
 
 type doctorSkillSnapshot struct {
 	Name         string
@@ -583,77 +594,365 @@ func buildDoctorReportJSON(skill string, report doctor.Report) doctorReportJSON 
 }
 
 func writeDoctorText(w io.Writer, skill string, report doctor.Report) error {
-	if len(report.Issues) == 0 {
-		if skill != "" {
-			_, err := fmt.Fprintf(w, "No managed skill issues found for %s.\n", skill)
-			return err
-		}
-		_, err := fmt.Fprintln(w, "No managed skill issues found.")
+	tty := term.IsTerminal(int(os.Stdout.Fd()))
+	var buf strings.Builder
+	if err := writeDoctorTextWithOptions(&buf, skill, report, tty); err != nil {
 		return err
 	}
-
-	if skill != "" {
-		if _, err := fmt.Fprintf(w, "Managed skill issues for %s:\n", skill); err != nil {
-			return err
-		}
-	} else {
-		if _, err := fmt.Fprintln(w, "Managed skill issues:"); err != nil {
-			return err
-		}
+	out := buf.String()
+	if !tty {
+		out = stripANSI(out)
 	}
-
-	for _, issue := range report.Issues {
-		if issue.Tool != "" {
-			if _, err := fmt.Fprintf(w, "- %s [%s] %s tool=%s: %s\n", issue.Skill, issue.Status, issue.Kind, issue.Tool, issue.Message); err != nil {
-				return err
-			}
-			continue
-		}
-		if _, err := fmt.Fprintf(w, "- %s [%s] %s: %s\n", issue.Skill, issue.Status, issue.Kind, issue.Message); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	_, err := io.WriteString(w, out)
+	return err
 }
 
 func writeDoctorFixText(w io.Writer, skill string, results []doctorFixResult) error {
+	tty := term.IsTerminal(int(os.Stdout.Fd()))
+	var buf strings.Builder
+	if err := writeDoctorFixTextStyled(&buf, skill, results); err != nil {
+		return err
+	}
+	out := buf.String()
+	if !tty {
+		out = stripANSI(out)
+	}
+	_, err := io.WriteString(w, out)
+	return err
+}
+
+func writeDoctorFixTextStyled(w io.Writer, skill string, results []doctorFixResult) error {
 	if len(results) == 0 {
-		if skill != "" {
-			_, err := fmt.Fprintf(w, "No managed skill issues found for %s.\n", skill)
-			return err
-		}
-		_, err := fmt.Fprintln(w, "No managed skill issues found.")
+		_, err := fmt.Fprintln(w, doctorOKStyle.Render("✓")+" "+doctorDimStyle.Render("No managed skill issues found."))
 		return err
 	}
 
 	if skill != "" {
-		if _, err := fmt.Fprintf(w, "Repaired managed skill %s:\n", skill); err != nil {
+		if _, err := fmt.Fprintln(w, doctorTitleStyle.Render(fmt.Sprintf("Repaired managed skill %s:", skill))); err != nil {
 			return err
 		}
 	} else {
-		if _, err := fmt.Fprintln(w, "Repaired managed skills:"); err != nil {
+		if _, err := fmt.Fprintln(w, doctorTitleStyle.Render("Repaired managed skills:")); err != nil {
 			return err
 		}
 	}
 
 	for _, result := range results {
-		message := "repaired projections"
 		if result.UpdatedCanonical {
-			message = "normalized canonical SKILL.md"
-		}
-		if _, err := fmt.Fprintf(w, "- %s %s", result.Name, message); err != nil {
-			return err
-		}
-		if len(result.RepairedTools) > 0 {
-			if _, err := fmt.Fprintf(w, " and repaired tools: %s", strings.Join(result.RepairedTools, ", ")); err != nil {
+			if _, err := fmt.Fprintf(w, "  %s %s normalized canonical SKILL.md\n", doctorOKStyle.Render("✓"), doctorBoldStyle.Render(result.Name)); err != nil {
 				return err
 			}
 		}
-		if _, err := fmt.Fprintln(w); err != nil {
-			return err
+		if len(result.RepairedTools) > 0 {
+			if _, err := fmt.Fprintf(w, "  %s %s repaired projections (%s)\n", doctorOKStyle.Render("✓"), doctorBoldStyle.Render(result.Name), doctorDimStyle.Render(strings.Join(result.RepairedTools, ", "))); err != nil {
+				return err
+			}
 		}
 	}
 
-	return nil
+	_, err := fmt.Fprintln(w, doctorDimStyle.Render(fmt.Sprintf("Repaired %d skills.", len(results))))
+	return err
+}
+
+func writeDoctorTextWithOptions(w io.Writer, skill string, report doctor.Report, truncate bool) error {
+	if len(report.Issues) == 0 {
+		_, err := fmt.Fprintln(w, doctorOKStyle.Render("✓")+" "+doctorDimStyle.Render("No managed skill issues found."))
+		return err
+	}
+
+	if skill != "" {
+		if _, err := fmt.Fprintln(w, doctorTitleStyle.Render(fmt.Sprintf("scribe doctor — %d issues for %s", len(report.Issues), skill))); err != nil {
+			return err
+		}
+	} else {
+		if _, err := fmt.Fprintln(w, doctorTitleStyle.Render(fmt.Sprintf("scribe doctor — %d issues across %d skills", len(report.Issues), countDoctorIssueSkills(report.Issues)))); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+
+	groups := groupDoctorIssuesByKind(report.Issues)
+	for gi, group := range groups {
+		if gi > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(w, doctorBoldStyle.Render(fmt.Sprintf("%s (%d)", prettyDoctorKind(group.Kind), group.Count))); err != nil {
+			return err
+		}
+		rows := group.Rows
+		remaining := 0
+		if truncate && len(rows) > 10 {
+			remaining = len(rows) - 10
+			rows = rows[:10]
+		}
+		for _, row := range rows {
+			if _, err := fmt.Fprintln(w, renderDoctorIssueRow(row)); err != nil {
+				return err
+			}
+		}
+		if remaining > 0 {
+			if _, err := fmt.Fprintf(w, "  %s\n", doctorDimStyle.Render(fmt.Sprintf("… %d more  (run with --skill <name> or --json for full list)", remaining))); err != nil {
+				return err
+			}
+		}
+	}
+
+	_, err := fmt.Fprintln(w, "\n"+doctorDimStyle.Render("Run `scribe doctor --fix` to repair drift and normalize canonical metadata."))
+	return err
+}
+
+type doctorIssueGroup struct {
+	Kind  doctor.IssueKind
+	Count int
+	Rows  []doctorIssueRow
+}
+
+type doctorIssueRow struct {
+	Kind    doctor.IssueKind
+	Skill   string
+	Tools   []string
+	Message string
+}
+
+func groupDoctorIssuesByKind(issues []doctor.Issue) []doctorIssueGroup {
+	byKind := map[doctor.IssueKind][]doctor.Issue{}
+	for _, issue := range issues {
+		byKind[issue.Kind] = append(byKind[issue.Kind], issue)
+	}
+
+	groups := make([]doctorIssueGroup, 0, len(byKind))
+	for kind, kindIssues := range byKind {
+		groups = append(groups, doctorIssueGroup{
+			Kind:  kind,
+			Count: len(kindIssues),
+			Rows:  foldDoctorIssueRows(kind, kindIssues),
+		})
+	}
+	sort.SliceStable(groups, func(i, j int) bool {
+		if groups[i].Count != groups[j].Count {
+			return groups[i].Count > groups[j].Count
+		}
+		return prettyDoctorKind(groups[i].Kind) < prettyDoctorKind(groups[j].Kind)
+	})
+	return groups
+}
+
+func foldDoctorIssueRows(kind doctor.IssueKind, issues []doctor.Issue) []doctorIssueRow {
+	bySkill := map[string][]doctor.Issue{}
+	for _, issue := range issues {
+		bySkill[issue.Skill] = append(bySkill[issue.Skill], issue)
+	}
+	skills := make([]string, 0, len(bySkill))
+	for skill := range bySkill {
+		skills = append(skills, skill)
+	}
+	sort.Strings(skills)
+
+	rows := make([]doctorIssueRow, 0, len(skills))
+	for _, skill := range skills {
+		skillIssues := bySkill[skill]
+		sort.SliceStable(skillIssues, func(i, j int) bool {
+			if skillIssues[i].Tool != skillIssues[j].Tool {
+				return skillIssues[i].Tool < skillIssues[j].Tool
+			}
+			return skillIssues[i].Message < skillIssues[j].Message
+		})
+		switch kind {
+		case doctor.IssueMigrationBudgetOverflow:
+			rows = append(rows, doctorIssueRow{
+				Kind:    kind,
+				Skill:   tildePath(skill),
+				Message: strings.Join(migrationBudgetParts(skillIssues), doctorDimStyle.Render(" · ")),
+			})
+		default:
+			rows = append(rows, doctorIssueRow{
+				Kind:    kind,
+				Skill:   tildePath(skill),
+				Tools:   issueTools(skillIssues),
+				Message: summarizeDoctorIssueMessage(kind, skillIssues),
+			})
+		}
+	}
+	return rows
+}
+
+func renderDoctorIssueRow(row doctorIssueRow) string {
+	switch row.Kind {
+	case doctor.IssueMigrationBudgetOverflow:
+		return fmt.Sprintf("  %-42s %s", doctorDimStyle.Render(row.Skill), row.Message)
+	default:
+		toolLabel := strings.Join(row.Tools, ", ")
+		if toolLabel == "" {
+			toolLabel = "-"
+		}
+		return fmt.Sprintf("  %-16s %-8s %s", doctorBoldStyle.Render(row.Skill), doctorMutedStyle.Render(toolLabel), row.Message)
+	}
+}
+
+func migrationBudgetParts(issues []doctor.Issue) []string {
+	parts := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		label := issue.Tool
+		if label == "" {
+			label = "tool"
+		}
+		parts = append(parts, fmt.Sprintf("%s +%s", label, formatBytes(extractByteCount(issue.Message))))
+	}
+	return parts
+}
+
+func issueTools(issues []doctor.Issue) []string {
+	seen := map[string]bool{}
+	var tools []string
+	for _, issue := range issues {
+		if issue.Tool == "" || seen[issue.Tool] {
+			continue
+		}
+		seen[issue.Tool] = true
+		tools = append(tools, issue.Tool)
+	}
+	sort.Strings(tools)
+	return tools
+}
+
+func summarizeDoctorIssueMessage(kind doctor.IssueKind, issues []doctor.Issue) string {
+	seen := map[string]bool{}
+	var parts []string
+	for _, issue := range issues {
+		for _, part := range strings.Split(issue.Message, ";") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			part = summarizeDoctorMessagePart(kind, part)
+			if !seen[part] {
+				seen[part] = true
+				parts = append(parts, part)
+			}
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, doctorDimStyle.Render(" · "))
+}
+
+func summarizeDoctorMessagePart(kind doctor.IssueKind, part string) string {
+	part = tildePath(part)
+	if kind != doctor.IssueProjectionDrift {
+		return part
+	}
+	switch {
+	case strings.HasPrefix(part, "unexpected managed projection "):
+		if path, ok := suffixAfter(part, " at "); ok {
+			return "unexpected projection at " + path
+		}
+	case strings.HasPrefix(part, "missing managed projection for "):
+		if path, ok := suffixAfter(part, " at "); ok {
+			return "missing projection at " + path
+		}
+	case strings.Contains(part, " projection at ") && strings.HasSuffix(part, " is conflicted"):
+		if path, ok := between(part, " projection at ", " is conflicted"); ok {
+			return "conflicted projection at " + path
+		}
+	case strings.Contains(part, " projection at ") && strings.HasSuffix(part, " does not point to the canonical target"):
+		if path, ok := between(part, " projection at ", " does not point to the canonical target"); ok {
+			return "projection target mismatch at " + path
+		}
+	}
+	return part
+}
+
+func suffixAfter(s, marker string) (string, bool) {
+	i := strings.LastIndex(s, marker)
+	if i < 0 {
+		return "", false
+	}
+	return strings.TrimSpace(s[i+len(marker):]), true
+}
+
+func between(s, start, end string) (string, bool) {
+	i := strings.Index(s, start)
+	if i < 0 {
+		return "", false
+	}
+	rest := s[i+len(start):]
+	j := strings.Index(rest, end)
+	if j < 0 {
+		return "", false
+	}
+	return strings.TrimSpace(rest[:j]), true
+}
+
+func prettyDoctorKind(kind doctor.IssueKind) string {
+	text := strings.ReplaceAll(string(kind), "_", " ")
+	if text == "" {
+		return ""
+	}
+	return strings.ToUpper(text[:1]) + text[1:]
+}
+
+func countDoctorIssueSkills(issues []doctor.Issue) int {
+	seen := map[string]bool{}
+	for _, issue := range issues {
+		seen[issue.Skill] = true
+	}
+	return len(seen)
+}
+
+func extractByteCount(message string) int64 {
+	fields := strings.Fields(message)
+	for i, field := range fields {
+		if field == "bytes" && i > 0 {
+			n, err := strconv.ParseInt(fields[i-1], 10, 64)
+			if err == nil && n > 0 {
+				return n
+			}
+		}
+	}
+	return 0
+}
+
+func formatBytes(n int64) string {
+	const kb = 1024
+	const mb = 1024 * kb
+	switch {
+	case n >= mb:
+		return fmt.Sprintf("%.1f MB", float64(n)/float64(mb))
+	default:
+		return fmt.Sprintf("%.1f KB", float64(n)/float64(kb))
+	}
+}
+
+func tildePath(s string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, home, "~")
+}
+
+func stripANSI(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == 0x1b {
+			if i+1 < len(s) && s[i+1] == '[' {
+				i += 2
+				for i < len(s) && (s[i] < '@' || s[i] > '~') {
+					i++
+				}
+			} else if i+1 < len(s) {
+				i++
+			}
+			continue
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
 }

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -407,6 +407,29 @@ func TestDoctorTextIncludesGroupedTool(t *testing.T) {
 	if strings.Contains(got, "tool=codex") {
 		t.Fatalf("expected compact tool column instead of old tool label, got:\n%s", got)
 	}
+	if !strings.Contains(got, "[warn]") {
+		t.Fatalf("expected status in text output, got:\n%s", got)
+	}
+}
+
+func TestDoctorTextShowsErrorStatus(t *testing.T) {
+	var buf bytes.Buffer
+	err := writeDoctorText(&buf, "", doctor.Report{
+		Issues: []doctor.Issue{{
+			Skill:   "recap",
+			Kind:    doctor.IssueCanonicalMetadata,
+			Status:  "error",
+			Message: "read canonical SKILL.md: denied",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("writeDoctorText: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "[error]") {
+		t.Fatalf("expected error status in text output, got:\n%s", got)
+	}
 }
 
 func TestDoctorTextFoldsMigrationBudgetRows(t *testing.T) {
@@ -526,6 +549,33 @@ func TestDoctorTextTruncatesOnlyForTTY(t *testing.T) {
 	}
 	if !strings.Contains(pipeOut, "skill-11") {
 		t.Fatalf("expected final row in piped output, got:\n%s", pipeOut)
+	}
+}
+
+func TestDoctorTextBufferOutputIsPlainAndUntruncated(t *testing.T) {
+	var issues []doctor.Issue
+	for i := 0; i < 12; i++ {
+		issues = append(issues, doctor.Issue{
+			Skill:   fmt.Sprintf("skill-%02d", i),
+			Kind:    doctor.IssueCanonicalMetadata,
+			Status:  "warn",
+			Message: "SKILL.md is missing a description",
+		})
+	}
+
+	var buf bytes.Buffer
+	if err := writeDoctorText(&buf, "", doctor.Report{Issues: issues}); err != nil {
+		t.Fatalf("writeDoctorText: %v", err)
+	}
+	got := buf.String()
+	if strings.Contains(got, "\x1b[") {
+		t.Fatalf("expected plain buffer output, got:\n%s", got)
+	}
+	if strings.Contains(got, "… 2 more") {
+		t.Fatalf("expected untruncated buffer output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "skill-11") {
+		t.Fatalf("expected final row in buffer output, got:\n%s", got)
 	}
 }
 

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,11 +32,20 @@ func TestDoctorCommandReportsIssues(t *testing.T) {
 	}
 
 	got := out.String()
+	if !strings.Contains(got, "scribe doctor — 1 issues across 1 skills") {
+		t.Fatalf("expected summary header in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Canonical metadata (1)") {
+		t.Fatalf("expected grouped canonical metadata in output, got:\n%s", got)
+	}
 	if !strings.Contains(got, "recap") {
 		t.Fatalf("expected recap in output, got:\n%s", got)
 	}
 	if !strings.Contains(got, "missing a description") {
 		t.Fatalf("expected canonical metadata message in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Run `scribe doctor --fix`") {
+		t.Fatalf("expected fix CTA in output, got:\n%s", got)
 	}
 }
 
@@ -372,7 +382,7 @@ func TestDoctorJSONOutput(t *testing.T) {
 	}
 }
 
-func TestDoctorTextIncludesTool(t *testing.T) {
+func TestDoctorTextIncludesGroupedTool(t *testing.T) {
 	var buf bytes.Buffer
 	err := writeDoctorText(&buf, "", doctor.Report{
 		Issues: []doctor.Issue{{
@@ -388,8 +398,158 @@ func TestDoctorTextIncludesTool(t *testing.T) {
 	}
 
 	got := buf.String()
-	if !strings.Contains(got, "tool=codex") {
+	if !strings.Contains(got, "Projection drift (1)") {
+		t.Fatalf("expected grouped projection drift output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "codex") {
 		t.Fatalf("expected tool in text output, got:\n%s", got)
+	}
+	if strings.Contains(got, "tool=codex") {
+		t.Fatalf("expected compact tool column instead of old tool label, got:\n%s", got)
+	}
+}
+
+func TestDoctorTextFoldsMigrationBudgetRows(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	report := doctor.Report{Issues: []doctor.Issue{
+		{
+			Skill:   filepath.Join(home, "Workspace", "Artistfy", "Dashboard"),
+			Tool:    "claude",
+			Kind:    doctor.IssueMigrationBudgetOverflow,
+			Status:  "warn",
+			Message: "migration-derived projections exceed claude budget by 27443 bytes",
+		},
+		{
+			Skill:   filepath.Join(home, "Workspace", "Artistfy", "Dashboard"),
+			Tool:    "codex",
+			Kind:    doctor.IssueMigrationBudgetOverflow,
+			Status:  "warn",
+			Message: "migration-derived projections exceed codex budget by 22732 bytes",
+		},
+		{
+			Skill:   filepath.Join(home, "Workspace", "Mine", "site"),
+			Tool:    "claude",
+			Kind:    doctor.IssueMigrationBudgetOverflow,
+			Status:  "warn",
+			Message: "migration-derived projections exceed claude budget by 1048576 bytes",
+		},
+	}}
+
+	var buf bytes.Buffer
+	if err := writeDoctorText(&buf, "", report); err != nil {
+		t.Fatalf("writeDoctorText: %v", err)
+	}
+	got := buf.String()
+
+	if !strings.Contains(got, "Migration budget overflow (3)") {
+		t.Fatalf("expected migration group, got:\n%s", got)
+	}
+	if !strings.Contains(got, "~/Workspace/Artistfy/Dashboard") {
+		t.Fatalf("expected tilde path, got:\n%s", got)
+	}
+	if !strings.Contains(got, "claude +26.8 KB · codex +22.2 KB") {
+		t.Fatalf("expected folded tool byte summary, got:\n%s", got)
+	}
+	if !strings.Contains(got, "claude +1.0 MB") {
+		t.Fatalf("expected MB formatting, got:\n%s", got)
+	}
+	if strings.Contains(got, "27443 bytes") {
+		t.Fatalf("expected human byte sizes only, got:\n%s", got)
+	}
+}
+
+func TestDoctorTextSummarizesProjectionDrift(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cursorPath := filepath.Join(home, ".cursor", "rules", "deploy.mdc")
+	claudePath := filepath.Join(home, ".claude", "skills", "deploy")
+
+	var buf bytes.Buffer
+	err := writeDoctorText(&buf, "", doctor.Report{
+		Issues: []doctor.Issue{{
+			Skill:   "deploy",
+			Tool:    "cursor",
+			Kind:    doctor.IssueProjectionDrift,
+			Status:  "warn",
+			Message: "unexpected managed projection cursor at " + cursorPath + "; missing managed projection for claude at " + claudePath,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("writeDoctorText: %v", err)
+	}
+	got := buf.String()
+
+	if !strings.Contains(got, "unexpected projection at ~/.cursor/rules/deploy.mdc") {
+		t.Fatalf("expected compact unexpected projection detail, got:\n%s", got)
+	}
+	if !strings.Contains(got, "missing projection at ~/.claude/skills/deploy") {
+		t.Fatalf("expected compact missing projection detail, got:\n%s", got)
+	}
+	if strings.Contains(got, "managed projection") {
+		t.Fatalf("expected managed projection noise removed, got:\n%s", got)
+	}
+}
+
+func TestDoctorTextTruncatesOnlyForTTY(t *testing.T) {
+	var issues []doctor.Issue
+	for i := 0; i < 12; i++ {
+		issues = append(issues, doctor.Issue{
+			Skill:   fmt.Sprintf("skill-%02d", i),
+			Kind:    doctor.IssueCanonicalMetadata,
+			Status:  "warn",
+			Message: "SKILL.md is missing a description",
+		})
+	}
+	report := doctor.Report{Issues: issues}
+
+	var ttyBuf bytes.Buffer
+	if err := writeDoctorTextWithOptions(&ttyBuf, "", report, true); err != nil {
+		t.Fatalf("writeDoctorTextWithOptions tty: %v", err)
+	}
+	ttyOut := stripANSI(ttyBuf.String())
+	if !strings.Contains(ttyOut, "… 2 more  (run with --skill <name> or --json for full list)") {
+		t.Fatalf("expected truncation hint, got:\n%s", ttyOut)
+	}
+	if strings.Contains(ttyOut, "skill-11") {
+		t.Fatalf("expected truncated tty output, got:\n%s", ttyOut)
+	}
+
+	var pipeBuf bytes.Buffer
+	if err := writeDoctorTextWithOptions(&pipeBuf, "", report, false); err != nil {
+		t.Fatalf("writeDoctorTextWithOptions pipe: %v", err)
+	}
+	pipeOut := stripANSI(pipeBuf.String())
+	if strings.Contains(pipeOut, "… 2 more") {
+		t.Fatalf("expected full piped output, got:\n%s", pipeOut)
+	}
+	if !strings.Contains(pipeOut, "skill-11") {
+		t.Fatalf("expected final row in piped output, got:\n%s", pipeOut)
+	}
+}
+
+func TestDoctorFixTextUsesRepairSummary(t *testing.T) {
+	var buf bytes.Buffer
+	err := writeDoctorFixText(&buf, "", []doctorFixResult{{
+		Name:             "deploy",
+		UpdatedCanonical: true,
+		RepairedTools:    []string{"cursor", "claude"},
+	}})
+	if err != nil {
+		t.Fatalf("writeDoctorFixText: %v", err)
+	}
+	got := buf.String()
+
+	for _, want := range []string{
+		"Repaired managed skills:",
+		"✓ deploy normalized canonical SKILL.md",
+		"✓ deploy repaired projections (cursor, claude)",
+		"Repaired 1 skills.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in output, got:\n%s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
Redesigns `scribe doctor` text output so large issue sets are grouped, folded, and easier to scan. JSON output is unchanged.

What changed:
- group issues by kind with a summary header
- fold migration budget rows by project and tool with human byte sizes
- shorten projection drift messages and use `~/...` paths
- truncate long groups only on TTY output
- refresh `doctor --fix` text output

Checked:
- `go test ./cmd/...`
- `go vet ./...`
- `go build ./...`
- `go run ./cmd/scribe doctor`