### PR TITLE
fix: repair registry add package prompt flow

### DIFF
--- a/cmd/registry_add.go
+++ b/cmd/registry_add.go
@@ -81,10 +81,6 @@ func runRegistryAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("authentication required — run `gh auth login` or set GITHUB_TOKEN")
 	}
 
-	targetStatuses, err := tools.ResolveStatuses(cfg)
-	if err != nil {
-		return fmt.Errorf("resolve tools: %w", err)
-	}
 	targets, err := tools.ResolveActive(cfg)
 	if err != nil {
 		return fmt.Errorf("resolve active tools: %w", err)
@@ -106,7 +102,7 @@ func runRegistryAdd(cmd *cobra.Command, args []string) error {
 
 	// Package ref fast path — doesn't need local/remote discovery.
 	if len(args) == 1 && strings.Contains(args[0], "/") {
-		return runRegistryAddPackageRef(ctx, args[0], installFlags, adder, targetRepo, st, client, targets, targetStatuses, useJSON, isTTY)
+		return runRegistryAddPackageRef(ctx, args[0], installFlags, adder, targetRepo, st, client, targets, useJSON, isTTY)
 	}
 
 	// Discover candidates.
@@ -166,7 +162,6 @@ func runRegistryAddPackageRef(
 	st *state.State,
 	client *gh.Client,
 	targets []tools.Tool,
-	knownTargets []tools.Status,
 	useJSON bool,
 	isTTY bool,
 ) error {
@@ -184,7 +179,7 @@ func runRegistryAddPackageRef(
 	}
 
 	// Gather install commands.
-	installs, perr := collectInstallCommands(packageRepo, installFlags, knownTargets, isTTY)
+	installs, perr := collectInstallCommands(packageRepo, installFlags, targets, isTTY)
 	if perr != nil {
 		return perr
 	}
@@ -221,12 +216,13 @@ func isPackageManifestMissingErr(err error) bool {
 
 // collectInstallCommands returns a map of tool name → install command,
 // either from --install flags or by prompting the user.
-func collectInstallCommands(packageRepo string, flags []string, knownTargets []tools.Status, isTTY bool) (map[string]string, error) {
+func collectInstallCommands(packageRepo string, flags []string, targets []tools.Tool, isTTY bool) (map[string]string, error) {
 	// Parse --install flags first — they always win.
 	installs := map[string]string{}
 	validTools := map[string]bool{}
-	for _, t := range knownTargets {
-		validTools[t.Name] = true
+	targetNames := toolTargetNames(targets)
+	for _, name := range targetNames {
+		validTools[name] = true
 	}
 
 	for _, raw := range flags {
@@ -240,7 +236,7 @@ func collectInstallCommands(packageRepo string, flags []string, knownTargets []t
 			return nil, fmt.Errorf("invalid --install value %q: tool and command must be non-empty", raw)
 		}
 		if !validTools[tool] {
-			return nil, fmt.Errorf("unknown tool %q in --install — expected one of: %s", tool, strings.Join(toolNames(knownTargets), ", "))
+			return nil, fmt.Errorf("unknown tool %q in --install — expected one of: %s", tool, strings.Join(targetNames, ", "))
 		}
 		installs[tool] = cmd
 	}
@@ -259,10 +255,10 @@ func collectInstallCommands(packageRepo string, flags []string, knownTargets []t
 	fmt.Println("Enter the install command for each tool (leave blank to skip):")
 	fmt.Println()
 
-	for _, t := range knownTargets {
+	for _, name := range targetNames {
 		var value string
 		prompt := huh.NewInput().
-			Title(fmt.Sprintf("Install command for %s", t.Name)).
+			Title(fmt.Sprintf("Install command for %s", name)).
 			Placeholder("e.g. /plugin install superpowers").
 			Value(&value)
 		if err := prompt.Run(); err != nil {
@@ -270,18 +266,24 @@ func collectInstallCommands(packageRepo string, flags []string, knownTargets []t
 		}
 		value = strings.TrimSpace(value)
 		if value != "" {
-			installs[t.Name] = value
+			installs[name] = value
 		}
 	}
 	return installs, nil
 }
 
-func toolNames(targets []tools.Status) []string {
+func toolTargetNames(targets []tools.Tool) []string {
 	names := make([]string, 0, len(targets))
 	for _, t := range targets {
-		names = append(names, t.Name)
+		names = append(names, t.Name())
 	}
 	return names
+}
+
+var fetchRegistryManifestForPackageRef = fetchRegistryManifest
+
+var pushRegistryFilesForPackageRef = func(ctx context.Context, client *gh.Client, owner, repo string, files map[string]string, message string) error {
+	return client.PushFiles(ctx, owner, repo, files, message)
 }
 
 // pushBarePackageRef appends a package-type catalog entry for packageRepo to
@@ -297,7 +299,7 @@ func pushBarePackageRef(ctx context.Context, adder *add.Adder, targetRepo, packa
 		return fmt.Errorf("parse package repo %q: %w", packageRepo, err)
 	}
 
-	m, err := fetchRegistryManifest(ctx, adder.Client, targetOwner, targetRepoName)
+	m, err := fetchRegistryManifestForPackageRef(ctx, adder.Client, targetOwner, targetRepoName)
 	if err != nil {
 		return fmt.Errorf("fetch manifest: %w", err)
 	}
@@ -322,7 +324,7 @@ func pushBarePackageRef(ctx context.Context, adder *add.Adder, targetRepo, packa
 	}
 
 	msg := fmt.Sprintf("add package: %s", entry.Name)
-	if err := adder.Client.PushFiles(ctx, targetOwner, targetRepoName, map[string]string{
+	if err := pushRegistryFilesForPackageRef(ctx, adder.Client, targetOwner, targetRepoName, map[string]string{
 		manifest.ManifestFilename: string(encoded),
 	}, msg); err != nil {
 		return err

--- a/cmd/registry_add_test.go
+++ b/cmd/registry_add_test.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/add"
+	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+type registryAddFakeTool struct {
+	name string
+}
+
+func (t registryAddFakeTool) Name() string { return t.name }
+
+func (t registryAddFakeTool) Install(string, string, string) ([]string, error) {
+	return nil, nil
+}
+
+func (t registryAddFakeTool) Uninstall(string) error { return nil }
+
+func (t registryAddFakeTool) Detect() bool { return true }
+
+func (t registryAddFakeTool) SkillPath(string, string) (string, error) {
+	return "", nil
+}
+
+func (t registryAddFakeTool) CanonicalTarget(string) (string, bool) {
+	return "", false
+}
+
+func TestCollectInstallCommandsUsesActiveTargets(t *testing.T) {
+	targets := []tools.Tool{
+		registryAddFakeTool{name: "aider"},
+		registryAddFakeTool{name: "gemini"},
+	}
+
+	installs, err := collectInstallCommands("acme/superpowers", []string{
+		"aider=aider install superpowers",
+		"gemini=gemini skills install superpowers",
+	}, targets, false)
+	if err != nil {
+		t.Fatalf("collectInstallCommands: %v", err)
+	}
+
+	if got := installs["aider"]; got != "aider install superpowers" {
+		t.Fatalf("aider install = %q", got)
+	}
+	if got := installs["gemini"]; got != "gemini skills install superpowers" {
+		t.Fatalf("gemini install = %q", got)
+	}
+
+	_, err = collectInstallCommands("acme/superpowers", []string{
+		"cursor=/plugin install superpowers",
+	}, targets, false)
+	if err == nil {
+		t.Fatal("expected inactive cursor install to be rejected")
+	}
+	if !strings.Contains(err.Error(), `unknown tool "cursor"`) {
+		t.Fatalf("error = %q, want unknown cursor", err.Error())
+	}
+	if !strings.Contains(err.Error(), "aider, gemini") {
+		t.Fatalf("error = %q, want active target names", err.Error())
+	}
+}
+
+func TestPushBarePackageRefEmitsVisibleAndJSONResults(t *testing.T) {
+	oldFetch := fetchRegistryManifestForPackageRef
+	oldPush := pushRegistryFilesForPackageRef
+	t.Cleanup(func() {
+		fetchRegistryManifestForPackageRef = oldFetch
+		pushRegistryFilesForPackageRef = oldPush
+	})
+
+	fetchRegistryManifestForPackageRef = func(context.Context, *gh.Client, string, string) (*manifest.Manifest, error) {
+		return &manifest.Manifest{
+			APIVersion: "scribe/v1",
+			Kind:       "Registry",
+			Team:       &manifest.Team{Name: "acme"},
+		}, nil
+	}
+
+	var pushed string
+	pushRegistryFilesForPackageRef = func(_ context.Context, _ *gh.Client, owner, repo string, files map[string]string, message string) error {
+		if owner != "acme" || repo != "registry" {
+			t.Fatalf("push repo = %s/%s, want acme/registry", owner, repo)
+		}
+		if message != "add package: superpowers" {
+			t.Fatalf("message = %q", message)
+		}
+		pushed = files[manifest.ManifestFilename]
+		return nil
+	}
+
+	adder := &add.Adder{Client: &gh.Client{}}
+	results := wireAddEmit(adder, "acme/registry", false)
+
+	out := captureStdout(t, func() {
+		err := pushBarePackageRef(t.Context(), adder, "acme/registry", "obra/superpowers", map[string]string{
+			"gemini": "gemini skills install superpowers",
+		})
+		if err != nil {
+			t.Fatalf("pushBarePackageRef: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "adding reference superpowers") {
+		t.Fatalf("stdout missing adding event: %q", out)
+	}
+	if !strings.Contains(out, "✓ superpowers added to acme/registry") {
+		t.Fatalf("stdout missing success event: %q", out)
+	}
+	if !strings.Contains(pushed, "gemini: gemini skills install superpowers") {
+		t.Fatalf("pushed manifest missing install command:\n%s", pushed)
+	}
+
+	adder = &add.Adder{Client: &gh.Client{}}
+	results = wireAddEmit(adder, "acme/registry", true)
+	if err := pushBarePackageRef(t.Context(), adder, "acme/registry", "obra/superpowers", map[string]string{
+		"gemini": "gemini skills install superpowers",
+	}); err != nil {
+		t.Fatalf("pushBarePackageRef json mode: %v", err)
+	}
+	if len(*results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(*results))
+	}
+	if (*results)[0].Name != "superpowers" || (*results)[0].Registry != "acme/registry" {
+		t.Fatalf("result = %+v", (*results)[0])
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"+":      *results,
+		"synced": false,
+	})
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	if !bytes.Contains(payload, []byte(`"name":"superpowers"`)) {
+		t.Fatalf("json payload missing package result: %s", payload)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil && !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close stdout reader: %v", err)
+	}
+	return buf.String()
+}


### PR DESCRIPTION
Fixes the package-ref fallback path for `scribe registry add owner/repo` when the upstream repo has no package manifest.\n\n- collect install commands from resolved active targets, so configured tools like Gemini/custom tools are included and disabled tools are rejected\n- keep the bare package push wired through the add formatter path, with coverage for visible text output and JSON result data\n\nTests:\n- `go test ./cmd`\n- `go test ./...`