### PR TITLE
docs(adoption): trim quickstart command comments

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -5,11 +5,11 @@ If you've been hand-rolling skills in `~/.claude/skills/`, `~/.codex/skills/`, o
 ## Quick start
 
 ```bash
-scribe adopt                 # interactive: review conflicts, adopt clean candidates
-scribe adopt --no-interaction  # auto-adopt all clean candidates
-scribe adopt --dry-run       # preview the plan, no writes
-scribe adopt <name>          # adopt a single named skill
-scribe adopt --json          # machine-readable plan + result
+scribe adopt                    # interactive review + adopt
+scribe adopt --no-interaction   # auto-adopt clean candidates
+scribe adopt --dry-run          # preview, no writes
+scribe adopt <name>             # adopt one skill by name
+scribe adopt --json             # machine-readable plan
 ```
 
 Adopted skills appear with `(local)` in `scribe list`. They have no upstream and stay until you `scribe remove` them.


### PR DESCRIPTION
## Summary

The `scribe adopt` quickstart block in `docs/adoption.md` had comments long enough to push the rendered code block past typical article width on the docs site, triggering a horizontal scrollbar.

## What changed

Comments shortened from sentence-style to verb-phrases. Same intent, tighter line:

| Before | After |
|---|---|
| `# interactive: review conflicts, adopt clean candidates` | `# interactive review + adopt` |
| `# auto-adopt all clean candidates` | `# auto-adopt clean candidates` |
| `# preview the plan, no writes` | `# preview, no writes` |
| `# adopt a single named skill` | `# adopt one skill by name` |
| `# machine-readable plan + result` | `# machine-readable plan` |

## Test plan

- [ ] Render adoption.md on the docs site and confirm no horizontal scrollbar in the Quick start block at typical reading widths
- [ ] Read the comments — still convey what each flag does

🤖 Generated with [Claude Code](https://claude.com/claude-code)