### PR TITLE
docs(readme): surface usescribe.dev + sharpen repo metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 |___/\___|_|_\___|___/___|
 ```
 
+**Website:** [usescribe.dev](https://usescribe.dev) · **Docs:** [usescribe.dev/docs](https://usescribe.dev/docs/)
+
 A skill manager for AI coding agents. One canonical store of `SKILL.md` files, symlinked into `~/.claude/skills/`, `.cursor/rules/`, `~/.agents/skills/`, and Gemini. Project-scoped, lockfile-pinned, and scriptable through a versioned JSON envelope.
 
 For engineers running Claude Code, Cursor, Codex, or Gemini who got tired of copying skill files between four directories.


### PR DESCRIPTION
## Summary

Two paired changes — README gets a website/docs reference at the top, and the GitHub repo metadata is sharpened to match.

## What changed

- **README.md**: One-line website + docs links right under the title, before the long-form description. Lets a first-time visitor click straight through to the live site.
- **Repo description** (via `gh api PATCH`, already applied): "Local skill manager for AI coding agents. One SKILL.md, projected across Claude Code, Cursor, Codex, Gemini. Lockfile-pinned, project-scoped, MIT."
- **Repo topics** (via `gh api PUT`, already applied): ai, ai-agents, claude, cli, codex, coding-agent, cursor, developer-tools, gemini, llm, skill-manager, skills

## Test plan

- [ ] Read top of README — does the website line read right?
- [ ] Visit https://github.com/Naoray/scribe — sidebar should show the new description, topics, and homepage link