### PR TITLE
feat: track registry visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+- Add `visibility` to registry config as a foundation for future opt-in registry discovery; no telemetry is added.
+
 ## v1.3.0 — 2026-05-09
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ This commits the skill directly to the registry's default branch via the GitHub 
 - **One repo, many skills.** Registries are intentionally flat collections — no nested registries.
 - **Stable skill names.** Renaming a skill is a breaking change for every consumer; bump the manifest version and document the migration in the registry's `README.md`.
 - **`scribe.yaml`, not `scribe.toml`.** The TOML format is deprecated; run `scribe registry migrate` on legacy registries to convert.
-- **Public discovery is opt-in.** Scribe does not phone home about registries you connect. A future public-discovery feature will be opt-in per registry.
+- **Public discovery is opt-in.** Scribe does not phone home about registries. Public discovery is opt-in and gated on registry visibility — see `docs/registry-visibility.md`.
 
 ## Code of conduct
 

--- a/cmd/registry_list.go
+++ b/cmd/registry_list.go
@@ -16,14 +16,29 @@ func newRegistryListCommand() *cobra.Command {
 		RunE:  runRegistryList,
 	}
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
-	return cmd
+	return markJSONSupported(cmd)
 }
 
 func runRegistryList(cmd *cobra.Command, args []string) error {
-	jsonFlag, _ := cmd.Flags().GetBool("json")
+	jsonFlag := jsonFlagPassed(cmd)
 
 	bag := &workflow.Bag{
-		JSONFlag: jsonFlag,
+		JSONFlag:   jsonFlag,
+		LazyGitHub: true,
+		Factory:    newCommandFactory(),
+	}
+
+	if jsonFlag {
+		steps := workflow.RegistryListSteps()[:2]
+		if err := workflow.Run(cmd.Context(), steps, bag); err != nil {
+			return err
+		}
+		out := workflow.BuildRegistryListJSON(bag.Config.EnabledRegistries(), bag.State)
+		renderer := jsonRendererForCommand(cmd, jsonFlag)
+		if err := renderer.Result(out); err != nil {
+			return err
+		}
+		return renderer.Flush()
 	}
 
 	if err := workflow.Run(cmd.Context(), workflow.RegistryListSteps(), bag); err != nil {

--- a/cmd/registry_list_json_test.go
+++ b/cmd/registry_list_json_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegistryListJSONEnvelopeIncludesVisibility(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".scribe")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	cfg := `registries:
+  - repo: acme/public
+    enabled: true
+    type: community
+    visibility: public
+  - repo: acme/private
+    enabled: true
+    type: team
+    visibility: private
+adoption:
+  mode: off
+scribe_agent:
+  enabled: false
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	stdout, stderr, code := runScribeHelperWithHome(t, home, []string{"registry", "list", "--json"})
+	if code != 0 {
+		t.Fatalf("exit code = %d\nstderr=%s\nstdout=%s", code, stderr, stdout)
+	}
+
+	var env struct {
+		Data struct {
+			Registries []struct {
+				Registry   string `json:"registry"`
+				Visibility string `json:"visibility"`
+			} `json:"registries"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v\nstdout=%s", err, stdout)
+	}
+	got := map[string]string{}
+	for _, registry := range env.Data.Registries {
+		got[registry.Registry] = registry.Visibility
+	}
+	if got["acme/public"] != "public" {
+		t.Errorf("acme/public visibility = %q, want public", got["acme/public"])
+	}
+	if got["acme/private"] != "private" {
+		t.Errorf("acme/private visibility = %q, want private", got["acme/private"])
+	}
+}

--- a/cmd/registry_list_schema.go
+++ b/cmd/registry_list_schema.go
@@ -1,0 +1,36 @@
+package cmd
+
+import clischema "github.com/Naoray/scribe/internal/cli/schema"
+
+const registryListOutputSchema = `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "registries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "registry": { "type": "string" },
+          "visibility": {
+            "type": "string",
+            "enum": ["public", "private", "unknown"]
+          },
+          "skill_count": { "type": "integer", "minimum": 0 }
+        },
+        "required": ["registry", "visibility", "skill_count"],
+        "additionalProperties": false
+      }
+    },
+    "last_sync": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    }
+  },
+  "required": ["registries", "last_sync"],
+  "additionalProperties": false
+}`
+
+func init() {
+	clischema.Register("scribe registry list", registryListOutputSchema)
+}

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -66,6 +66,37 @@ func TestSchemaCommandAll(t *testing.T) {
 	}
 }
 
