### PR TITLE
docs: comparison v2 — add real peers (skills-manager, Kasetto, skills-supply)

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,22 +1,22 @@
 # Scribe vs alternatives
 
-Scribe is for teams that want a reproducible, cross-agent way to publish, install, scope, and update coding-agent skills from registries. The closest neighbours are **GitHub Copilot custom instructions** and the open **Agent Skills** format — both ship instructions to coding agents, but with different goals. Scribe is _not_ a replacement for an IDE agent, a coding methodology, or MCP servers — those solve different problems (see [Different layer](#different-layer-not-an-alternative)).
+Scribe is for teams that want a reproducible, cross-agent way to publish, install, scope, and update coding-agent skills from registries. The closest direct peers are **xingkongliang/skills-manager**, **pivoshenko/Kasetto**, and **803/skills-supply** — three projects that, like Scribe, treat `SKILL.md` as the unit and project it across multiple agents. **GitHub Copilot custom instructions** sit nearby as the most-used per-repo rule renderer. Scribe is _not_ a replacement for an IDE agent, MCP servers, or coding methodologies (see [Different layer](#different-layer-not-an-alternative)).
 
 ## Feature comparison
 
-| Feature | Scribe | GitHub Copilot custom instructions | skills.sh / Agent Skills |
-|---|---|---|---|
-| Primary job | Skill manager: publish, install, project, sync | Repo-scoped instructions for Copilot Chat, code review, agent | Open `SKILL.md` format and public directory |
-| Where instructions live | `~/.scribe/` (canonical), projected to `.claude/`, `.cursor/`, `.codex/`, `.gemini/` | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, `AGENTS.md` | Per-skill `SKILL.md` (frontmatter) anywhere a tool can read |
-| Cross-tool support | Claude Code, Codex, Cursor, Gemini, custom tools | Copilot (Chat, code review, cloud agent). `AGENTS.md` is also read by Claude (`CLAUDE.md`) and Gemini (`GEMINI.md`). | Any agent that consumes the spec |
-| Path/file scoping | `.scribe.yaml` per project, kits, snippets | `applyTo: "src/**/*.ts"` glob frontmatter on `*.instructions.md` | Not part of spec |
-| Reproducibility | `scribe.lock` lockfile, `scribe sync`, `scribe doctor` | None — markdown files in git, no lockfile or sync command | None — repo or directory listing |
-| Discovery | Connected registries (Naoray, anthropics, custom) | None — author your own, or borrow from `awesome-copilot` | Public directory and leaderboard |
-| Existing skill adoption | `scribe adopt` claims unmanaged local skills via symlink | N/A — instructions are author-only | Compatible `SKILL.md` format (cross-import) |
-| Per-project state | `.scribe.yaml`, `.ai/scribe.lock`, projection map | Repo-scoped instructions in `.github/`, but no manifest or lockfile | Per-skill, not project state |
-| Budget enforcement | Codex skill-description guardrail in `scribe doctor` | Not documented | Spec gives description limits, not session budgets |
-| Schema / introspection | JSON envelopes, `scribe schema <command>`, exit codes | Not applicable — natural-language markdown | Not part of spec |
-| Best at | Multi-agent skill lifecycle and team sync | Tightly-scoped repo instructions for Copilot users | Portable skill authoring format |
+| Feature | Scribe | xingkongliang/skills-manager | pivoshenko/Kasetto | 803/skills-supply | GitHub Copilot custom instructions |
+|---|---|---|---|---|---|
+| Primary job | Skill manager: publish, install, project, sync | Desktop GUI for cross-tool `SKILL.md` library | Declarative agent environment manager (Rust CLI) | One-manifest skill installer for multiple agents | Repo-scoped instructions for Copilot Chat, code review, agent |
+| Where instructions live | `~/.scribe/` (canonical), projected to `.claude/`, `.cursor/`, `.codex/`, `.gemini/` | `~/.skills-manager/` (default), GUI-managed | `kasetto.yaml` + lockfile, projected to agent dirs | `agents.toml` per project or global | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, `AGENTS.md` |
+| Cross-tool support | Claude Code, Codex, Cursor, Gemini, custom | Cursor, Claude Code, Codex, OpenCode, Amp, Roo Code, Gemini CLI, Copilot, Windsurf | 21 built-in agent presets (Claude Code, Cursor, Codex, Windsurf, Copilot, Gemini CLI, …) | Claude Code, Amp, Codex, OpenCode, Factory | Copilot (Chat, code review, cloud agent). `AGENTS.md` is also read by Claude (`CLAUDE.md`) and Gemini (`GEMINI.md`). |
+| Path/file scoping | `.scribe.yaml` per project, kits, snippets | "Scenarios" + "Project Workspaces" | Per-skill selection + project/global scope | `agents.toml` (project or global) | `applyTo: "src/**/*.ts"` glob frontmatter on `*.instructions.md` |
+| Reproducibility | `scribe.lock` lockfile, `scribe sync`, `scribe doctor` | Git backup/restore, snapshot tags, multi-machine sync (no lockfile) | Lockfile + pinned refs/tags/commits + `doctor` | Tracked state + reconciliation, no user-facing lockfile | Plain markdown in git, no lockfile or sync command |
+| Discovery | Connected registries (Naoray, anthropics, custom) | Git repos, local folders, archives, skills.sh marketplace | GitHub / GitLab / Bitbucket / Codeberg / Gitea / self-hosted, local paths, remote team config URLs | GitHub, arbitrary Git remotes, local paths, Claude plugin marketplaces | None — write your own, or borrow from `awesome-copilot` |
+| Existing skill adoption | `scribe adopt` claims unmanaged local skills via symlink | Project Workspaces compare project-local skill folders with the central library and sync either direction | Limited — sync from local folders, no one-shot claim | Refuses to overwrite manually-added skills; can reset state to mark them "unmanaged" | N/A — instructions are author-only |
+| Per-project state | `.scribe.yaml`, `.ai/scribe.lock`, projection map | Project Workspaces with per-agent assignment | Project-scope install + selectable subset | `agents.toml` per project | Repo-scoped instructions in `.github/`, but no manifest or lockfile |
+| Budget enforcement | Codex skill-description guardrail in `scribe doctor` | Not documented | Not documented | Not documented | Not documented |
+| Schema / introspection | JSON envelopes, `scribe schema <command>`, exit codes | `--json` output for scripts and agents | `sync`, `list`, `doctor`, `clean`, self-update all expose `--json` | Scriptable via `--non-interactive`, no JSON output | Not applicable — natural-language markdown |
+| Best at | Multi-agent skill lifecycle and team sync | Desktop-first cross-tool skill library with backup/sync | Declarative reproducible agent environments (CLI) | Manifest-driven skill sync across agents | Tightly-scoped repo instructions for Copilot users |
 
 ## When to pick Scribe
 
@@ -27,8 +27,21 @@ Scribe is for teams that want a reproducible, cross-agent way to publish, instal
 
 ## When to pick an alternative
 
-- Pick **GitHub Copilot custom instructions** when your team is all-in on Copilot and a path-scoped `*.instructions.md` plus a repo `copilot-instructions.md` cover what you need. Lighter than Scribe, but no lockfile, no project state, no cross-tool projection.
-- Pick **skills.sh / Agent Skills** when you mainly need the open `SKILL.md` format, public discovery, or compatibility with tools that already consume Agent Skills directly. (Scribe consumes the same `SKILL.md` format — you can use both.)
+- Pick **xingkongliang/skills-manager** if you want a polished desktop GUI as the primary surface, and value built-in backup/restore + multi-machine sync over a CLI-first lockfile model.
+- Pick **pivoshenko/Kasetto** if you want a declarative, Rust-based CLI with a strong lockfile + `--json` everywhere, and don't yet need an `adopt`-style claim flow.
+- Pick **803/skills-supply** if a single `agents.toml` per project covers your needs and you don't need a registry/lockfile/adopt bundle.
+- Pick **GitHub Copilot custom instructions** if your team is all-in on Copilot and a path-scoped `*.instructions.md` plus a repo `copilot-instructions.md` cover what you need. Lighter than Scribe, but no lockfile, no project state, no cross-tool projection.
+- Use **skills.sh / Agent Skills** as the format underneath any of the above. Scribe consumes `SKILL.md` directly; most peers do too. It is a spec, not a tool.
+
+## Related projects (partial overlap, broader category)
+
+These solve a slice of the same problem but sit in adjacent categories:
+
+- **[pr-pm/prpm](https://github.com/pr-pm/prpm)** — universal registry that auto-converts one package into vendor-native formats (Cursor rules, Claude skills, Copilot instructions, …). Strong registry/conversion, weaker on canonical local storage and adoption.
+- **[enulus/OpenPackage](https://github.com/enulus/OpenPackage)** — package manager for agent configs (rules, commands, agents, skills, MCP) with project/global scope and a wide platform matrix. Broader than Scribe; not `SKILL.md`-first.
+- **[frmlabz/omnidev](https://github.com/frmlabz/omnidev)** — capability format (`omni.toml` / `OMNI.md`) with provider-specific generation and profile switching. Alpha-stage; provider-renderer rather than skill manager.
+- **[dennishavermans/agentfile](https://github.com/dennishavermans/agentfile)** — single committed `ai/contract.yaml` rendered into `CLAUDE.md`, `.cursor/rules/*.mdc`, `.github/copilot-instructions.md`, `AGENTS.md`. Cross-tool contract renderer; no registry, no central skill store.
+- **[KrystianJonca/lnai](https://github.com/KrystianJonca/lnai)** — define once in `.ai/`, sync everywhere. One-config renderer; no registry, no lockfile.
 
 ## Different layer, not an alternative
 
@@ -41,6 +54,9 @@ Scribe is for teams that want a reproducible, cross-agent way to publish, instal
 - [scribe README](../README.md)
 - [scribe commands reference](commands.md)
 - [scribe projects, kits, and snippets](projects-and-kits.md)
+- [xingkongliang/skills-manager](https://github.com/xingkongliang/skills-manager)
+- [pivoshenko/Kasetto](https://github.com/pivoshenko/Kasetto)
+- [803/skills-supply](https://github.com/803/skills-supply)
 - [GitHub Copilot custom instructions](https://docs.github.com/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot)
 - [Path-scoped Copilot instructions changelog](https://github.blog/changelog/2025-09-03-copilot-code-review-path-scoped-custom-instruction-file-support/)
 - [skills.sh](https://skills.sh)


### PR DESCRIPTION
## Summary

After deeper research, three projects sit clearly in the same product category as Scribe and were missing from the v1 comparison (PR #180):

- **[xingkongliang/skills-manager](https://github.com/xingkongliang/skills-manager)** — desktop GUI for cross-tool SKILL.md library with backup/restore + multi-machine sync. Closest overall feature-bundle match (delivery shape is GUI, not CLI).
- **[pivoshenko/Kasetto](https://github.com/pivoshenko/Kasetto)** — declarative Rust CLI with lockfile, `--json` everywhere, 21 built-in agent presets. Closest CLI-native peer.
- **[803/skills-supply](https://github.com/803/skills-supply)** — one-manifest (`agents.toml`) skill installer for multiple agents. Smaller scope but same direction.

Calling these "apples-to-oranges" would be wrong — they're peers.

## What changed

- **Comparison table** is now 5 columns: Scribe + 3 peers + GitHub Copilot custom instructions. Same rows as before (primary job, where instructions live, cross-tool support, scoping, reproducibility, discovery, adoption, per-project state, budget enforcement, schema, best at).
- **"When to pick an alternative"** prose now covers each true peer + Copilot. `skills.sh / Agent Skills` is reframed as the format underlying most peers, not a column of its own.
- **New "Related projects" section** lists partial-overlap tools sitting one layer over (prpm, OpenPackage, omnidev, agentfile, lnai) — useful neighbours but different category.
- **"Different layer, not an alternative"** unchanged — MCP, IDE agents, coding methodologies.

## Test plan

- [ ] Read each cell — does the claim hold up? Particularly: Kasetto's lockfile vs Scribe's lockfile distinction; skills-manager's adoption story vs `scribe adopt`.
- [ ] Confirm the 3 peers are stable enough to keep in primary docs (not vapourware): skills-manager 659★, Kasetto 67★ (active May 2026), skills-supply 31★.
- [ ] Once merged + a release is cut, scribe-website unhides `/docs/comparison/` from the sidebar (currently `navHidden`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)