### PR TITLE
ci: notify scribe-website on release

### DIFF
--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -1,0 +1,12 @@
+name: Notify website on release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: POST Cloudflare Pages deploy hook
+        run: curl -fsS -X POST "${{ secrets.SCRIBE_WEBSITE_DEPLOY_HOOK }}"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/notify-website.yml` so a published Release automatically POSTs the Cloudflare Pages deploy hook for `scribe-website`. The website pulls docs from the latest release tag — this keeps the live site in sync without a manual rebuild step.

## How it works

- Trigger: `release.published` (drafts and pre-releases skipped)
- One step: `curl -fsS -X POST "$SCRIBE_WEBSITE_DEPLOY_HOOK"`
- Secret: `SCRIBE_WEBSITE_DEPLOY_HOOK` (already set on this repo)

## Test plan

- [ ] After merge, publish any release (or re-publish an existing one) and check the workflow run succeeds
- [ ] Check Cloudflare Pages → scribe-website → Deployments to see a new build kicked off ~30s later