### PR TITLE
chore: point repo homepage and docs at usescribe.dev

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ brews:
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Formula
-    homepage: "https://github.com/Naoray/scribe"
+    homepage: "https://usescribe.dev"
     description: "Team skill sync CLI for AI coding agents"
     license: "MIT"
     install: |


### PR DESCRIPTION
## Summary

- Repo homepage URL set to `https://usescribe.dev` via `gh api repos/Naoray/scribe -X PATCH`
- `.goreleaser.yml` brew formula homepage updated `https://github.com/Naoray/scribe` -> `https://usescribe.dev`

## Files changed

- `.goreleaser.yml` — brew formula `homepage` field points at usescribe.dev

## Metadata change (out of tree)

- GitHub repo `homepage` field: `""` -> `https://usescribe.dev`

## Test plan

- [ ] `gh repo view Naoray/scribe --json homepageUrl` returns `https://usescribe.dev`
- [ ] After merge, GitHub repo sidebar shows usescribe.dev link
- [ ] Next release: brew formula in `Naoray/homebrew-tap` shows new homepage

## Notes

- No stale `pages.dev` / `scribe-website-2fn.pages.dev` / `usescribe` strings found in repo. Audit was clean.
- README has no website link in hero/footer. Did not auto-add — flag for follow-up if you want one.
- `docs/superpowers/` skipped per task spec.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>