### PR TITLE
docs: rewrite comparison to drop apples-to-oranges entries

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Scribe documentation
 
-- [Comparison](comparison.md) — how scribe compares with skills.sh, Superpowers, Anthropic skills, Cursor rules, Cline/Roo, and MCP
+- [Comparison](comparison.md) — how scribe compares with GitHub Copilot custom instructions and skills.sh / Agent Skills
 - [Commands reference](commands.md) — every subcommand grouped by use
 - [JSON envelope + agent contract](json-envelope.md) — envelope shape, exit codes, `--fields`, schema introspection
 - [Projects, kits, and snippets](projects-and-kits.md) — `.scribe.yaml`, kits, snippet rules

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -8,7 +8,7 @@ Scribe is for teams that want a reproducible, cross-agent way to publish, instal
 |---|---|---|---|
 | Primary job | Skill manager: publish, install, project, sync | Repo-scoped instructions for Copilot Chat, code review, agent | Open `SKILL.md` format and public directory |
 | Where instructions live | `~/.scribe/` (canonical), projected to `.claude/`, `.cursor/`, `.codex/`, `.gemini/` | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, `AGENTS.md` | Per-skill `SKILL.md` (frontmatter) anywhere a tool can read |
-| Cross-tool support | Claude Code, Codex, Cursor, Gemini, custom tools | Copilot (Chat, code review, agent, cloud agent). `AGENTS.md` is also read by Claude (`CLAUDE.md`) and Gemini (`GEMINI.md`). | Any agent that consumes the spec |
+| Cross-tool support | Claude Code, Codex, Cursor, Gemini, custom tools | Copilot (Chat, code review, cloud agent). `AGENTS.md` is also read by Claude (`CLAUDE.md`) and Gemini (`GEMINI.md`). | Any agent that consumes the spec |
 | Path/file scoping | `.scribe.yaml` per project, kits, snippets | `applyTo: "src/**/*.ts"` glob frontmatter on `*.instructions.md` | Not part of spec |
 | Reproducibility | `scribe.lock` lockfile, `scribe sync`, `scribe doctor` | None — markdown files in git, no lockfile or sync command | None — repo or directory listing |
 | Discovery | Connected registries (Naoray, anthropics, custom) | None — author your own, or borrow from `awesome-copilot` | Public directory and leaderboard |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,25 +1,24 @@
 # Scribe vs alternatives
 
