### PR TITLE
feat(list-tui): show diff inline before update [r]/[l]/[m] choice

### DIFF
--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -149,6 +149,16 @@ func (m listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m = m.ensureCursorVisible()
+		if m.substate == listSubstateUpdateChoice {
+			_, rightWidth := m.paneWidths()
+			diffWidth := rightWidth - 2
+			if diffWidth < 20 {
+				diffWidth = 20
+			}
+			m.viewYours.SetWidth(diffWidth)
+			m.viewIncoming.SetWidth(diffWidth)
+			redistributeViewportHeights(&m, m.contentHeight())
+		}
 		return m, nil
 	case tea.InterruptMsg:
 		m.quitting = true

--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -6,10 +6,12 @@ import (
 	"os/exec"
 	"strings"
 
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
+	"github.com/Naoray/scribe/internal/textdiff"
 	"github.com/Naoray/scribe/internal/tools"
 	"github.com/Naoray/scribe/internal/workflow"
 )
@@ -27,6 +29,7 @@ const (
 	listSubstateNone listSubstate = iota
 	listSubstateConfirm
 	listSubstateUpdateChoice
+	listSubstateUpdateConflictExists
 	listSubstateTools
 )
 
@@ -45,7 +48,19 @@ const (
 	focusPreview
 )
 
+type viewportTarget int
+
+const (
+	viewportYours viewportTarget = iota
+	viewportIncoming
+)
+
 type listRow = workflow.ListRow
+
+const (
+	updatePreviewMaxLines = 500
+	updatePreviewMaxBytes = 64 * 1024
+)
 
 type listModel struct {
 	stage          listStage
@@ -74,7 +89,25 @@ type listModel struct {
 	restoreDetail  bool
 	statusMsg      string
 	updateHasMods  bool
-	pendingTickID  int
+	updatePreview  struct {
+		loading           bool
+		err               error
+		requestID         uint64
+		rowName           string
+		rowGroup          string
+		diffYours         string
+		diffIncoming      string
+		diffOverflowed    bool
+		yoursOverflowN    int
+		incomingOverflowN int
+		baseSkillMD       []byte
+		localSkillMD      []byte
+	}
+	viewYours        viewport.Model
+	viewIncoming     viewport.Model
+	activeViewport   viewportTarget
+	previewIDCounter uint64
+	pendingTickID    int
 
 	ctx context.Context
 	bag *workflow.Bag
@@ -89,10 +122,12 @@ type listModel struct {
 
 func newListModel(ctx context.Context, bag *workflow.Bag) listModel {
 	return listModel{
-		stage:  stageLoading,
-		search: bag.InitialQuery,
-		ctx:    ctx,
-		bag:    bag,
+		stage:        stageLoading,
+		search:       bag.InitialQuery,
+		ctx:          ctx,
+		bag:          bag,
+		viewYours:    viewport.New(viewport.WithWidth(0), viewport.WithHeight(0)),
+		viewIncoming: viewport.New(viewport.WithWidth(0), viewport.WithHeight(0)),
 	}
 }
 
@@ -119,12 +154,13 @@ func (m listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.quitting = true
 		return m, tea.Quit
 	case tickSpinnerMsg:
-		if m.stage == stageLoading {
+		if m.stage == stageLoading || m.updatePreview.loading || m.backgroundLoad {
 			m.spinnerFrame = (m.spinnerFrame + 1) % len(spinnerFrames)
 			return m, tickSpinnerCmd()
 		}
 		return m, nil
 	case rowsLoadedMsg:
+		m = m.clearUpdatePreview()
 		m.stage = stageBrowse
 		m.rows = msg.rows
 		m.warnings = msg.warnings
@@ -143,6 +179,7 @@ func (m listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.err = msg.err
 		return m, nil
 	case registryStatusesLoadedMsg:
+		m = m.clearUpdatePreview()
 		m.backgroundLoad = false
 		m = m.applyRegistryStatuses(msg.statuses)
 		if len(msg.warnings) > 0 {
@@ -172,6 +209,7 @@ func (m listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusMsg = ""
 		return m, loadRowsCmd(m.ctx, m.bag)
 	case updateDoneMsg:
+		m = m.clearUpdatePreview()
 		if msg.err != nil {
 			m.statusMsg = fmt.Sprintf("Error: %v", msg.err)
 			return m, nil
@@ -198,6 +236,23 @@ func (m listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}))
 		}
 		return m, tea.Batch(cmds...)
+	case upstreamPreviewMsg:
+		if msg.requestID != m.updatePreview.requestID || msg.rowName != m.updatePreview.rowName {
+			return m, nil
+		}
+		m.updatePreview.loading = false
+		m.updatePreview.err = msg.err
+		if msg.err != nil {
+			return m, nil
+		}
+		incoming := textdiff.Unified("SKILL.md", m.updatePreview.baseSkillMD, msg.skillMD)
+		truncatedIncoming, incomingOverflowed := textdiff.TruncateUnified(incoming, updatePreviewMaxLines, updatePreviewMaxBytes)
+		m.updatePreview.diffIncoming = truncatedIncoming
+		m.updatePreview.incomingOverflowN = diffOverflowLines(truncatedIncoming)
+		m.updatePreview.diffOverflowed = m.updatePreview.diffOverflowed || incomingOverflowed
+		m.viewYours.SetContent(m.updatePreview.diffYours)
+		m.viewIncoming.SetContent(m.updatePreview.diffIncoming)
+		return m, nil
 	case toolsSavedMsg:
 		if msg.err != nil {
 			m.statusMsg = fmt.Sprintf("Error: %v", msg.err)
@@ -242,6 +297,48 @@ func (m listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateList(msg)
 	}
 	return m, nil
+}
+
+func (m listModel) nextPreviewID() (listModel, uint64) {
+	m.previewIDCounter++
+	return m, m.previewIDCounter
+}
+
+func (m listModel) clearUpdatePreview() listModel {
+	if m.updatePreview.requestID != 0 {
+		m.previewIDCounter++
+	}
+	m.updatePreview.loading = false
+	m.updatePreview.err = nil
+	m.updatePreview.requestID = 0
+	m.updatePreview.rowName = ""
+	m.updatePreview.rowGroup = ""
+	m.updatePreview.diffYours = ""
+	m.updatePreview.diffIncoming = ""
+	m.updatePreview.diffOverflowed = false
+	m.updatePreview.yoursOverflowN = 0
+	m.updatePreview.incomingOverflowN = 0
+	m.updatePreview.baseSkillMD = nil
+	m.updatePreview.localSkillMD = nil
+	m.viewYours.SetContent("")
+	m.viewIncoming.SetContent("")
+	return m
+}
+
+func diffOverflowLines(diff string) int {
+	const marker = "… diff truncated: "
+	idx := strings.LastIndex(diff, marker)
+	if idx < 0 {
+		return 0
+	}
+	var n int
+	for _, r := range diff[idx+len(marker):] {
+		if r < '0' || r > '9' {
+			break
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
 }
 
 func (m listModel) applyRegistryStatuses(statusesByRepo map[string][]sync.SkillStatus) listModel {

--- a/cmd/list_tui_actions.go
+++ b/cmd/list_tui_actions.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,7 +16,9 @@ import (
 	"github.com/Naoray/scribe/internal/discovery"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
+	"github.com/Naoray/scribe/internal/textdiff"
 	"github.com/Naoray/scribe/internal/tools"
+	"github.com/Naoray/scribe/internal/workflow"
 )
 
 type tickSpinnerMsg struct{}
@@ -37,6 +40,12 @@ type updateDoneMsg struct {
 	merged     bool
 	conflicted bool
 	openPath   string
+}
+type upstreamPreviewMsg struct {
+	requestID uint64
+	rowName   string
+	skillMD   []byte
+	err       error
 }
 type toolsSavedMsg struct {
 	result skillEditResult
@@ -129,6 +138,50 @@ func (m listModel) runInstall(row listRow) tea.Cmd {
 		)
 		return commandDoneMsg{err: err}
 	}
+}
+
+func fetchUpstreamForDiffCmd(ctx context.Context, bag *workflow.Bag, row listRow, requestID uint64) tea.Cmd {
+	return func() tea.Msg {
+		if row.Entry == nil {
+			return upstreamPreviewMsg{requestID: requestID, rowName: row.Name, err: fmt.Errorf("source unknown")}
+		}
+		if err := listEnsureRemoteDepsFn(ctx, bag); err != nil {
+			return upstreamPreviewMsg{requestID: requestID, rowName: row.Name, err: err}
+		}
+		if bag.Provider == nil {
+			return upstreamPreviewMsg{requestID: requestID, rowName: row.Name, err: fmt.Errorf("registry provider unavailable")}
+		}
+		files, err := bag.Provider.Fetch(ctx, *row.Entry)
+		if err != nil {
+			return upstreamPreviewMsg{requestID: requestID, rowName: row.Name, err: err}
+		}
+		for _, file := range files {
+			if file.Path == "SKILL.md" {
+				return upstreamPreviewMsg{requestID: requestID, rowName: row.Name, skillMD: file.Content}
+			}
+		}
+		return upstreamPreviewMsg{requestID: requestID, rowName: row.Name, err: fmt.Errorf("SKILL.md not found in registry response")}
+	}
+}
+
+func prepareUpdatePreview(row listRow) (base []byte, local []byte, diffYours string, overflowed bool, overflowN int, err error) {
+	if row.Local == nil || row.Local.LocalPath == "" {
+		return nil, nil, "", false, 0, fmt.Errorf("local skill path unavailable")
+	}
+	local, err = os.ReadFile(filepath.Join(row.Local.LocalPath, "SKILL.md"))
+	if err != nil {
+		return nil, nil, "", false, 0, err
+	}
+	base, err = os.ReadFile(filepath.Join(row.Local.LocalPath, ".scribe-base.md"))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, nil, "", false, 0, err
+		}
+		base = local
+	}
+	diff := textdiff.Unified("SKILL.md", base, local)
+	diff, overflowed = textdiff.TruncateUnified(diff, updatePreviewMaxLines, updatePreviewMaxBytes)
+	return base, local, diff, overflowed, diffOverflowLines(diff), nil
 }
 
 func (m listModel) runUpdate(choice updateChoice) tea.Cmd {

--- a/cmd/list_tui_diff.go
+++ b/cmd/list_tui_diff.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+)
+
+func newDiffViewport(width, height int) viewport.Model {
+	v := viewport.New(viewport.WithWidth(width), viewport.WithHeight(height))
+	v.SoftWrap = false
+	v.FillHeight = false
+	return v
+}
+
+func redistributeViewportHeights(m *listModel, paneHeight int) {
+	if m.height < 20 {
+		m.viewYours.SetHeight(1)
+		m.viewIncoming.SetHeight(1)
+		return
+	}
+	if m.height < 28 {
+		h := paneHeight - 8
+		if h < 3 {
+			h = 3
+		}
+		if h > 16 {
+			h = 16
+		}
+		m.viewYours.SetHeight(h)
+		m.viewIncoming.SetHeight(h)
+		return
+	}
+	h := paneHeight / 2
+	if h > 12 {
+		h = 12
+	}
+	if h < 3 {
+		h = 3
+	}
+	m.viewYours.SetHeight(h)
+	m.viewIncoming.SetHeight(h)
+}
+
+func forwardScrollKey(m *listModel, msg tea.KeyPressMsg) tea.Cmd {
+	target := &m.viewYours
+	if m.activeViewport == viewportIncoming {
+		target = &m.viewIncoming
+	}
+	switch msg.String() {
+	case "j", "down":
+		target.ScrollDown(1)
+	case "k", "up":
+		target.ScrollUp(1)
+	case "pgdown", "pagedown", "d":
+		target.ScrollDown(target.Height())
+	case "pgup", "pageup", "u":
+		target.ScrollUp(target.Height())
+	}
+	return nil
+}
+
+func (m listModel) renderUpdateChoiceDetail(width int) string {
+	var b strings.Builder
+	b.WriteString(ltHeaderStyle.Render("Update diff") + "\n")
+	if m.updatePreview.loading {
+		b.WriteString(ltDimStyle.Render(spinnerFrames[m.spinnerFrame]+" Fetching upstream…") + "\n")
+	}
+	if m.updatePreview.err != nil {
+		b.WriteString(ltErrorStyle.Render("Could not reach registry — diff unavailable. [l] keep local, [esc] cancel.") + "\n")
+	}
+	paneHeight := m.contentHeight()
+	contentWidth := width - 2
+	if contentWidth < 20 {
+		contentWidth = 20
+	}
+	m.viewYours.SetWidth(contentWidth)
+	m.viewIncoming.SetWidth(contentWidth)
+	redistributeViewportHeights(&m, paneHeight)
+	switch {
+	case m.height >= 28:
+		b.WriteString(m.renderDiffViewport("Your edits", m.viewYours, m.updatePreview.diffYours) + "\n")
+		b.WriteString(m.renderDiffViewport("Incoming", m.viewIncoming, m.updatePreview.diffIncoming) + "\n")
+	case m.height >= 20:
+		combined := combineDiffs(m.updatePreview.diffYours, m.updatePreview.diffIncoming)
+		v := newDiffViewport(contentWidth, m.viewYours.Height())
+		v.SetContent(combined)
+		b.WriteString(m.renderDiffViewport("Diff", v, combined) + "\n")
+	case m.height >= 12:
+		yAdd, yDel := diffStats(m.updatePreview.diffYours)
+		iAdd, iDel := diffStats(m.updatePreview.diffIncoming)
+		b.WriteString(ltDimStyle.Render(fmt.Sprintf("+%d −%d local · +%d −%d incoming", yAdd, yDel, iAdd, iDel)) + "\n")
+	default:
+		b.WriteString(ltDimStyle.Render("(diff hidden — terminal too small)") + "\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(m.renderUpdateChoiceBlock())
+	return b.String()
+}
+
+func (m listModel) renderDiffViewport(title string, v viewport.Model, content string) string {
+	var b strings.Builder
+	b.WriteString(ltDimStyle.Render(title) + "\n")
+	if strings.TrimSpace(content) == "" {
+		b.WriteString(ltDimStyle.Render("(no changes)") + "\n")
+		return b.String()
+	}
+	b.WriteString(v.View())
+	return b.String()
+}
+
+func combineDiffs(yours, incoming string) string {
+	parts := []string{"Your edits", strings.TrimSpace(yours), "", "Incoming", strings.TrimSpace(incoming)}
+	return strings.Join(parts, "\n")
+}
+
+func diffStats(diff string) (additions, deletions int) {
+	for _, line := range strings.Split(diff, "\n") {
+		if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "+"):
+			additions++
+		case strings.HasPrefix(line, "-"):
+			deletions++
+		}
+	}
+	return additions, deletions
+}
+
+func (m listModel) renderUpdateChoiceBlock() string {
+	if !m.updateHasMods {
+		return ltDimStyle.Render("[u] update now") + "\n" + ltDimStyle.Render("[esc] cancel") + "\n"
+	}
+	return strings.Join([]string{
+		ltDimStyle.Render("[m] merge with upstream"),
+		ltDimStyle.Render("[r] replace with registry version"),
+		ltDimStyle.Render("[l] keep local version"),
+		ltDimStyle.Render("[esc] cancel"),
+	}, "\n") + "\n"
+}

--- a/cmd/list_tui_diff_test.go
+++ b/cmd/list_tui_diff_test.go
@@ -1,0 +1,298 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/discovery"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/sync"
+	"github.com/Naoray/scribe/internal/tools"
+	"github.com/Naoray/scribe/internal/workflow"
+)
+
+type previewStubProvider struct {
+	content []byte
+	err     error
+	calls   int
+}
+
+func (p *previewStubProvider) Discover(context.Context, string) (*provider.DiscoverResult, error) {
+	return nil, nil
+}
+
+func (p *previewStubProvider) Fetch(context.Context, manifest.Entry) ([]tools.SkillFile, error) {
+	p.calls++
+	if p.err != nil {
+		return nil, p.err
+	}
+	return []tools.SkillFile{{Path: "SKILL.md", Content: p.content}}, nil
+}
+
+func withPreviewDeps(t *testing.T) {
+	t.Helper()
+	original := listEnsureRemoteDepsFn
+	listEnsureRemoteDepsFn = func(context.Context, *workflow.Bag) error { return nil }
+	t.Cleanup(func() { listEnsureRemoteDepsFn = original })
+}
+
+func newPreviewModel(t *testing.T, upstream []byte, fetchErr error) (listModel, *previewStubProvider) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	skillDir := filepath.Join(home, ".scribe", "skills", "recap")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	base := []byte("# Skill\n\nbase\n")
+	local := []byte("# Skill\n\nlocal\n")
+	if err := os.WriteFile(filepath.Join(skillDir, ".scribe-base.md"), base, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), local, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	provider := &previewStubProvider{content: upstream, err: fetchErr}
+	row := listRow{
+		Name:      "recap",
+		Group:     "owner/repo",
+		Status:    sync.StatusOutdated,
+		HasStatus: true,
+		Entry:     &manifest.Entry{Name: "recap", Source: "github:owner/repo@main"},
+		Local:     &discovery.Skill{Name: "recap", LocalPath: skillDir},
+		Managed:   true,
+	}
+	m := listModel{
+		ctx:         context.Background(),
+		stage:       stageBrowse,
+		selected:    true,
+		focus:       focusActions,
+		width:       120,
+		height:      40,
+		rows:        []listRow{row},
+		filtered:    []listRow{row},
+		groupCounts: map[string]int{"owner/repo": 1},
+		bag: &workflow.Bag{
+			Config:   &config.Config{},
+			State:    &state.State{Installed: map[string]state.InstalledSkill{"recap": {InstalledHash: sync.ComputeFileHash(base)}}},
+			Provider: provider,
+		},
+		viewYours:    newDiffViewport(80, 8),
+		viewIncoming: newDiffViewport(80, 8),
+	}
+	return m, provider
+}
+
+func runPreviewFetch(t *testing.T, cmd tea.Cmd) upstreamPreviewMsg {
+	t.Helper()
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("preview command returned %T, want tea.BatchMsg", msg)
+	}
+	for _, c := range batch {
+		got := c()
+		if preview, ok := got.(upstreamPreviewMsg); ok {
+			return preview
+		}
+	}
+	t.Fatal("batch did not contain upstreamPreviewMsg")
+	return upstreamPreviewMsg{}
+}
+
+func TestListTUIDiffPreviewPopulatesViewports(t *testing.T) {
+	withPreviewDeps(t)
+	m, _ := newPreviewModel(t, []byte("# Skill\n\nincoming\n"), nil)
+	nm, cmd := m.executeAction("update")
+	if cmd == nil {
+		t.Fatal("expected preview fetch command")
+	}
+	lm := nm.(listModel)
+	if !lm.updatePreview.loading {
+		t.Fatal("preview should start loading")
+	}
+	updated, _ := lm.Update(runPreviewFetch(t, cmd))
+	lm = updated.(listModel)
+	if lm.updatePreview.loading {
+		t.Fatal("preview should stop loading after fetch")
+	}
+	if !strings.Contains(lm.updatePreview.diffYours, "-base") || !strings.Contains(lm.updatePreview.diffYours, "+local") {
+		t.Fatalf("yours diff missing local change:\n%s", lm.updatePreview.diffYours)
+	}
+	if !strings.Contains(lm.updatePreview.diffIncoming, "+incoming") {
+		t.Fatalf("incoming diff missing upstream change:\n%s", lm.updatePreview.diffIncoming)
+	}
+	if !strings.Contains(lm.viewIncoming.View(), "@@") {
+		t.Fatalf("incoming viewport missing unified hunk:\n%s", lm.viewIncoming.View())
+	}
+}
+
+func TestListTUIDiffKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want func(t *testing.T, m listModel, cmd tea.Cmd)
+	}{
+		{
+			name: "tab toggles viewport",
+			key:  "tab",
+			want: func(t *testing.T, m listModel, _ tea.Cmd) {
+				if m.activeViewport != viewportIncoming {
+					t.Fatalf("activeViewport = %v, want incoming", m.activeViewport)
+				}
+			},
+		},
+		{
+			name: "j scrolls",
+			key:  "j",
+			want: func(t *testing.T, _ listModel, cmd tea.Cmd) {
+				if cmd != nil {
+					t.Fatal("scroll should not return async command")
+				}
+			},
+		},
+		{
+			name: "keep local clears substate",
+			key:  "l",
+			want: func(t *testing.T, m listModel, cmd tea.Cmd) {
+				if cmd != nil {
+					t.Fatal("keep local should not return command")
+				}
+				if m.substate != listSubstateNone {
+					t.Fatalf("substate = %v, want none", m.substate)
+				}
+			},
+		},
+		{
+			name: "merge starts update",
+			key:  "m",
+			want: func(t *testing.T, m listModel, cmd tea.Cmd) {
+				if cmd == nil {
+					t.Fatal("merge should return update command")
+				}
+				if m.substate != listSubstateNone {
+					t.Fatalf("substate = %v, want none", m.substate)
+				}
+			},
+		},
+		{
+			name: "replace starts update",
+			key:  "r",
+			want: func(t *testing.T, _ listModel, cmd tea.Cmd) {
+				if cmd == nil {
+					t.Fatal("replace should return update command")
+				}
+			},
+		},
+		{
+			name: "escape clears substate",
+			key:  "esc",
+			want: func(t *testing.T, m listModel, cmd tea.Cmd) {
+				if cmd != nil {
+					t.Fatal("escape should not return command")
+				}
+				if m.substate != listSubstateNone {
+					t.Fatalf("substate = %v, want none", m.substate)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, _ := newPreviewModel(t, []byte("# Skill\n\nincoming\n"), nil)
+			m.substate = listSubstateUpdateChoice
+			m.updateHasMods = true
+			m.updatePreview.requestID = 1
+			nm, cmd := m.updateUpdateChoice(key(tt.key))
+			tt.want(t, nm.(listModel), cmd)
+		})
+	}
+}
+
+func TestListTUIDiffStaleResponseDropped(t *testing.T) {
+	m, _ := newPreviewModel(t, []byte("# Skill\n\nincoming\n"), nil)
+	m.substate = listSubstateUpdateChoice
+	m.updatePreview.requestID = 2
+	m.updatePreview.rowName = "recap"
+	updated, _ := m.Update(upstreamPreviewMsg{requestID: 1, rowName: "recap", skillMD: []byte("wrong")})
+	lm := updated.(listModel)
+	if lm.updatePreview.diffIncoming != "" {
+		t.Fatalf("stale response populated incoming diff: %q", lm.updatePreview.diffIncoming)
+	}
+}
+
+func TestListTUIDiffOfflineGatesRegistryChoices(t *testing.T) {
+	withPreviewDeps(t)
+	m, _ := newPreviewModel(t, nil, errors.New("offline"))
+	nm, cmd := m.executeAction("update")
+	lm := nm.(listModel)
+	updated, _ := lm.Update(runPreviewFetch(t, cmd))
+	lm = updated.(listModel)
+	if lm.updatePreview.err == nil {
+		t.Fatal("expected preview error")
+	}
+	out := lm.renderDetailPane(lm.filtered[lm.cursor], 80)
+	if !strings.Contains(out, "Could not reach registry") {
+		t.Fatalf("missing offline render:\n%s", out)
+	}
+	nm, cmd = lm.updateUpdateChoice(key("m"))
+	lm = nm.(listModel)
+	if cmd != nil {
+		t.Fatal("offline merge should not start update")
+	}
+	if !strings.Contains(lm.statusMsg, "Registry unavailable") {
+		t.Fatalf("statusMsg = %q", lm.statusMsg)
+	}
+}
+
+func TestListTUIDiffConflictExistsRoutesResolve(t *testing.T) {
+	withPreviewDeps(t)
+	m, provider := newPreviewModel(t, []byte("# Skill\n\nincoming\n"), nil)
+	if err := os.WriteFile(filepath.Join(m.filtered[0].Local.LocalPath, "SKILL.md"), []byte("<<<<<<< HEAD\nlocal\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	nm, cmd := m.executeAction("update")
+	lm := nm.(listModel)
+	if cmd != nil {
+		t.Fatal("conflict marker path should not fetch upstream")
+	}
+	if provider.calls != 0 {
+		t.Fatalf("provider calls = %d, want 0", provider.calls)
+	}
+	if lm.substate != listSubstateUpdateConflictExists {
+		t.Fatalf("substate = %v, want conflict-exists", lm.substate)
+	}
+	_, cmd = lm.updateUpdateConflictExists(key("r"))
+	if cmd == nil {
+		t.Fatal("resolve key should dispatch process command")
+	}
+}
+
+func TestListTUIDiffSmokeUpdateChoiceRenderAndKeepLocal(t *testing.T) {
+	withPreviewDeps(t)
+	m, _ := newPreviewModel(t, []byte("# Skill\n\nincoming\n"), nil)
+	nm, cmd := m.executeAction("update")
+	lm := nm.(listModel)
+	updated, _ := lm.Update(runPreviewFetch(t, cmd))
+	lm = updated.(listModel)
+	out := lm.renderDetailPane(lm.filtered[lm.cursor], 120)
+	if !strings.Contains(out, "@@") {
+		t.Fatalf("smoke render missing diff hunk:\n%s", out)
+	}
+	nm, cmd = lm.updateUpdateChoice(key("l"))
+	if cmd != nil {
+		t.Fatal("keep local should not start command")
+	}
+	if nm.(listModel).substate != listSubstateNone {
+		t.Fatal("keep local should clear update substate")
+	}
+}

--- a/cmd/list_tui_keys.go
+++ b/cmd/list_tui_keys.go
@@ -267,11 +267,18 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m.updateCommandMode(msg)
 		}
 		text := typedText(msg)
+		previousRowName := ""
+		if m.cursor >= 0 && m.cursor < len(m.filtered) {
+			previousRowName = m.filtered[m.cursor].Name
+		}
 		switch key {
 		case "up", "k":
 			if m.cursor > 0 {
 				m.cursor--
 				m = m.ensureCursorVisible()
+				if m.filtered[m.cursor].Name != previousRowName {
+					m = m.clearUpdatePreview()
+				}
 				m.actionCursor = 0
 				m.excerptOffset = 0
 				m.statusMsg = ""
@@ -280,6 +287,9 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			if m.cursor < len(m.filtered)-1 {
 				m.cursor++
 				m = m.ensureCursorVisible()
+				if m.filtered[m.cursor].Name != previousRowName {
+					m = m.clearUpdatePreview()
+				}
 				m.actionCursor = 0
 				m.excerptOffset = 0
 				m.statusMsg = ""
@@ -454,10 +464,12 @@ func (m listModel) updateUpdateChoice(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 	if !m.updateHasMods {
 		switch msg.String() {
 		case "u", "enter":
+			m = m.clearUpdatePreview()
 			m.substate = listSubstateNone
 			m.statusMsg = "Updating..."
 			return m, m.runUpdate(updateChoiceMerge)
 		case "esc", "escape":
+			m = m.clearUpdatePreview()
 			m.substate = listSubstateNone
 			m.statusMsg = ""
 		}
@@ -466,19 +478,23 @@ func (m listModel) updateUpdateChoice(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 
 	switch msg.String() {
 	case "m":
+		m = m.clearUpdatePreview()
 		m.substate = listSubstateNone
 		m.statusMsg = "Updating..."
 		return m, m.runUpdate(updateChoiceMerge)
 	case "r":
+		m = m.clearUpdatePreview()
 		m.substate = listSubstateNone
 		m.statusMsg = "Updating..."
 		return m, m.runUpdate(updateChoicePreferTheirs)
 	case "l":
+		m = m.clearUpdatePreview()
 		m.substate = listSubstateNone
 		m.statusMsg = "Kept local version. Registry update skipped."
 		m.updateHasMods = false
 		return m, nil
 	case "esc", "escape":
+		m = m.clearUpdatePreview()
 		m.substate = listSubstateNone
 		m.statusMsg = ""
 		m.updateHasMods = false
@@ -640,16 +656,46 @@ func (m listModel) executeAction(key string) (tea.Model, tea.Cmd) {
 		if row.Entry == nil {
 			return m, nil
 		}
-		if rowHasLocalModifications(row, m.bag.State) && !row.Entry.IsPackage() {
+		if row.Entry.IsPackage() {
+			m = m.clearUpdatePreview()
 			m.substate = listSubstateUpdateChoice
-			m.updateHasMods = true
-			m.statusMsg = "Local edits detected. Choose: [r]egistry version, keep [l]ocal version, or [m]erge with upstream."
+			m.updateHasMods = false
+			m.statusMsg = "No local edits detected. Update will replace the local copy with the registry version."
 			return m, nil
 		}
+		base, local, diffYours, yoursOverflowed, yoursOverflowN, err := prepareUpdatePreview(row)
+		if err != nil {
+			m.statusMsg = fmt.Sprintf("Could not read local SKILL.md: %v", err)
+			return m, nil
+		}
+		m = m.clearUpdatePreview()
+		if sync.HasConflictMarkers(local) {
+			m.substate = listSubstateUpdateConflictExists
+			m.updateHasMods = true
+			m.statusMsg = "Unresolved conflict markers in SKILL.md."
+			return m, nil
+		}
+		m, requestID := m.nextPreviewID()
 		m.substate = listSubstateUpdateChoice
-		m.updateHasMods = false
+		m.updateHasMods = rowHasLocalModifications(row, m.bag.State) && !row.Entry.IsPackage()
+		m.updatePreview.loading = true
+		m.updatePreview.requestID = requestID
+		m.updatePreview.rowName = row.Name
+		m.updatePreview.rowGroup = row.Group
+		m.updatePreview.diffYours = diffYours
+		m.updatePreview.diffOverflowed = yoursOverflowed
+		m.updatePreview.yoursOverflowN = yoursOverflowN
+		m.updatePreview.baseSkillMD = base
+		m.updatePreview.localSkillMD = local
+		m.activeViewport = viewportYours
+		m.viewYours.SetContent(diffYours)
+		m.viewIncoming.SetContent("")
+		if m.updateHasMods {
+			m.statusMsg = "Local edits detected. Choose: [r]egistry version, keep [l]ocal version, or [m]erge with upstream."
+			return m, tea.Batch(tickSpinnerCmd(), fetchUpstreamForDiffCmd(m.ctx, m.bag, row, requestID))
+		}
 		m.statusMsg = "No local edits detected. Update will replace the local copy with the registry version."
-		return m, nil
+		return m, tea.Batch(tickSpinnerCmd(), fetchUpstreamForDiffCmd(m.ctx, m.bag, row, requestID))
 	case "adopt":
 		if row.Local == nil || row.Managed {
 			return m, nil
@@ -696,6 +742,7 @@ func (m listModel) executeAction(key string) (tea.Model, tea.Cmd) {
 }
 
 func (m listModel) resetSearch() listModel {
+	m = m.clearUpdatePreview()
 	m.search = ""
 	m.searchMode = false
 	m = m.refreshFiltered()
@@ -710,6 +757,7 @@ func (m listModel) backspaceSearch() listModel {
 		m.searchMode = false
 		return m
 	}
+	m = m.clearUpdatePreview()
 	m.search = m.search[:len(m.search)-1]
 	if m.search == "" {
 		m.searchMode = false
@@ -725,6 +773,7 @@ func (m listModel) appendSearch(key string) listModel {
 	if len(key) != 1 {
 		return m
 	}
+	m = m.clearUpdatePreview()
 	m.searchMode = true
 	m.search += key
 	m = m.refreshFiltered()

--- a/cmd/list_tui_keys.go
+++ b/cmd/list_tui_keys.go
@@ -192,6 +192,9 @@ func (m listModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.substate == listSubstateUpdateChoice {
 		return m.updateUpdateChoice(msg)
 	}
+	if m.substate == listSubstateUpdateConflictExists {
+		return m.updateUpdateConflictExists(msg)
+	}
 	if m.substate == listSubstateTools {
 		return m.updateToolsEditor(msg)
 	}
@@ -461,6 +464,24 @@ func (m listModel) updateConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m listModel) updateUpdateChoice(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "tab":
+		if m.activeViewport == viewportYours {
+			m.activeViewport = viewportIncoming
+		} else {
+			m.activeViewport = viewportYours
+		}
+		return m, nil
+	case "j", "down", "k", "up", "pgdown", "pagedown", "d", "pgup", "pageup":
+		return m, forwardScrollKey(&m, msg)
+	}
+	if m.updatePreview.err != nil {
+		switch msg.String() {
+		case "m", "r", "u", "enter":
+			m.statusMsg = "Registry unavailable; keep local or cancel."
+			return m, nil
+		}
+	}
 	if !m.updateHasMods {
 		switch msg.String() {
 		case "u", "enter":
@@ -493,6 +514,28 @@ func (m listModel) updateUpdateChoice(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		m.statusMsg = "Kept local version. Registry update skipped."
 		m.updateHasMods = false
 		return m, nil
+	case "esc", "escape":
+		m = m.clearUpdatePreview()
+		m.substate = listSubstateNone
+		m.statusMsg = ""
+		m.updateHasMods = false
+	}
+	return m, nil
+}
+
+func (m listModel) updateUpdateConflictExists(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "r":
+		if m.cursor < 0 || m.cursor >= len(m.filtered) {
+			return m, nil
+		}
+		row := m.filtered[m.cursor]
+		m = m.clearUpdatePreview()
+		m.substate = listSubstateNone
+		m.statusMsg = ""
+		return m, tea.ExecProcess(exec.Command(os.Args[0], "resolve", row.Name), func(err error) tea.Msg {
+			return commandDoneMsg{err: err}
+		})
 	case "esc", "escape":
 		m = m.clearUpdatePreview()
 		m.substate = listSubstateNone

--- a/cmd/list_tui_render.go
+++ b/cmd/list_tui_render.go
@@ -143,10 +143,12 @@ func (m listModel) viewSplit() string {
 		b.WriteString(ltDimStyle.Render("y confirm · n cancel") + "\n")
 	case m.substate == listSubstateUpdateChoice:
 		if m.updateHasMods {
-			b.WriteString(ltDimStyle.Render("r registry · l local · m merge · esc cancel") + "\n")
+			b.WriteString(ltDimStyle.Render("tab pane · ↑↓/pg scroll · r registry · l local · m merge · esc cancel") + "\n")
 		} else {
-			b.WriteString(ltDimStyle.Render("u update · esc cancel") + "\n")
+			b.WriteString(ltDimStyle.Render("tab pane · ↑↓/pg scroll · u update · esc cancel") + "\n")
 		}
+	case m.substate == listSubstateUpdateConflictExists:
+		b.WriteString(ltDimStyle.Render("r resolve · esc cancel") + "\n")
 	case m.substate == listSubstateTools:
 		b.WriteString(ltDimStyle.Render("↑↓ choose · enter toggle/save · esc cancel") + "\n")
 	case m.focus == focusList:
@@ -479,6 +481,17 @@ func (m listModel) renderDetailPane(row listRow, width int) string {
 
 	if m.substate == listSubstateTools {
 		b.WriteString(m.renderToolsEditor(width))
+		return b.String()
+	}
+
+	if m.substate == listSubstateUpdateChoice {
+		b.WriteString(m.renderUpdateChoiceDetail(width))
+		return b.String()
+	}
+
+	if m.substate == listSubstateUpdateConflictExists {
+		b.WriteString(ltErrorStyle.Render("Unresolved conflict markers in SKILL.md.") + "\n\n")
+		b.WriteString(ltDimStyle.Render("[r] launch scribe resolve · [esc] cancel") + "\n")
 		return b.String()
 	}
 

--- a/cmd/list_tui_test.go
+++ b/cmd/list_tui_test.go
@@ -1161,8 +1161,8 @@ func TestExecuteActionUpdate_ModifiedSkillPromptsForStrategy(t *testing.T) {
 	}
 
 	nm, cmd := m.executeAction("update")
-	if cmd != nil {
-		t.Fatal("expected modified skill update to wait for user choice")
+	if cmd == nil {
+		t.Fatal("expected modified skill update to start preview fetch")
 	}
 	lm := nm.(listModel)
 	if lm.substate != listSubstateUpdateChoice {

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,14 @@ require (
 	charm.land/lipgloss/v2 v2.0.1
 	github.com/BurntSushi/toml v1.6.0
 	github.com/charmbracelet/glamour v1.0.0
+	github.com/creack/pty v1.1.24
 	github.com/google/go-github/v69 v69.2.0
+	github.com/hexops/gotextdiff v1.0.3
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-runewidth v0.0.20
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	golang.org/x/mod v0.34.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.41.0
@@ -38,7 +42,6 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
-	github.com/creack/pty v1.1.24 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
@@ -51,8 +54,6 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark v1.7.13 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Naoray/scribe
 go 1.26.1
 
 require (
+	charm.land/bubbles/v2 v2.0.0
 	charm.land/bubbletea/v2 v2.0.2
 	charm.land/huh/v2 v2.0.3
 	charm.land/lipgloss/v2 v2.0.1
@@ -23,7 +24,6 @@ require (
 )
 
 require (
-	charm.land/bubbles/v2 v2.0.0 // indirect
 	github.com/alecthomas/chroma/v2 v2.20.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect

--- a/internal/sync/merge.go
+++ b/internal/sync/merge.go
@@ -88,6 +88,24 @@ func normalizeLineEndings(content []byte) []byte {
 	return bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
 }
 
+func HasConflictMarkers(content []byte) bool {
+	if bytes.HasPrefix(content, []byte("<<<<<<< ")) {
+		return true
+	}
+	marker := []byte("\n<<<<<<< ")
+	for offset := 0; ; {
+		idx := bytes.Index(content[offset:], marker)
+		if idx < 0 {
+			return false
+		}
+		absolute := offset + idx
+		if absolute == 0 || content[absolute-1] != '\r' {
+			return true
+		}
+		offset = absolute + len(marker)
+	}
+}
+
 // IsLocallyModified checks if SKILL.md has been modified since last sync.
 // When .scribe-base.md is readable, it is the source of truth and is compared
 // directly with SKILL.md. When .scribe-base.md is missing, installedHash is the

--- a/internal/sync/merge_test.go
+++ b/internal/sync/merge_test.go
@@ -92,6 +92,52 @@ func TestComputeFileHash(t *testing.T) {
 	}
 }
 
+func TestHasConflictMarkers(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "top of file",
+			content: "<<<<<<< HEAD\nlocal\n=======\nupstream\n>>>>>>> feature\n",
+			want:    true,
+		},
+		{
+			name:    "mid file",
+			content: "before\n<<<<<<< feature\nlocal\n=======\nupstream\n>>>>>>> feature\n",
+			want:    true,
+		},
+		{
+			name:    "indented marker",
+			content: "  <<<<<<< nope\n",
+			want:    false,
+		},
+		{
+			name:    "prose marker",
+			content: "this line mentions <<<<<<< as prose\n",
+			want:    false,
+		},
+		{
+			name:    "crlf marker",
+			content: "before\r\n<<<<<<< foo\n",
+			want:    false,
+		},
+		{
+			name:    "empty",
+			content: "",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasConflictMarkers([]byte(tt.content)); got != tt.want {
+				t.Fatalf("HasConflictMarkers() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsLocallyModified_SidecarMatchesSkill_ReturnsFalse(t *testing.T) {
 	dir := t.TempDir()
 	content := []byte("original content")

--- a/internal/textdiff/textdiff.go
+++ b/internal/textdiff/textdiff.go
@@ -1,0 +1,87 @@
+package textdiff
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/hexops/gotextdiff/span"
+)
+
+// Unified produces a unified diff "a/<label>" -> "b/<label>" between base and modified.
+func Unified(label string, base, modified []byte) string {
+	if string(base) == string(modified) {
+		return ""
+	}
+	edits := myers.ComputeEdits(span.URIFromPath(label), string(base), string(modified))
+	return fmt.Sprint(gotextdiff.ToUnified("a/"+label, "b/"+label, string(base), edits))
+}
+
+// TruncateUnified caps diff by line count or byte count, whichever hits first.
+func TruncateUnified(diff string, maxLines, maxBytes int) (string, bool) {
+	if diff == "" {
+		return "", false
+	}
+	if maxLines <= 0 || maxBytes <= 0 {
+		return fmt.Sprintf("… diff truncated: %d more lines not shown", countLines(diff)), true
+	}
+	lines := strings.SplitAfter(diff, "\n")
+	totalLines := len(lines)
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		totalLines--
+		lines = lines[:len(lines)-1]
+	}
+
+	var b strings.Builder
+	writtenLines := 0
+	for _, line := range lines {
+		if writtenLines >= maxLines {
+			break
+		}
+		if b.Len()+len(line) > maxBytes {
+			remaining := maxBytes - b.Len()
+			if remaining > 0 {
+				b.WriteString(validPrefix(line, remaining))
+			}
+			break
+		}
+		b.WriteString(line)
+		writtenLines++
+	}
+	if writtenLines >= totalLines && b.Len() == len(diff) {
+		return diff, false
+	}
+	remaining := totalLines - writtenLines
+	if remaining < 0 {
+		remaining = 0
+	}
+	out := strings.TrimRight(b.String(), "\n")
+	if out != "" {
+		out += "\n"
+	}
+	out += fmt.Sprintf("… diff truncated: %d more lines not shown", remaining)
+	return out, true
+}
+
+func countLines(s string) int {
+	if s == "" {
+		return 0
+	}
+	n := strings.Count(s, "\n")
+	if !strings.HasSuffix(s, "\n") {
+		n++
+	}
+	return n
+}
+
+func validPrefix(s string, maxBytes int) string {
+	if maxBytes >= len(s) {
+		return s
+	}
+	for maxBytes > 0 && !utf8.ValidString(s[:maxBytes]) {
+		maxBytes--
+	}
+	return s[:maxBytes]
+}

--- a/internal/textdiff/textdiff_test.go
+++ b/internal/textdiff/textdiff_test.go
@@ -1,0 +1,80 @@
+package textdiff
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUnified(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     string
+		modified string
+		want     []string
+	}{
+		{name: "identical inputs return empty", base: "one\ntwo\n", modified: "one\ntwo\n"},
+		{name: "addition", base: "one\n", modified: "one\ntwo\n", want: []string{"--- a/SKILL.md", "+++ b/SKILL.md", "+two"}},
+		{name: "deletion", base: "one\ntwo\n", modified: "one\n", want: []string{"--- a/SKILL.md", "+++ b/SKILL.md", "-two"}},
+		{name: "hunk grouping", base: "a\nb\nc\nd\ne\nf\ng\n", modified: "a\nb\nC\nd\ne\nF\ng\n", want: []string{"@@", "-c", "+C", "-f", "+F"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Unified("SKILL.md", []byte(tt.base), []byte(tt.modified))
+			if len(tt.want) == 0 {
+				if got != "" {
+					t.Fatalf("Unified() = %q, want empty", got)
+				}
+				return
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("Unified() missing %q in:\n%s", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestTruncateUnified(t *testing.T) {
+	tests := []struct {
+		name      string
+		diff      string
+		maxLines  int
+		maxBytes  int
+		want      string
+		truncated bool
+	}{
+		{name: "unchanged under cap", diff: "a\nb\n", maxLines: 5, maxBytes: 100, want: "a\nb\n"},
+		{name: "line cap", diff: "a\nb\nc\nd\n", maxLines: 2, maxBytes: 100, want: "a\nb\n… diff truncated: 2 more lines not shown", truncated: true},
+		{name: "byte cap", diff: "abcdef\nsecond\n", maxLines: 10, maxBytes: 3, want: "abc\n… diff truncated: 2 more lines not shown", truncated: true},
+		{name: "zero cap", diff: "a\nb\n", maxLines: 0, maxBytes: 100, want: "… diff truncated: 2 more lines not shown", truncated: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, truncated := TruncateUnified(tt.diff, tt.maxLines, tt.maxBytes)
+			if truncated != tt.truncated {
+				t.Fatalf("truncated = %v, want %v", truncated, tt.truncated)
+			}
+			if got != tt.want {
+				t.Fatalf("got:\n%q\nwant:\n%q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncateUnifiedLargeInput(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < 600; i++ {
+		b.WriteString("+line\n")
+	}
+	got, truncated := TruncateUnified(b.String(), 500, 64*1024)
+	if !truncated {
+		t.Fatal("expected truncation")
+	}
+	if lines := strings.Count(got, "\n") + 1; lines != 501 {
+		t.Fatalf("rendered lines = %d, want 501 including footer", lines)
+	}
+	if !strings.Contains(got, "… diff truncated: 100 more lines not shown") {
+		t.Fatalf("missing footer in:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- `scribe list → update` now renders unified diffs inline before the [r]/[l]/[m] choice. Two stacked viewports: "Your edits" (base→local) and "Incoming" (base→upstream).
- Diff lib: `gotextdiff` (already in go.sum, promoted to direct).
- Eager upstream fetch when entering the update substate; request-id guard drops stale responses.
- Small-terminal layout ladder degrades gracefully (4 height tiers).
- Pre-existing conflict markers route to `scribe resolve` via in-process binary.
- No cached upstream reuse — `runUpdate` stays unchanged. Defers a provider-cache surface.

## Why
Layer 1 (PR #173) fixed false-positive "Local edits detected." Layer 2 surfaces the actual diff so the user can choose [r]/[l]/[m] with full context.

## Test plan
- [x] go test ./internal/textdiff/...
- [x] go test ./internal/sync/...
- [x] go test ./cmd/...
- [x] go test ./...
- [x] go build ./...
- [x] go vet ./...
- [ ] Manual: edit a SKILL.md, run scribe list → update, see diff, pick [l]; revert and repeat → "no local edits".

## Related
- Solo todo #661 (Layer 2 of two-layer fix; Layer 1 = PR #173)
- Plan: scratchpad plan/layer2-diff-in-prompt-v2

## Follow-ups (out of scope, files todos in scratchpad done/layer2-impl)
- [d] pager escape for oversized diffs
- Cached-upstream reuse so [m]/[r] skip the second fetch