+func TestSchemaCommandRegistryListIncludesVisibility(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := newRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{"schema", "registry list"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var got commandSchema
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out.String())
+	}
+	if got.OutputSchema == nil {
+		t.Fatal("output_schema = nil, want registry list schema")
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(*got.OutputSchema, &schema); err != nil {
+		t.Fatalf("output schema unmarshal: %v", err)
+	}
+	props := schema["properties"].(map[string]any)
+	registries := props["registries"].(map[string]any)
+	items := registries["items"].(map[string]any)
+	itemProps := items["properties"].(map[string]any)
+	if _, ok := itemProps["visibility"]; !ok {
+		t.Fatalf("registry list schema missing visibility: %#v", itemProps)
+	}
+}
+
 func TestSchemaCommandUnregistered(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	root := newRootCmd()

--- a/docs/registry-visibility.md
+++ b/docs/registry-visibility.md
@@ -1,0 +1,19 @@
+# Registry Visibility
+
+Scribe tracks registry visibility so future discovery features can make a clear privacy decision before reading or reporting registry metadata.
+
+Visibility has three values:
+
+- `public`: GitHub reported the registry repository as public, or a legacy `community` registry was migrated as the best available historical signal.
+- `private`: GitHub reported the repository as private, or a legacy `team` registry was migrated as private.
+- `unknown`: Scribe could not verify visibility, including legacy `github` rows and GitHub API errors.
+
+Only `public` registries are eligible for future public discovery features. `private` and `unknown` registries are treated as private. That fail-closed rule means an unavailable GitHub API, missing credentials, renamed repo, or permission error prevents public treatment.
+
+`scribe registry connect` checks GitHub repository metadata and stores the result in `~/.scribe/config.yaml`. Existing configs are migrated on load with conservative defaults:
+
+- `community` -> `public`
+- `team` -> `private`
+- `github` -> `unknown`
+
+Scribe does not phone home about registries in this phase. Visibility is local plumbing only.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,15 +18,20 @@ const (
 	RegistryTypeGitHub    = "github"    // kind: legacy-migrated registry (no type info at migration time)
 	RegistryTypeTeam      = "team"      // kind: org/team registry with scribe.yaml
 	RegistryTypeCommunity = "community" // kind: community registry (marketplace or tree scan)
+
+	RegistryVisibilityPublic  = "public"
+	RegistryVisibilityPrivate = "private"
+	RegistryVisibilityUnknown = "unknown"
 )
 
 // RegistryConfig describes a connected skill registry.
 type RegistryConfig struct {
-	Repo     string `yaml:"repo"`
-	Enabled  bool   `yaml:"enabled"`
-	Builtin  bool   `yaml:"builtin,omitempty"`
-	Type     string `yaml:"type,omitempty"`
-	Writable bool   `yaml:"writable,omitempty"`
+	Repo       string `yaml:"repo"`
+	Enabled    bool   `yaml:"enabled"`
+	Builtin    bool   `yaml:"builtin,omitempty"`
+	Type       string `yaml:"type,omitempty"`
+	Visibility string `yaml:"visibility,omitempty"`
+	Writable   bool   `yaml:"writable,omitempty"`
 }
 
 // ToolConfig describes an AI tool target for skill installation.
@@ -94,6 +99,7 @@ func (c *Config) TeamRepos() []string {
 
 // AddRegistry adds or updates a registry in the config.
 func (c *Config) AddRegistry(rc RegistryConfig) {
+	rc.Normalize()
 	for i := range c.Registries {
 		if strings.EqualFold(c.Registries[i].Repo, rc.Repo) {
 			c.Registries[i] = rc
@@ -207,6 +213,40 @@ func (rc RegistryConfig) IsTeam() bool {
 	return rc.Type == RegistryTypeTeam
 }
 
+// IsPublic returns true only for registries verified or migrated as public.
+func (rc RegistryConfig) IsPublic() bool {
+	return rc.Visibility == RegistryVisibilityPublic
+}
+
+// Normalize fills privacy-safe defaults for legacy or incomplete registry rows.
+func (rc *RegistryConfig) Normalize() {
+	if rc.Visibility == "" {
+		rc.Visibility = VisibilityForLegacyType(rc.Type)
+		return
+	}
+	rc.Visibility = NormalizeRegistryVisibility(rc.Visibility)
+}
+
+func NormalizeRegistryVisibility(visibility string) string {
+	switch visibility {
+	case RegistryVisibilityPublic, RegistryVisibilityPrivate, RegistryVisibilityUnknown:
+		return visibility
+	default:
+		return RegistryVisibilityUnknown
+	}
+}
+
+func VisibilityForLegacyType(regType string) string {
+	switch regType {
+	case RegistryTypeCommunity:
+		return RegistryVisibilityPublic
+	case RegistryTypeTeam:
+		return RegistryVisibilityPrivate
+	default:
+		return RegistryVisibilityUnknown
+	}
+}
+
 // legacyTOML is the shadow struct for reading old config.toml files.
 type legacyTOML struct {
 	TeamRepo  string   `toml:"team_repo"`
@@ -271,6 +311,9 @@ func (c *Config) applyDefaults() {
 	if !c.ScribeAgent.enabledSet {
 		c.ScribeAgent.Enabled = true
 	}
+	for i := range c.Registries {
+		c.Registries[i].Normalize()
+	}
 }
 
 // migrateFromTOML converts legacy TOML fields to the new Config struct.
@@ -283,9 +326,10 @@ func migrateFromTOML(raw legacyTOML) *Config {
 	cfg := &Config{Token: raw.Token}
 	for _, repo := range repos {
 		cfg.Registries = append(cfg.Registries, RegistryConfig{
-			Repo:    repo,
-			Enabled: true,
-			Type:    RegistryTypeGitHub,
+			Repo:       repo,
+			Enabled:    true,
+			Type:       RegistryTypeGitHub,
+			Visibility: RegistryVisibilityUnknown,
 		})
 	}
 	return cfg

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,6 +73,11 @@ token = "ghp_test"
 	if cfg.Token != "ghp_test" {
 		t.Errorf("token: got %q", cfg.Token)
 	}
+	for _, registry := range cfg.Registries {
+		if registry.Visibility != config.RegistryVisibilityUnknown {
+			t.Errorf("legacy TOML visibility for %s: got %q, want %q", registry.Repo, registry.Visibility, config.RegistryVisibilityUnknown)
+		}
+	}
 }
 
 func TestLoadLegacyTeamRepo(t *testing.T) {
@@ -88,6 +93,9 @@ token = "ghp_legacy"
 	}
 	if len(cfg.TeamRepos()) != 1 {
 		t.Fatalf("expected 1 team repo from legacy migration, got %d", len(cfg.TeamRepos()))
+	}
+	if cfg.Registries[0].Visibility != config.RegistryVisibilityUnknown {
+		t.Errorf("legacy team_repo visibility: got %q, want %q", cfg.Registries[0].Visibility, config.RegistryVisibilityUnknown)
 	}
 	if cfg.TeamRepos()[0] != "ArtistfyHQ/team-skills" {
 		t.Errorf("migrated repo: got %q", cfg.TeamRepos()[0])
@@ -364,7 +372,7 @@ func TestSaveYAML(t *testing.T) {
 
 	cfg := &config.Config{
 		Registries: []config.RegistryConfig{
-			{Repo: "ArtistfyHQ/team-skills", Enabled: true, Type: config.RegistryTypeGitHub, Writable: true},
+			{Repo: "ArtistfyHQ/team-skills", Enabled: true, Type: config.RegistryTypeGitHub, Visibility: config.RegistryVisibilityPrivate, Writable: true},
 		},
 		Token: "ghp_save_test",
 	}
@@ -397,6 +405,9 @@ func TestSaveYAML(t *testing.T) {
 	}
 	if loaded.Token != "ghp_save_test" {
 		t.Errorf("Token round-trip: got %q", loaded.Token)
+	}
+	if loaded.Registries[0].Visibility != config.RegistryVisibilityPrivate {
+		t.Errorf("Visibility round-trip: got %q, want %q", loaded.Registries[0].Visibility, config.RegistryVisibilityPrivate)
 	}
 }
 
@@ -441,6 +452,86 @@ func TestRegistryType(t *testing.T) {
 	}
 }
 
+func TestRegistryVisibilityHelpers(t *testing.T) {
+	cases := []struct {
+		name       string
+		visibility string
+		wantPublic bool
+	}{
+		{"public", config.RegistryVisibilityPublic, true},
+		{"private", config.RegistryVisibilityPrivate, false},
+		{"unknown", config.RegistryVisibilityUnknown, false},
+		{"empty", "", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rc := config.RegistryConfig{Repo: "owner/repo", Visibility: c.visibility}
+			if rc.IsPublic() != c.wantPublic {
+				t.Errorf("IsPublic: got %v, want %v", rc.IsPublic(), c.wantPublic)
+			}
+		})
+	}
+}
+
+func TestRegistryVisibilityMigration(t *testing.T) {
+	cases := []struct {
+		name    string
+		regType string
+		want    string
+	}{
+		{"community becomes public", config.RegistryTypeCommunity, config.RegistryVisibilityPublic},
+		{"team becomes private", config.RegistryTypeTeam, config.RegistryVisibilityPrivate},
+		{"github becomes unknown", config.RegistryTypeGitHub, config.RegistryVisibilityUnknown},
+		{"empty becomes unknown", "", config.RegistryVisibilityUnknown},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rc := config.RegistryConfig{Repo: "owner/repo", Type: c.regType}
+			rc.Normalize()
+			if rc.Visibility != c.want {
+				t.Errorf("Visibility = %q, want %q", rc.Visibility, c.want)
+			}
+		})
+	}
+}
+
+func TestLoadYAMLMigratesLegacyRegistryVisibility(t *testing.T) {
+	home := setupHome(t)
+	writeYAMLConfig(t, home, `
+registries:
+  - repo: acme/community
+    enabled: true
+    type: community
+  - repo: acme/team
+    enabled: true
+    type: team
+  - repo: acme/github
+    enabled: true
+    type: github
+`)
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := map[string]string{}
+	for _, registry := range cfg.Registries {
+		got[registry.Repo] = registry.Visibility
+	}
+	want := map[string]string{
+		"acme/community": config.RegistryVisibilityPublic,
+		"acme/team":      config.RegistryVisibilityPrivate,
+		"acme/github":    config.RegistryVisibilityUnknown,
+	}
+	for repo, visibility := range want {
+		if got[repo] != visibility {
+			t.Errorf("%s visibility = %q, want %q", repo, got[repo], visibility)
+		}
+	}
+}
+
 func TestFindRegistry(t *testing.T) {
 	cfg := &config.Config{
 		Registries: []config.RegistryConfig{
@@ -477,10 +568,11 @@ func TestAddRegistryUpdatesExisting(t *testing.T) {
 	}
 
 	cfg.AddRegistry(config.RegistryConfig{
-		Repo:     "acme/skills",
-		Enabled:  true,
-		Type:     config.RegistryTypeTeam,
-		Writable: true,
+		Repo:       "acme/skills",
+		Enabled:    true,
+		Type:       config.RegistryTypeTeam,
+		Visibility: config.RegistryVisibilityPrivate,
+		Writable:   true,
 	})
 
 	if len(cfg.Registries) != 1 {
@@ -491,6 +583,9 @@ func TestAddRegistryUpdatesExisting(t *testing.T) {
 	}
 	if !cfg.Registries[0].Writable {
 		t.Error("expected writable to be updated")
+	}
+	if cfg.Registries[0].Visibility != config.RegistryVisibilityPrivate {
+		t.Errorf("visibility: got %q, want %q", cfg.Registries[0].Visibility, config.RegistryVisibilityPrivate)
 	}
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -449,6 +449,18 @@ func (c *Client) HasPushAccess(ctx context.Context, owner, repo string) (bool, e
 	return perms["push"] || perms["admin"], nil
 }
 
+// RepositoryIsPrivate returns the GitHub repository privacy flag.
+func (c *Client) RepositoryIsPrivate(ctx context.Context, owner, repo string) (bool, error) {
+	if c == nil || c.gh == nil {
+		return false, errors.New("github client is not initialized")
+	}
+	r, _, err := c.gh.Repositories.Get(ctx, owner, repo)
+	if err != nil {
+		return false, wrapErr(err, fmt.Sprintf("check visibility %s/%s", owner, repo))
+	}
+	return r.GetPrivate(), nil
+}
+
 // LatestRelease fetches the latest published release for a repository.
 func (c *Client) LatestRelease(ctx context.Context, owner, repo string) (*github.RepositoryRelease, error) {
 	release, _, err := c.gh.Repositories.GetLatestRelease(ctx, owner, repo)

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -1,6 +1,8 @@
 package workflow
 
 import (
+	"context"
+
 	"github.com/Naoray/scribe/internal/app"
 	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/discovery"
@@ -11,6 +13,10 @@ import (
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
 )
+
+type RepositoryVisibilityClient interface {
+	RepositoryIsPrivate(ctx context.Context, owner, repo string) (bool, error)
+}
 
 // Bag carries all intermediate state across workflow steps.
 // Each step reads/writes only its relevant fields.
@@ -52,6 +58,7 @@ type Bag struct {
 	Config        *config.Config
 	State         *state.State
 	Client        *gh.Client
+	Visibility    RepositoryVisibilityClient
 	Tools         []tools.Tool
 	ProjectRoot   string
 	TeamShareMode bool
@@ -77,8 +84,9 @@ type Bag struct {
 	Partial       bool                          // true when a mutating workflow completed with failures
 
 	// Registry list command results:
-	RegistryRepos  []string       // connected registries
-	RegistryCounts map[string]int // skills per registry
+	RegistryRepos   []string                // connected registries
+	RegistryConfigs []config.RegistryConfig // connected registry config rows
+	RegistryCounts  map[string]int          // skills per registry
 
 	// Internal fields populated by steps
 	manifest *manifest.Manifest

--- a/internal/workflow/connect.go
+++ b/internal/workflow/connect.go
@@ -106,6 +106,7 @@ func StepInferRegistryType(ctx context.Context, b *Bag) error {
 	if b.manifest.IsRegistry() {
 		regType = config.RegistryTypeTeam
 	}
+	visibility := registryVisibility(ctx, b)
 
 	writable := false
 	if b.Client != nil {
@@ -116,13 +117,32 @@ func StepInferRegistryType(ctx context.Context, b *Bag) error {
 	}
 
 	b.Config.AddRegistry(config.RegistryConfig{
-		Repo:     b.RepoArg,
-		Enabled:  true,
-		Type:     regType,
-		Writable: writable,
+		Repo:       b.RepoArg,
+		Enabled:    true,
+		Type:       regType,
+		Visibility: visibility,
+		Writable:   writable,
 	})
 
 	return nil
+}
+
+func registryVisibility(ctx context.Context, b *Bag) string {
+	if b.Visibility == nil {
+		return config.RegistryVisibilityUnknown
+	}
+	owner, repo, err := manifest.ParseOwnerRepo(b.RepoArg)
+	if err != nil {
+		return config.RegistryVisibilityUnknown
+	}
+	private, err := b.Visibility.RepositoryIsPrivate(ctx, owner, repo)
+	if err != nil {
+		return config.RegistryVisibilityUnknown
+	}
+	if private {
+		return config.RegistryVisibilityPrivate
+	}
+	return config.RegistryVisibilityPublic
 }
 
 func StepSaveConfig(_ context.Context, b *Bag) error {

--- a/internal/workflow/connect_test.go
+++ b/internal/workflow/connect_test.go
@@ -1,10 +1,42 @@
 package workflow_test
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/tools"
 	"github.com/Naoray/scribe/internal/workflow"
 )
+
+type connectTestProvider struct {
+	isTeam bool
+}
+
+func (p connectTestProvider) Discover(context.Context, string) (*provider.DiscoverResult, error) {
+	return &provider.DiscoverResult{
+		IsTeam: p.isTeam,
+		Entries: []manifest.Entry{
+			{Name: "deploy", Source: "github:acme/skills@main", Path: "skills/deploy"},
+		},
+	}, nil
+}
+
+func (p connectTestProvider) Fetch(context.Context, manifest.Entry) ([]tools.SkillFile, error) {
+	return nil, errors.New("unused")
+}
+
+type connectVisibilityClient struct {
+	private bool
+	err     error
+}
+
+func (c connectVisibilityClient) RepositoryIsPrivate(context.Context, string, string) (bool, error) {
+	return c.private, c.err
+}
 
 func TestConnectSteps_EndsWithShowAvailable(t *testing.T) {
 	steps := workflow.ConnectSteps()
@@ -65,5 +97,48 @@ func TestConnectInstallAllTail_EndsWithSyncSkills(t *testing.T) {
 	last := tail[len(tail)-1]
 	if last.Name != "SyncSkills" {
 		t.Errorf("expected ConnectInstallAllTail last step SyncSkills, got %s", last.Name)
+	}
+}
+
+func TestStepInferRegistryTypeSetsVisibilityFromGitHubMetadata(t *testing.T) {
+	cases := []struct {
+		name       string
+		private    bool
+		err        error
+		want       string
+		wantPublic bool
+	}{
+		{"public repo", false, nil, config.RegistryVisibilityPublic, true},
+		{"private repo", true, nil, config.RegistryVisibilityPrivate, false},
+		{"metadata error fail closed", false, errors.New("api unavailable"), config.RegistryVisibilityUnknown, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			bag := &workflow.Bag{
+				Config:     &config.Config{},
+				Provider:   connectTestProvider{},
+				Visibility: connectVisibilityClient{private: c.private, err: c.err},
+				RepoArg:    "acme/skills",
+			}
+
+			if err := workflow.StepFetchManifest(context.Background(), bag); err != nil {
+				t.Fatalf("StepFetchManifest: %v", err)
+			}
+			if err := workflow.StepValidateManifest(context.Background(), bag); err != nil {
+				t.Fatalf("StepValidateManifest: %v", err)
+			}
+			if err := workflow.StepInferRegistryType(context.Background(), bag); err != nil {
+				t.Fatalf("StepInferRegistryType: %v", err)
+			}
+
+			got := bag.Config.Registries[0]
+			if got.Visibility != c.want {
+				t.Errorf("Visibility = %q, want %q", got.Visibility, c.want)
+			}
+			if got.IsPublic() != c.wantPublic {
+				t.Errorf("IsPublic = %v, want %v", got.IsPublic(), c.wantPublic)
+			}
+		})
 	}
 }

--- a/internal/workflow/registry_list.go
+++ b/internal/workflow/registry_list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mattn/go-isatty"
 
+	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/state"
 )
 
@@ -45,7 +46,8 @@ func StepPrintRegistryList(_ context.Context, b *Bag) error {
 	useJSON := b.JSONFlag || !isatty.IsTerminal(os.Stdout.Fd())
 	w := os.Stdout
 
-	repos := b.Config.TeamRepos()
+	registries := b.Config.EnabledRegistries()
+	repos := registryRepos(registries)
 
 	if len(repos) == 0 {
 		if useJSON {
@@ -59,34 +61,46 @@ func StepPrintRegistryList(_ context.Context, b *Bag) error {
 	counts := CountSkillsPerRegistry(repos, b.State)
 
 	if useJSON {
-		return PrintRegistryJSON(w, repos, b.State)
+		return PrintRegistryJSON(w, registries, b.State)
 	}
 
 	// Populate Bag for cmd/ to render.
 	b.RegistryRepos = repos
+	b.RegistryConfigs = registries
 	b.RegistryCounts = counts
 	return nil
 }
 
-type regJSON struct {
+type RegistryJSON struct {
 	Registry   string `json:"registry"`
+	Visibility string `json:"visibility"`
 	SkillCount int    `json:"skill_count"`
 }
 
-type regListJSON struct {
-	Registries []regJSON `json:"registries"`
-	LastSync   *string   `json:"last_sync"`
+type RegistryListJSON struct {
+	Registries []RegistryJSON `json:"registries"`
+	LastSync   *string        `json:"last_sync"`
 }
 
 // PrintRegistryJSON writes registry list as JSON to w.
-func PrintRegistryJSON(w io.Writer, repos []string, st *state.State) error {
+func PrintRegistryJSON(w io.Writer, registries []config.RegistryConfig, st *state.State) error {
+	out := BuildRegistryListJSON(registries, st)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+func BuildRegistryListJSON(registries []config.RegistryConfig, st *state.State) RegistryListJSON {
+	repos := registryRepos(registries)
 	counts := CountSkillsPerRegistry(repos, st)
 
-	entries := make([]regJSON, 0, len(repos))
-	for _, repo := range repos {
-		entries = append(entries, regJSON{
-			Registry:   repo,
-			SkillCount: counts[repo],
+	entries := make([]RegistryJSON, 0, len(registries))
+	for _, registry := range registries {
+		registry.Normalize()
+		entries = append(entries, RegistryJSON{
+			Registry:   registry.Repo,
+			Visibility: registry.Visibility,
+			SkillCount: counts[registry.Repo],
 		})
 	}
 
@@ -96,17 +110,23 @@ func PrintRegistryJSON(w io.Writer, repos []string, st *state.State) error {
 		lastSync = &s
 	}
 
-	out := regListJSON{
+	out := RegistryListJSON{
 		Registries: entries,
 		LastSync:   lastSync,
 	}
 
 	// Ensure empty slice renders as [] not null.
 	if out.Registries == nil {
-		out.Registries = []regJSON{}
+		out.Registries = []RegistryJSON{}
 	}
 
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(out)
+	return out
+}
+
+func registryRepos(registries []config.RegistryConfig) []string {
+	repos := make([]string, 0, len(registries))
+	for _, registry := range registries {
+		repos = append(repos, registry.Repo)
+	}
+	return repos
 }

--- a/internal/workflow/registry_list_test.go
+++ b/internal/workflow/registry_list_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/workflow"
 )
@@ -67,13 +68,16 @@ func TestPrintRegistryJSON_Shape(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := workflow.PrintRegistryJSON(&buf, []string{"Foo/bar"}, st); err != nil {
+	if err := workflow.PrintRegistryJSON(&buf, []config.RegistryConfig{
+		{Repo: "Foo/bar", Visibility: config.RegistryVisibilityPublic},
+	}, st); err != nil {
 		t.Fatalf("PrintRegistryJSON error: %v", err)
 	}
 
 	var out struct {
 		Registries []struct {
 			Registry   string `json:"registry"`
+			Visibility string `json:"visibility"`
 			SkillCount int    `json:"skill_count"`
 		} `json:"registries"`
 		LastSync *string `json:"last_sync"`
@@ -90,6 +94,9 @@ func TestPrintRegistryJSON_Shape(t *testing.T) {
 	}
 	if out.Registries[0].SkillCount != 2 {
 		t.Errorf("skill_count = %d, want 2", out.Registries[0].SkillCount)
+	}
+	if out.Registries[0].Visibility != config.RegistryVisibilityPublic {
+		t.Errorf("visibility = %q, want %q", out.Registries[0].Visibility, config.RegistryVisibilityPublic)
 	}
 	if out.LastSync == nil {
 		t.Fatal("last_sync is nil, want non-nil")

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -708,6 +708,9 @@ func StepLoadConfig(ctx context.Context, b *Bag) error {
 			b.Provider = provider.NewGitHubProvider(provider.WrapGitHubClient(b.Client))
 		}
 	}
+	if b.Visibility == nil {
+		b.Visibility = b.Client
+	}
 
 	return nil
 }


### PR DESCRIPTION
Adds local registry visibility plumbing for the aggregator foundation.

What changed:
- store visibility on registry config rows and migrate old types (community -> public, team -> private, github -> unknown)
- classify new registry connects from GitHub repo metadata, falling back to unknown on errors
- include visibility in scribe registry list --json and register the output schema
- document the privacy boundary in docs/registry-visibility.md

No telemetry or local index in this PR.

Tests: go test ./...