-Scribe is for teams that want a reproducible, cross-agent way to publish, install, scope, and update coding-agent skills from registries. It is not a replacement for agent-specific workflow systems, IDE agents, or MCP servers: those are often better when you want a richer coding methodology, editor automation, or runtime access to external tools and data.
+Scribe is for teams that want a reproducible, cross-agent way to publish, install, scope, and update coding-agent skills from registries. The closest neighbours are **GitHub Copilot custom instructions** and the open **Agent Skills** format — both ship instructions to coding agents, but with different goals. Scribe is _not_ a replacement for an IDE agent, a coding methodology, or MCP servers — those solve different problems (see [Different layer](#different-layer-not-an-alternative)).
 
 ## Feature comparison
 
-| Feature | scribe | skills.sh / Agent Skills | superpowers | anthropics/skills | Cursor MDC | Cline / Roo | MCP servers |
-|---|---|---|---|---|---|---|---|
-| Primary job | ✓ skill manager | ✓ open skill format and directory | ✓ coding methodology and plugin | ✓ Claude skill examples and reference | ✓ scoped Cursor instructions | ✓ IDE workflows, skills, and commands | ✓ runtime tools, data, and workflows |
-| Reproducibility | ✓ `scribe.lock`, manifests, sync | partial spec validation, no lockfile | partial plugin/extension installs, no skill lockfile | partial git repo / plugin install | partial versioned if committed | partial project files if committed | N/A protocol integration |
-| Cross-tool support | ✓ Claude Code, Codex, Cursor, Gemini/custom tools | ✓ broad agent ecosystem | ✓ many coding-agent/plugin surfaces | partial Claude surfaces | ✗ Cursor only | partial Cline/Roo and `.agents` paths | ✓ broad clients and servers |
-| Discovery model | ✓ connected registries plus browse/list | ✓ public directory and leaderboard | partial plugin marketplaces and repo | partial curated example repo | partial local rule list | partial local menus/marketplaces | ✓ registries and server catalogs |
-| Update flow | ✓ explicit `sync`, `status`, `doctor`, schemas | partial CLI install/update behavior | partial agent-dependent, often automatic | partial plugin/repo updates | ✗ manual/project workflow | partial extension and local-file flows | partial client/server dependent |
-| Author publishing | ✓ `registry create/add`, `init`, `push` flows | partial publish by repository/directory listing | partial PR/plugin contribution | partial PR-based examples/templates | ✗ commit files in one repo | partial commit local project files | N/A build and publish servers |
-| Per-project state | ✓ `.scribe.yaml`, kits, snippets, projections | ✗ format is per skill, not project state | partial methodology can use worktrees | ✗ repository of skills, not project state | ✓ `.cursor/rules` and nested rules | ✓ project skills/workflows/commands | N/A client configuration |
-| Budget enforcement | ✓ Codex skill-description guardrail | ✗ spec gives description limits, not session budgets | ✗ not documented | ✗ not documented | ✗ not documented | ✗ not documented | N/A |
-| Existing skill adoption | ✓ adopt unmanaged local skills | partial compatible format | partial consumes skills/plugins | partial examples/template | N/A | partial can read local skill dirs | N/A |
-| Frontmatter-only skill format | ✓ uses `SKILL.md` frontmatter | ✓ spec is `SKILL.md` frontmatter | partial skills plus plugin instructions | ✓ `SKILL.md` frontmatter | partial MDC frontmatter, not skills | ✓ `SKILL.md` for skills | N/A |
-| Command/schema introspection | ✓ JSON envelopes and `scribe schema` | ✗ not part of spec | ✗ not documented | ✗ not documented | ✗ not documented | partial command UIs/CLI, no shared schema | ✓ tool schemas in protocol |
-| Best at | ✓ skill lifecycle and team sync | ✓ portable skill authoring format | ✓ disciplined development workflow | ✓ Claude-native examples | ✓ Cursor prompt policy | ✓ IDE automation and task workflows | ✓ connecting agents to external systems |
+| Feature | Scribe | GitHub Copilot custom instructions | skills.sh / Agent Skills |
+|---|---|---|---|
+| Primary job | Skill manager: publish, install, project, sync | Repo-scoped instructions for Copilot Chat, code review, agent | Open `SKILL.md` format and public directory |
+| Where instructions live | `~/.scribe/` (canonical), projected to `.claude/`, `.cursor/`, `.codex/`, `.gemini/` | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, `AGENTS.md` | Per-skill `SKILL.md` (frontmatter) anywhere a tool can read |
+| Cross-tool support | Claude Code, Codex, Cursor, Gemini, custom tools | Copilot (Chat, code review, agent, cloud agent). `AGENTS.md` is also read by Claude (`CLAUDE.md`) and Gemini (`GEMINI.md`). | Any agent that consumes the spec |
+| Path/file scoping | `.scribe.yaml` per project, kits, snippets | `applyTo: "src/**/*.ts"` glob frontmatter on `*.instructions.md` | Not part of spec |
+| Reproducibility | `scribe.lock` lockfile, `scribe sync`, `scribe doctor` | None — markdown files in git, no lockfile or sync command | None — repo or directory listing |
+| Discovery | Connected registries (Naoray, anthropics, custom) | None — author your own, or borrow from `awesome-copilot` | Public directory and leaderboard |
+| Existing skill adoption | `scribe adopt` claims unmanaged local skills via symlink | N/A — instructions are author-only | Compatible `SKILL.md` format (cross-import) |
+| Per-project state | `.scribe.yaml`, `.ai/scribe.lock`, projection map | Repo-scoped instructions in `.github/`, but no manifest or lockfile | Per-skill, not project state |
+| Budget enforcement | Codex skill-description guardrail in `scribe doctor` | Not documented | Spec gives description limits, not session budgets |
+| Schema / introspection | JSON envelopes, `scribe schema <command>`, exit codes | Not applicable — natural-language markdown | Not part of spec |
+| Best at | Multi-agent skill lifecycle and team sync | Tightly-scoped repo instructions for Copilot users | Portable skill authoring format |
 
-## When to pick scribe
+## When to pick Scribe
 
 - You maintain team skills in Git and want one manifest-driven install/update flow across multiple agent tools.
 - You need reproducible sync, lockfiles, repair commands, and machine-readable output for agent automation.
@@ -28,25 +27,22 @@ Scribe is for teams that want a reproducible, cross-agent way to publish, instal
 
 ## When to pick an alternative
 
-- Pick **skills.sh / Agent Skills** when you mainly need the open `SKILL.md` format, public discovery, or compatibility with tools that already consume Agent Skills directly.
-- Pick **superpowers** when you want a complete agentic software-development methodology with planning, TDD, review, worktree, and subagent workflows.
-- Pick **anthropics/skills** when you want Claude-native examples, templates, or document skills that demonstrate Anthropic's skill patterns.
-- Pick **Cursor MDC** when your only target is Cursor and you want lightweight, version-controlled rules tied to file globs or manual `@ruleName` attachment.
-- Pick **Cline or Roo Code** when you want a VS Code agent with editor automation, slash-command workflows, skills, checkpoints, modes, browser tools, or human-in-the-loop command approval.
-- Pick **MCP servers** when the problem is tool/data access at runtime, such as calling GitHub, reading a database, or connecting an agent to an internal service.
+- Pick **GitHub Copilot custom instructions** when your team is all-in on Copilot and a path-scoped `*.instructions.md` plus a repo `copilot-instructions.md` cover what you need. Lighter than Scribe, but no lockfile, no project state, no cross-tool projection.
+- Pick **skills.sh / Agent Skills** when you mainly need the open `SKILL.md` format, public discovery, or compatibility with tools that already consume Agent Skills directly. (Scribe consumes the same `SKILL.md` format — you can use both.)
+
+## Different layer, not an alternative
+
+- **MCP servers** solve runtime tool/data access (calling GitHub, reading a database, connecting to internal services). Scribe and Copilot instructions ship _prompts and skills_; MCP ships _capabilities_. Most teams want both.
+- **IDE agents** (Cline, Roo Code, Cursor agent mode, Claude Code) are the runtime that _executes_ skills. Scribe is the source-of-truth and delivery system; the agent is the consumer.
+- **Coding methodologies** (TDD-first, agentic plan/build/review loops) are _how_ an agent works. Scribe is _what_ the agent reads.
 
 ## References
 
 - [scribe README](../README.md)
 - [scribe commands reference](commands.md)
 - [scribe projects, kits, and snippets](projects-and-kits.md)
+- [GitHub Copilot custom instructions](https://docs.github.com/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot)
+- [Path-scoped Copilot instructions changelog](https://github.blog/changelog/2025-09-03-copilot-code-review-path-scoped-custom-instruction-file-support/)
 - [skills.sh](https://skills.sh)
 - [Agent Skills specification](https://agentskills.io/specification)
-- [obra/superpowers README](https://github.com/obra/superpowers)
-- [anthropics/skills README](https://github.com/anthropics/skills)
-- [Cursor rules documentation](https://docs.cursor.com/en/context)
-- [Cline workflows documentation](https://docs.cline.bot/customization/workflows)
-- [Cline skills documentation](https://docs.cline.bot/customization/skills)
-- [Roo Code skills documentation](https://docs.roocode.com/features/skills)
-- [Roo Code slash commands documentation](https://docs.roocode.com/features/slash-commands)
 - [Model Context Protocol introduction](https://modelcontextprotocol.io/docs/getting-started/intro)


### PR DESCRIPTION
## Summary

The previous comparison table had 7 columns including **Superpowers**, **anthropics/skills**, and **Cursor MDC** — none of which are direct alternatives to Scribe. They're either a different layer (methodology, examples) or a different scope (single-IDE rules). The table was also missing **GitHub Copilot's custom instruction system**, which is now a real neighbour after Copilot shipped path-scoped `*.instructions.md` and the cross-tool `AGENTS.md` convention.

## What changed

- Drop **Superpowers** column — coding methodology, not skill manager
- Drop **anthropics/skills** column — example repo, not a tool
- Drop **Cursor MDC** column — single-IDE rule format
- Drop **Cline / Roo Code** column — IDE agents, runtime not delivery (moved to "Different layer" prose)
- Add **GitHub Copilot custom instructions** column with `applyTo` glob, `.github/instructions/*.instructions.md`, and AGENTS.md cross-tool note
- Keep **skills.sh / Agent Skills** column — Scribe consumes the same format, fair comparison
- Reframe **MCP servers**, **IDE agents**, and **coding methodologies** as "different layer, not an alternative" in prose
- Net: 7 columns → 4. Fits cleanly inside narrow docs article width.

## Sources reviewed

- [Copilot custom instructions docs](https://docs.github.com/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot)
- [Path-scoped Copilot instructions changelog (2025-09-03)](https://github.blog/changelog/2025-09-03-copilot-code-review-path-scoped-custom-instruction-file-support/)
- microsoft/vscode-docs custom-instructions.md

## Test plan

- [ ] Read the new table — does each row still hold up?
- [ ] Confirm the "Different layer" framing reads right for MCP / IDE agents / methodologies
- [ ] Sanity-check the Copilot column (applyTo syntax, file paths)
- [ ] Once merged + a release is cut, scribe-website unhides `/docs/comparison/` from sidebar (currently `navHidden` until upstream is fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)