### PR TITLE
feat: browse Vercel skills sources

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Naoray/scribe/internal/config"
 	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
@@ -32,10 +33,10 @@ func newBrowseCommand() *cobra.Command {
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.Flags().String("query", "", "Filter remote skills by query")
 	cmd.Flags().String("install", "", "Install a skill by exact name or owner/repo:skill")
-	cmd.Flags().String("registry", "", "Limit browse/install to one connected registry")
+	cmd.Flags().String("registry", "", "Limit browse/install to one connected registry or GitHub owner/repo")
 	cmd.Flags().Bool("resync", false, "Overwrite local edits with the upstream version for modified skills")
 	addNoInteractionFlag(cmd, "Disable interactive prompts", false)
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func runBrowse(cmd *cobra.Command, _ []string) error {
@@ -52,9 +53,6 @@ func runBrowse(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
-	if len(cfg.TeamRepos()) == 0 {
-		return fmt.Errorf("no registries connected — run: scribe connect <owner/repo>")
-	}
 	st, err := factory.State()
 	if err != nil {
 		return fmt.Errorf("load state: %w", err)
@@ -68,16 +66,29 @@ func runBrowse(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("resolve active tools: %w", err)
 	}
 
-	repos := cfg.TeamRepos()
-	if registryFilter != "" {
-		repo, err := resolveRegistry(registryFilter, repos)
-		if err != nil {
-			return err
-		}
-		repos = []string{repo}
+	repos, err := browseRepos(registryFilter, cfg.TeamRepos())
+	if err != nil {
+		return err
 	}
 
 	return runBrowseWithDeps(cmd.Context(), repos, query, installRef, cfg, st, client, targets, useJSON, yes, resync)
+}
+
+func browseRepos(registryFilter string, connected []string) ([]string, error) {
+	if registryFilter == "" {
+		if len(connected) == 0 {
+			return nil, fmt.Errorf("no registries connected — run: scribe connect <owner/repo>")
+		}
+		return connected, nil
+	}
+	if repo, err := resolveRegistry(registryFilter, connected); err == nil {
+		return []string{repo}, nil
+	}
+	repo, err := manifest.NormalizeGitHubRepo(registryFilter)
+	if err != nil {
+		return nil, err
+	}
+	return []string{repo}, nil
 }
 
 func runBrowseWithDeps(
@@ -94,6 +105,13 @@ func runBrowseWithDeps(
 	resync bool,
 ) error {
 	if installRef == "" && !useJSON {
+		if cfg != nil {
+			for _, repo := range repos {
+				if cfg.FindRegistry(repo) == nil {
+					cfg.AddRegistry(config.RegistryConfig{Repo: repo, Enabled: true, Type: config.RegistryTypeCommunity})
+				}
+			}
+		}
 		bag := &workflow.Bag{
 			JSONFlag:         false,
 			RemoteFlag:       true,

--- a/cmd/browse_test.go
+++ b/cmd/browse_test.go
@@ -56,6 +56,32 @@ func TestRunBrowseWithDeps_JSONQueryFiltersResults(t *testing.T) {
 	}
 }
 
+func TestBrowseReposAcceptsUnconnectedGitHubSource(t *testing.T) {
+	repos, err := browseRepos("https://github.com/vercel-labs/agent-skills", nil)
+	if err != nil {
+		t.Fatalf("browseRepos() error = %v", err)
+	}
+	if len(repos) != 1 || repos[0] != "vercel-labs/agent-skills" {
+		t.Fatalf("repos = %#v", repos)
+	}
+}
+
+func TestBrowseReposPrefersConnectedRegistryAlias(t *testing.T) {
+	repos, err := browseRepos("skills", []string{"acme/skills"})
+	if err != nil {
+		t.Fatalf("browseRepos() error = %v", err)
+	}
+	if len(repos) != 1 || repos[0] != "acme/skills" {
+		t.Fatalf("repos = %#v", repos)
+	}
+}
+
+func TestNewBrowseCommandSupportsJSON(t *testing.T) {
+	if !commandSupportsJSON(newBrowseCommand()) {
+		t.Fatal("browse should be marked JSON-supported")
+	}
+}
+
 func TestBrowseInstallRejectsAmbiguousName(t *testing.T) {
 	err := browseInstall(context.Background(), "cleanup", []browseEntry{
 		{Registry: "acme/skills", Status: sync.SkillStatus{Name: "cleanup"}},

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -66,7 +66,7 @@ func runConnect(cmd *cobra.Command, args []string) error {
 // resolveRepo returns the owner/repo string from args or an interactive prompt.
 func resolveRepo(args []string) (string, error) {
 	if len(args) > 0 {
-		return args[0], nil
+		return manifest.NormalizeGitHubRepo(args[0])
 	}
 
 	if !isatty.IsTerminal(os.Stdin.Fd()) {

--- a/cmd/connect_test.go
+++ b/cmd/connect_test.go
@@ -59,6 +59,16 @@ func TestResolveRepoWithArg(t *testing.T) {
 	}
 }
 
+func TestResolveRepoWithGitHubURL(t *testing.T) {
+	repo, err := resolveRepo([]string{"https://github.com/vercel-labs/agent-skills/tree/main/skills/nextjs"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo != "vercel-labs/agent-skills" {
+		t.Errorf("got %q", repo)
+	}
+}
+
 func TestResolveRepoNoArgNonTTY(t *testing.T) {
 	// When stdin is not a TTY (like in tests), resolveRepo with no args should error.
 	_, err := resolveRepo([]string{})

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -520,7 +520,7 @@ func extractFirstParagraphRaw(data []byte) string {
 // truncateDescription shortens a description to a scannable length.
 func truncateDescription(s string) string {
 	// Take first sentence or max 80 chars.
-	if idx := strings.IndexAny(s, ".!"); idx > 0 && idx < 80 {
+	if idx := firstSentenceEnd(s); idx > 0 && idx < 80 {
 		return s[:idx+1]
 	}
 	if len(s) > 80 {
@@ -532,6 +532,18 @@ func truncateDescription(s string) string {
 		return s[:80] + "..."
 	}
 	return s
+}
+
+func firstSentenceEnd(s string) int {
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '.', '!', '?':
+			if i == len(s)-1 || s[i+1] == ' ' || s[i+1] == '\n' || s[i+1] == '\t' {
+				return i
+			}
+		}
+	}
+	return -1
 }
 
 // ReadSkillMetadata extracts SKILL.md metadata from a skill directory.
@@ -564,10 +576,12 @@ func ParseSkillMetadata(data []byte) (SkillMeta, error) {
 	}
 
 	meta := SkillMeta{
-		Name:        raw.Name,
-		Description: truncateDescription(raw.Description),
-		Version:     raw.Version,
-		Author:      raw.Author,
+		Name:           raw.Name,
+		Description:    truncateDescription(raw.Description),
+		RawDescription: strings.TrimSpace(raw.Description),
+		Version:        raw.Version,
+		Author:         raw.Author,
+		Source:         raw.Source,
 	}
 	if v, ok := raw.Metadata["version"]; ok {
 		meta.Version = fmt.Sprint(v)
@@ -576,7 +590,8 @@ func ParseSkillMetadata(data []byte) (SkillMeta, error) {
 		meta.Author = fmt.Sprint(v)
 	}
 	if meta.Description == "" {
-		meta.Description = extractFirstParagraph(data)
+		meta.RawDescription = extractFirstParagraphRaw(data)
+		meta.Description = truncateDescription(meta.RawDescription)
 	}
 	return meta, nil
 }

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -3,6 +3,8 @@ package manifest
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"path"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -50,10 +52,10 @@ type Entry struct {
 	Source      string            `yaml:"source,omitempty"`
 	Path        string            `yaml:"path,omitempty"`
 	Type        string            `yaml:"type,omitempty"`
-	Install     string            `yaml:"install,omitempty"`            // global fallback install command
-	Update      string            `yaml:"update,omitempty"`             // global fallback update command
-	Installs    map[string]string `yaml:"installs,omitempty"`           // per-tool install commands; override Install
-	Updates     map[string]string `yaml:"updates,omitempty"`            // per-tool update commands; override Update
+	Install     string            `yaml:"install,omitempty"`  // global fallback install command
+	Update      string            `yaml:"update,omitempty"`   // global fallback update command
+	Installs    map[string]string `yaml:"installs,omitempty"` // per-tool install commands; override Install
+	Updates     map[string]string `yaml:"updates,omitempty"`  // per-tool update commands; override Update
 	Author      string            `yaml:"author,omitempty"`
 	Description string            `yaml:"description,omitempty"`
 	Timeout     int               `yaml:"timeout,omitempty"`
@@ -175,4 +177,46 @@ func ParseOwnerRepo(s string) (owner, repo string, err error) {
 		return "", "", fmt.Errorf("invalid repo %q: expected owner/repo", s)
 	}
 	return parts[0], parts[1], nil
+}
+
+// NormalizeGitHubRepo returns owner/repo for either a plain owner/repo string
+// or a github.com repository URL. Tree/blob URLs are accepted and normalized to
+// the containing repository; subdirectory-scoped sources need a richer source
+// schema and are intentionally not represented here.
+func NormalizeGitHubRepo(s string) (string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", fmt.Errorf("invalid repo %q: expected owner/repo", s)
+	}
+
+	if strings.HasPrefix(s, "git@github.com:") {
+		rest := strings.TrimPrefix(s, "git@github.com:")
+		rest = strings.TrimSuffix(rest, ".git")
+		owner, repo, err := ParseOwnerRepo(rest)
+		if err != nil {
+			return "", err
+		}
+		return owner + "/" + repo, nil
+	}
+
+	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+		u, err := url.Parse(s)
+		if err != nil {
+			return "", fmt.Errorf("invalid GitHub URL %q: %w", s, err)
+		}
+		if !strings.EqualFold(u.Hostname(), "github.com") {
+			return "", fmt.Errorf("unsupported registry URL %q: only github.com URLs are supported", s)
+		}
+		parts := strings.Split(strings.Trim(path.Clean(u.Path), "/"), "/")
+		if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+			return "", fmt.Errorf("invalid GitHub URL %q: expected github.com/owner/repo", s)
+		}
+		return parts[0] + "/" + strings.TrimSuffix(parts[1], ".git"), nil
+	}
+
+	owner, repo, err := ParseOwnerRepo(strings.TrimSuffix(s, ".git"))
+	if err != nil {
+		return "", err
+	}
+	return owner + "/" + repo, nil
 }

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -204,6 +204,34 @@ func TestParseSource(t *testing.T) {
 	}
 }
 
+func TestNormalizeGitHubRepo(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"vercel-labs/agent-skills", "vercel-labs/agent-skills"},
+		{"https://github.com/vercel-labs/agent-skills", "vercel-labs/agent-skills"},
+		{"https://github.com/vercel-labs/agent-skills/tree/main/skills/nextjs", "vercel-labs/agent-skills"},
+		{"git@github.com:vercel-labs/agent-skills.git", "vercel-labs/agent-skills"},
+	}
+
+	for _, c := range cases {
+		got, err := manifest.NormalizeGitHubRepo(c.input)
+		if err != nil {
+			t.Fatalf("NormalizeGitHubRepo(%q): %v", c.input, err)
+		}
+		if got != c.want {
+			t.Fatalf("NormalizeGitHubRepo(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeGitHubRepoRejectsUnsupportedURL(t *testing.T) {
+	if _, err := manifest.NormalizeGitHubRepo("https://gitlab.com/acme/skills"); err == nil {
+		t.Fatal("expected unsupported URL error")
+	}
+}
+
 func TestManifestEncode(t *testing.T) {
 	m, err := manifest.Parse([]byte(teamRegistry))
 	if err != nil {

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -46,7 +46,11 @@ func (p *GitHubProvider) warn(msg string) {
 
 // Discover probes the repo using a fallback chain and returns all discovered entries.
 func (p *GitHubProvider) Discover(ctx context.Context, repo string) (*DiscoverResult, error) {
-	owner, repoName, err := manifest.ParseOwnerRepo(repo)
+	normalized, err := manifest.NormalizeGitHubRepo(repo)
+	if err != nil {
+		return nil, err
+	}
+	owner, repoName, err := manifest.ParseOwnerRepo(normalized)
 	if err != nil {
 		return nil, err
 	}
@@ -126,6 +130,24 @@ func (p *GitHubProvider) discoverTreeScan(ctx context.Context, owner, repo strin
 	entries := ScanTreeForSkills(tree, owner, repo)
 	if len(entries) == 0 {
 		return nil, fmt.Errorf("no SKILL.md files found in %s/%s", owner, repo)
+	}
+
+	for i := range entries {
+		skillPath := entries[i].Path
+		if path.Base(skillPath) != skillFileName {
+			skillPath = path.Join(skillPath, skillFileName)
+		}
+		data, err := p.client.FetchFile(ctx, owner, repo, skillPath, "HEAD")
+		if err != nil {
+			p.warn(fmt.Sprintf("%s/%s: could not read %s frontmatter: %v", owner, repo, skillPath, err))
+			continue
+		}
+		enriched, err := EnrichTreeSkillEntry(entries[i], data)
+		if err != nil {
+			p.warn(fmt.Sprintf("%s/%s: invalid %s frontmatter: %v", owner, repo, skillPath, err))
+			continue
+		}
+		entries[i] = enriched
 	}
 	return entries, nil
 }

--- a/internal/provider/github_test.go
+++ b/internal/provider/github_test.go
@@ -269,6 +269,83 @@ func TestDiscoverTreeScanAsLastResort(t *testing.T) {
 	}
 }
 
+func TestDiscoverTreeScanEnrichesSkillFrontmatter(t *testing.T) {
+	client := &stubClient{
+		treeFiles: []provider.TreeEntry{
+			{Path: "skills/nextjs/SKILL.md", Type: "blob"},
+		},
+		files: map[string][]byte{
+			"vercel-labs/agent-skills/skills/nextjs/SKILL.md": []byte(`---
+name: next-js
+description: Build and debug Next.js applications.
+source:
+  author: vercel
+---
+# Next.js
+`),
+		},
+	}
+
+	p := provider.NewGitHubProvider(client)
+	result, err := p.Discover(context.Background(), "https://github.com/vercel-labs/agent-skills")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	if result.IsTeam {
+		t.Fatal("tree-scan repo should not be a team registry")
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("entries: got %d, want 1", len(result.Entries))
+	}
+	entry := result.Entries[0]
+	if entry.Name != "next-js" {
+		t.Fatalf("Name = %q, want frontmatter name", entry.Name)
+	}
+	if entry.Description != "Build and debug Next.js applications." {
+		t.Fatalf("Description = %q", entry.Description)
+	}
+	if entry.Author != "vercel" {
+		t.Fatalf("Author = %q", entry.Author)
+	}
+	if entry.Source != "github:vercel-labs/agent-skills@HEAD" {
+		t.Fatalf("Source = %q", entry.Source)
+	}
+	if entry.Path != "skills/nextjs" {
+		t.Fatalf("Path = %q", entry.Path)
+	}
+}
+
+func TestDiscoverTreeScanWarnsAndKeepsDirectoryNameForBadFrontmatter(t *testing.T) {
+	client := &stubClient{
+		treeFiles: []provider.TreeEntry{
+			{Path: "skills/nextjs/SKILL.md", Type: "blob"},
+		},
+		files: map[string][]byte{
+			"vercel-labs/agent-skills/skills/nextjs/SKILL.md": []byte(`---
+name: ../nextjs
+description: bad
+---
+`),
+		},
+	}
+
+	var warnings []string
+	p := provider.NewGitHubProvider(client)
+	p.OnWarning = func(msg string) { warnings = append(warnings, msg) }
+
+	result, err := p.Discover(context.Background(), "vercel-labs/agent-skills")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected frontmatter warning")
+	}
+	if result.Entries[0].Name != "nextjs" {
+		t.Fatalf("Name = %q, want directory fallback", result.Entries[0].Name)
+	}
+}
+
 func TestDiscoverTreeScanAnthropicsFixture(t *testing.T) {
 	client := &stubClient{
 		treeFiles: []provider.TreeEntry{

--- a/internal/provider/treescan.go
+++ b/internal/provider/treescan.go
@@ -3,11 +3,15 @@ package provider
 import (
 	"fmt"
 	"path"
+	"regexp"
 
+	"github.com/Naoray/scribe/internal/discovery"
 	"github.com/Naoray/scribe/internal/manifest"
 )
 
 const skillFileName = "SKILL.md"
+
+var treeScanSkillName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
 // ScanTreeForSkills finds all SKILL.md files in a tree listing and returns
 // catalog entries for each. The skill name is derived from the parent directory.
@@ -46,4 +50,29 @@ func ScanTreeForSkills(tree []TreeEntry, owner, repo string) []manifest.Entry {
 	}
 
 	return entries
+}
+
+// EnrichTreeSkillEntry applies SKILL.md frontmatter metadata to a tree-scan
+// entry while preserving source and path fields used for install and lock pins.
+func EnrichTreeSkillEntry(entry manifest.Entry, content []byte) (manifest.Entry, error) {
+	meta, err := discovery.ParseSkillMetadata(content)
+	if err != nil {
+		return entry, err
+	}
+	if meta.Name != "" {
+		if !treeScanSkillName.MatchString(meta.Name) || path.Base(meta.Name) != meta.Name {
+			return entry, fmt.Errorf("invalid frontmatter name %q", meta.Name)
+		}
+		entry.Name = meta.Name
+	}
+	if meta.Description != "" {
+		entry.Description = meta.Description
+	}
+	if meta.Author != "" {
+		entry.Author = meta.Author
+	}
+	if meta.Source.Author != "" {
+		entry.Author = meta.Source.Author
+	}
+	return entry, nil
 }

--- a/internal/provider/treescan_test.go
+++ b/internal/provider/treescan_test.go
@@ -70,3 +70,34 @@ func TestScanTreeSkipsTreeEntryType(t *testing.T) {
 		t.Errorf("expected 0 entries for tree type, got %d", len(entries))
 	}
 }
+
+func TestEnrichTreeSkillEntryPreservesSourceAndPath(t *testing.T) {
+	entries := provider.ScanTreeForSkills([]provider.TreeEntry{
+		{Path: "skills/nextjs/SKILL.md", Type: "blob"},
+	}, "vercel-labs", "agent-skills")
+	enriched, err := provider.EnrichTreeSkillEntry(entries[0], []byte(`---
+name: next-js
+description: Build Next.js apps.
+author: vercel
+---
+# Next.js
+`))
+	if err != nil {
+		t.Fatalf("EnrichTreeSkillEntry: %v", err)
+	}
+	if enriched.Name != "next-js" {
+		t.Fatalf("Name = %q", enriched.Name)
+	}
+	if enriched.Description != "Build Next.js apps." {
+		t.Fatalf("Description = %q", enriched.Description)
+	}
+	if enriched.Author != "vercel" {
+		t.Fatalf("Author = %q", enriched.Author)
+	}
+	if enriched.Source != "github:vercel-labs/agent-skills@HEAD" {
+		t.Fatalf("Source = %q", enriched.Source)
+	}
+	if enriched.Path != "skills/nextjs" {
+		t.Fatalf("Path = %q", enriched.Path)
+	}
+}


### PR DESCRIPTION
This lets browse work against Vercel/skills.sh-style GitHub skill repos, including the official `vercel-labs/agent-skills` source.

What changed:
- `scribe browse --registry <owner/repo-or-github-url>` can browse an unconnected GitHub source
- tree-scan discovery reads each `SKILL.md` frontmatter for name, description, and author
- install-facing source/path metadata stays on the manifest entry so state and lock handling keep using the repo path
- `browse --json` is now marked JSON-supported, matching the existing flag and output path

Full Vercel CLI parity needs follow-up schema work for direct subdirectory scopes, GitLab/arbitrary git URLs, and local paths. I documented that separately rather than forcing it into the current registry shape.

Tested:
- `go test ./internal/provider ./internal/manifest ./internal/discovery ./cmd`
- `go test ./...`
- `go run ./cmd/scribe browse --registry vercel-labs/agent-skills --query next --json`