### PR TITLE
feat: add registry kit discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.3.0 — 2026-05-09
 
 ### Added
+- **Registry-published kits are discoverable** — registry manifests can now advertise `kits[]`, and `scribe kit list --remote` / `scribe kit show <owner/repo>:<kit>` expose remote kit metadata and ref classification without installing anything.
 - **New brand mark + wordmark lockup across the CLI** — replaces the old single-line gradient banner with a chip+S brand mark beside a FIGlet "Slant" `cribe` wordmark, mirroring the website logo. Uses the website palette directly (`#15212a` ink, `#f3ede1` cream, `#b9540f` orange chip).
 - **Logo coverage extended to more commands** — `scribe`, `scribe list`, `scribe status`, `scribe doctor`, `scribe upgrade`, `scribe upgrade --check`, and `scribe guide` (interactive) all now print the brand lockup. First-run banner also includes it.
 

--- a/cmd/kit.go
+++ b/cmd/kit.go
@@ -14,8 +14,10 @@ import (
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/cli/fields"
 	"github.com/Naoray/scribe/internal/cli/output"
+	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/kit"
 	"github.com/Naoray/scribe/internal/paths"
+	"github.com/Naoray/scribe/internal/registry"
 )
 
 type kitCreateOptions struct {
@@ -25,6 +27,11 @@ type kitCreateOptions struct {
 	registry    string
 	force       bool
 	json        bool
+}
+
+type kitListOptions struct {
+	remote   bool
+	registry string
 }
 
 type kitCreateOutput struct {
@@ -39,10 +46,15 @@ type kitListOutput struct {
 }
 
 type kitListItem struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	SkillsCount int      `json:"skills_count"`
-	Skills      []string `json:"skills"`
+	Name             string   `json:"name"`
+	Description      string   `json:"description"`
+	SkillsCount      int      `json:"skills_count"`
+	Skills           []string `json:"skills,omitempty"`
+	Registry         string   `json:"registry,omitempty"`
+	Path             string   `json:"path,omitempty"`
+	Author           string   `json:"author,omitempty"`
+	Remote           bool     `json:"remote,omitempty"`
+	InstalledLocally bool     `json:"installed_locally,omitempty"`
 }
 
 type kitShowOutput struct {
@@ -50,12 +62,30 @@ type kitShowOutput struct {
 	Description string           `json:"description"`
 	Skills      []string         `json:"skills"`
 	Source      *kitSourceOutput `json:"source,omitempty"`
+	Registry    string           `json:"registry,omitempty"`
+	Refs        []kitRefOutput   `json:"refs,omitempty"`
 }
 
 type kitSourceOutput struct {
 	Registry string `json:"registry"`
 	Rev      string `json:"rev,omitempty"`
 }
+
+type kitRefOutput struct {
+	Raw       string `json:"raw"`
+	Skill     string `json:"skill"`
+	Origin    string `json:"origin"`
+	Registry  string `json:"registry,omitempty"`
+	Connected bool   `json:"connected"`
+	Glob      bool   `json:"glob,omitempty"`
+	Local     bool   `json:"local,omitempty"`
+	Source    string `json:"source,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+var listRemoteKitsFn = registry.ListKits
+var findRemoteKitFn = registry.FindKit
+var fetchRemoteKitFn = registry.FetchKitBody
 
 var kitListFieldSet = fields.FieldSet[kitListItem]{
 	"name": func(item kitListItem) any {
@@ -69,6 +99,12 @@ var kitListFieldSet = fields.FieldSet[kitListItem]{
 	},
 	"skills": func(item kitListItem) any {
 		return item.Skills
+	},
+	"registry": func(item kitListItem) any {
+		return item.Registry
+	},
+	"path": func(item kitListItem) any {
+		return item.Path
 	},
 }
 
@@ -104,13 +140,18 @@ func newKitCreateCommand() *cobra.Command {
 }
 
 func newKitListCommand() *cobra.Command {
+	opts := &kitListOptions{}
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List local skill kits",
 		Args:  cobra.NoArgs,
-		RunE:  runKitList,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runKitListWithOptions(cmd, args, opts)
+		},
 	}
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	cmd.Flags().BoolVar(&opts.remote, "remote", false, "List kits from connected registries")
+	cmd.Flags().StringVar(&opts.registry, "registry", "", "Limit remote kits to one connected registry")
 	output.AttachFieldsFlag(cmd, kitListFieldSet)
 	return markJSONSupported(cmd)
 }
@@ -181,6 +222,13 @@ func runKitCreate(cmd *cobra.Command, name string, opts *kitCreateOptions) error
 }
 
 func runKitList(cmd *cobra.Command, args []string) error {
+	return runKitListWithOptions(cmd, args, &kitListOptions{})
+}
+
+func runKitListWithOptions(cmd *cobra.Command, args []string, opts *kitListOptions) error {
+	if opts == nil {
+		opts = &kitListOptions{}
+	}
 	scribeDir, err := paths.ScribeDir()
 	if err != nil {
 		return fmt.Errorf("resolve scribe dir: %w", err)
@@ -191,6 +239,19 @@ func runKitList(cmd *cobra.Command, args []string) error {
 	}
 
 	items := kitListItems(loaded)
+	if opts.remote || opts.registry != "" {
+		remote, err := remoteKitListItems(cmd, opts, loaded)
+		if err != nil {
+			return err
+		}
+		items = append(items, remote...)
+		sort.Slice(items, func(i, j int) bool {
+			if items[i].Registry != items[j].Registry {
+				return items[i].Registry < items[j].Registry
+			}
+			return items[i].Name < items[j].Name
+		})
+	}
 	fieldsFlag, _ := cmd.Flags().GetString("fields")
 	projected, err := projectKitListItems(items, fieldsFlag)
 	if err != nil {
@@ -210,6 +271,9 @@ func runKitList(cmd *cobra.Command, args []string) error {
 
 func runKitShow(cmd *cobra.Command, args []string) error {
 	name := args[0]
+	if strings.Contains(name, ":") {
+		return runKitShowRemote(cmd, name)
+	}
 	scribeDir, err := paths.ScribeDir()
 	if err != nil {
 		return fmt.Errorf("resolve scribe dir: %w", err)
@@ -239,6 +303,115 @@ func runKitShow(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(cmd.OutOrStdout(), "Description: %s\n", out.Description)
 	fmt.Fprintf(cmd.OutOrStdout(), "Skills (%d): %s\n", len(out.Skills), strings.Join(out.Skills, ", "))
 	fmt.Fprintf(cmd.OutOrStdout(), "Source: %s\n", kitSourceLabel(out.Source))
+	return nil
+}
+
+func remoteKitListItems(cmd *cobra.Command, opts *kitListOptions, local map[string]*kit.Kit) ([]kitListItem, error) {
+	factory := commandFactory()
+	cfg, err := factory.Config()
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	client, err := factory.Client()
+	if err != nil {
+		return nil, fmt.Errorf("load github client: %w", err)
+	}
+	repos, err := remoteKitRepos(opts.registry, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var items []kitListItem
+	for _, repo := range repos {
+		kits, err := listRemoteKitsFn(cmd.Context(), client, repo)
+		if err != nil {
+			return nil, fmt.Errorf("list kits from %s: %w", repo, err)
+		}
+		for _, remote := range kits {
+			_, installed := local[remote.Name]
+			items = append(items, kitListItem{
+				Name:             remote.Name,
+				Description:      remote.Description,
+				Registry:         remote.Registry,
+				Path:             remote.Path,
+				Author:           remote.Author,
+				Remote:           true,
+				InstalledLocally: installed,
+			})
+		}
+	}
+	return items, nil
+}
+
+func remoteKitRepos(registryFilter string, cfg *config.Config) ([]string, error) {
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	if registryFilter == "" {
+		return cfg.TeamRepos(), nil
+	}
+	repo, err := resolveRegistry(registryFilter, cfg.TeamRepos())
+	if err != nil {
+		return nil, clierrors.Wrap(fmt.Errorf("registry %q is not connected", registryFilter), "REGISTRY_NOT_CONNECTED", clierrors.ExitNotFound,
+			clierrors.WithResource(registryFilter),
+			clierrors.WithRemediation("Run `scribe registry connect "+registryFilter+"` first."),
+		)
+	}
+	return []string{repo}, nil
+}
+
+func runKitShowRemote(cmd *cobra.Command, ref string) error {
+	registryRepo, kitName, err := parseSkillRef(ref)
+	if err != nil {
+		return err
+	}
+	factory := commandFactory()
+	cfg, err := factory.Config()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	if !registryConnected(cfg, registryRepo) {
+		return clierrors.Wrap(fmt.Errorf("registry %q is not connected", registryRepo), "REGISTRY_NOT_CONNECTED", clierrors.ExitNotFound,
+			clierrors.WithResource(registryRepo),
+			clierrors.WithRemediation("Run `scribe registry connect "+registryRepo+"` first."),
+		)
+	}
+	client, err := factory.Client()
+	if err != nil {
+		return fmt.Errorf("load github client: %w", err)
+	}
+	entry, err := findRemoteKitFn(cmd.Context(), client, registryRepo, kitName)
+	if err != nil {
+		return clierrors.Wrap(err, "KIT_NOT_FOUND", clierrors.ExitNotFound,
+			clierrors.WithResource(ref),
+			clierrors.WithRemediation("Run `scribe kit list --remote --registry "+registryRepo+"`."),
+		)
+	}
+	k, err := fetchRemoteKitFn(cmd.Context(), client, registryRepo, entry)
+	if err != nil {
+		return err
+	}
+	out := kitShowOutputFromKit(k)
+	out.Registry = registryRepo
+	out.Refs = kitRefOutputs(k.Skills, registryRepo, cfg)
+
+	if jsonFlagPassed(cmd) {
+		r := jsonRendererForCommand(cmd, true)
+		if err := r.Result(out); err != nil {
+			return err
+		}
+		return r.Flush()
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Kit: %s:%s\n", registryRepo, out.Name)
+	fmt.Fprintf(cmd.OutOrStdout(), "Description: %s\n", out.Description)
+	for _, ref := range out.Refs {
+		status := "missing"
+		if ref.Connected {
+			status = "connected"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "- %s (%s, %s)\n", ref.Raw, ref.Origin, status)
+	}
 	return nil
 }
 
@@ -339,6 +512,49 @@ func kitShowOutputFromKit(k *kit.Kit) kitShowOutput {
 		}
 	}
 	return out
+}
+
+func kitRefOutputs(rawRefs []string, defaultRegistry string, cfg *config.Config) []kitRefOutput {
+	out := make([]kitRefOutput, 0, len(rawRefs))
+	for _, raw := range rawRefs {
+		ref, err := kit.ParseSkillRef(raw, defaultRegistry)
+		if err != nil {
+			out = append(out, kitRefOutput{Raw: raw, Reason: err.Error()})
+			continue
+		}
+		origin := string(kit.OriginCrossRegistry)
+		if ref.Local {
+			origin = string(kit.OriginLocal)
+		} else if ref.Registry == defaultRegistry {
+			origin = string(kit.OriginSameRegistry)
+		}
+		connected := ref.Local || ref.Registry == defaultRegistry || registryConnected(cfg, ref.Registry)
+		item := kitRefOutput{
+			Raw:       raw,
+			Skill:     ref.Skill,
+			Origin:    origin,
+			Registry:  ref.Registry,
+			Connected: connected,
+			Glob:      ref.Glob,
+			Local:     ref.Local,
+		}
+		if ref.Source.Host != "" {
+			item.Source = ref.Source.String()
+		}
+		if !connected {
+			item.Reason = "registry_not_connected"
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func registryConnected(cfg *config.Config, repo string) bool {
+	if cfg == nil || repo == "" {
+		return false
+	}
+	rc := cfg.FindRegistry(repo)
+	return rc != nil && rc.Enabled
 }
 
 func kitSourceLabel(source *kitSourceOutput) string {

--- a/cmd/kit_list_test.go
+++ b/cmd/kit_list_test.go
@@ -2,11 +2,17 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Naoray/scribe/internal/app"
+	"github.com/Naoray/scribe/internal/config"
+	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/registry"
 )
 
 func TestKitListTextOutput(t *testing.T) {
@@ -106,6 +112,72 @@ skills:
 	}
 	if data.Kits[0]["skills_count"] != float64(1) {
 		t.Fatalf("skills_count = %v, want 1", data.Kits[0]["skills_count"])
+	}
+}
+
+func TestKitListRemoteJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeKitFixture(t, home, "local-kit", `name: local-kit
+skills:
+  - local-skill
+`)
+
+	oldFactory := commandFactory
+	oldList := listRemoteKitsFn
+	t.Cleanup(func() {
+		commandFactory = oldFactory
+		listRemoteKitsFn = oldList
+	})
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) {
+				return &config.Config{Registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}}}, nil
+			},
+			Client: func() (*gh.Client, error) {
+				return gh.NewClient(context.Background(), ""), nil
+			},
+		}
+	}
+	listRemoteKitsFn = func(_ context.Context, _ registry.FileFetcher, repo string) ([]registry.ManifestKit, error) {
+		return []registry.ManifestKit{{
+			Registry:    repo,
+			Name:        "remote-kit",
+			Path:        "kits/remote-kit.yaml",
+			Description: "Remote kit",
+			Author:      "acme",
+		}}, nil
+	}
+
+	cmd := newKitListCommand()
+	cmd.SetArgs([]string{"--remote", "--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute kit list --remote: %v", err)
+	}
+
+	var env testEnvelope
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v\n%s", err, out.String())
+	}
+	var data struct {
+		Kits []struct {
+			Name     string `json:"name"`
+			Registry string `json:"registry,omitempty"`
+			Path     string `json:"path,omitempty"`
+			Remote   bool   `json:"remote,omitempty"`
+		} `json:"kits"`
+	}
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if len(data.Kits) != 2 {
+		t.Fatalf("kits count = %d, want 2: %#v", len(data.Kits), data.Kits)
+	}
+	if data.Kits[1].Name != "remote-kit" || data.Kits[1].Registry != "acme/skills" || data.Kits[1].Path != "kits/remote-kit.yaml" || !data.Kits[1].Remote {
+		t.Fatalf("remote kit = %#v", data.Kits[1])
 	}
 }
 

--- a/cmd/kit_schema.go
+++ b/cmd/kit_schema.go
@@ -1,0 +1,69 @@
+package cmd
+
+import clischema "github.com/Naoray/scribe/internal/cli/schema"
+
+const kitListOutputSchema = `{
+  "type": "object",
+  "required": ["kits"],
+  "properties": {
+    "kits": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "description", "skills_count"],
+        "properties": {
+          "name": {"type": "string"},
+          "description": {"type": "string"},
+          "skills_count": {"type": "integer"},
+          "skills": {"type": "array", "items": {"type": "string"}},
+          "registry": {"type": "string"},
+          "path": {"type": "string"},
+          "author": {"type": "string"},
+          "remote": {"type": "boolean"},
+          "installed_locally": {"type": "boolean"}
+        }
+      }
+    }
+  }
+}`
+
+const kitShowOutputSchema = `{
+  "type": "object",
+  "required": ["name", "description", "skills"],
+  "properties": {
+    "name": {"type": "string"},
+    "description": {"type": "string"},
+    "skills": {"type": "array", "items": {"type": "string"}},
+    "registry": {"type": "string"},
+    "source": {
+      "type": "object",
+      "properties": {
+        "registry": {"type": "string"},
+        "rev": {"type": "string"}
+      }
+    },
+    "refs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["raw", "skill", "origin", "connected"],
+        "properties": {
+          "raw": {"type": "string"},
+          "skill": {"type": "string"},
+          "origin": {"type": "string", "enum": ["same_registry", "cross_registry", "local"]},
+          "registry": {"type": "string"},
+          "connected": {"type": "boolean"},
+          "glob": {"type": "boolean"},
+          "local": {"type": "boolean"},
+          "source": {"type": "string"},
+          "reason": {"type": "string"}
+        }
+      }
+    }
+  }
+}`
+
+func init() {
+	clischema.Register("scribe kit list", kitListOutputSchema)
+	clischema.Register("scribe kit show", kitShowOutputSchema)
+}

--- a/cmd/kit_show_test.go
+++ b/cmd/kit_show_test.go
@@ -2,11 +2,18 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/Naoray/scribe/internal/app"
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/Naoray/scribe/internal/config"
+	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/kit"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/registry"
 )
 
 func TestKitShowTextOutput(t *testing.T) {
@@ -111,5 +118,112 @@ func TestKitShowNotFound(t *testing.T) {
 	}
 	if got := clierrors.ExitCode(err); got != clierrors.ExitNotFound {
 		t.Fatalf("exit = %d, want %d; err=%v", got, clierrors.ExitNotFound, err)
+	}
+}
+
+func TestKitShowRemoteJSONClassifiesRefs(t *testing.T) {
+	oldFactory := commandFactory
+	oldFind := findRemoteKitFn
+	oldFetch := fetchRemoteKitFn
+	t.Cleanup(func() {
+		commandFactory = oldFactory
+		findRemoteKitFn = oldFind
+		fetchRemoteKitFn = oldFetch
+	})
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) {
+				return &config.Config{Registries: []config.RegistryConfig{
+					{Repo: "acme/skills", Enabled: true},
+					{Repo: "other/skills", Enabled: true},
+				}}, nil
+			},
+			Client: func() (*gh.Client, error) {
+				return gh.NewClient(context.Background(), ""), nil
+			},
+		}
+	}
+	findRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, _, name string) (manifest.KitEntry, error) {
+		return manifest.KitEntry{Name: name, Path: "kits/" + name + ".yaml"}, nil
+	}
+	fetchRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, registryRepo string, entry manifest.KitEntry) (*kit.Kit, error) {
+		return &kit.Kit{
+			Name:        entry.Name,
+			Description: "Remote baseline",
+			Skills:      []string{"tdd", "other/skills:debugging", "missing/skills:qa", "init-*"},
+			Source:      &kit.Source{Registry: registryRepo},
+		}, nil
+	}
+
+	cmd := newKitShowCommand()
+	cmd.SetArgs([]string{"acme/skills:baseline", "--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute kit show remote: %v", err)
+	}
+
+	var env testEnvelope
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v\n%s", err, out.String())
+	}
+	var data struct {
+		Name     string `json:"name"`
+		Registry string `json:"registry"`
+		Refs     []struct {
+			Raw       string `json:"raw"`
+			Origin    string `json:"origin"`
+			Registry  string `json:"registry"`
+			Connected bool   `json:"connected"`
+			Glob      bool   `json:"glob"`
+			Reason    string `json:"reason"`
+		} `json:"refs"`
+	}
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if data.Name != "baseline" || data.Registry != "acme/skills" {
+		t.Fatalf("data = %#v", data)
+	}
+	if len(data.Refs) != 4 {
+		t.Fatalf("refs count = %d, want 4", len(data.Refs))
+	}
+	if data.Refs[0].Origin != "same_registry" || !data.Refs[0].Connected {
+		t.Fatalf("same-registry ref = %#v", data.Refs[0])
+	}
+	if data.Refs[1].Origin != "cross_registry" || data.Refs[1].Registry != "other/skills" || !data.Refs[1].Connected {
+		t.Fatalf("connected cross-registry ref = %#v", data.Refs[1])
+	}
+	if data.Refs[2].Reason != "registry_not_connected" || data.Refs[2].Connected {
+		t.Fatalf("missing cross-registry ref = %#v", data.Refs[2])
+	}
+	if !data.Refs[3].Glob {
+		t.Fatalf("glob ref = %#v", data.Refs[3])
+	}
+}
+
+func TestKitShowRemoteRegistryNotConnected(t *testing.T) {
+	oldFactory := commandFactory
+	t.Cleanup(func() { commandFactory = oldFactory })
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) {
+				return &config.Config{}, nil
+			},
+		}
+	}
+
+	cmd := newKitShowCommand()
+	cmd.SetArgs([]string{"acme/skills:baseline", "--json"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := clierrors.ExitCode(err); got != clierrors.ExitNotFound {
+		t.Fatalf("exit = %d, want %d; err=%v", got, clierrors.ExitNotFound, err)
+	}
+	if !strings.Contains(err.Error(), `registry "acme/skills" is not connected`) {
+		t.Fatalf("error = %v", err)
 	}
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -62,8 +62,8 @@ Tune individual skills, project-author new ones, and decide which AI tools each 
 | `scribe tools` | List, enable, or disable detected tools machine-wide |
 | `scribe tools add` | Register a custom tool integration (`--detect`, `--install`, `--path`, `--uninstall`) |
 | `scribe kit create <name>` | Create a local kit — a named list of skills and MCP servers scoped to a project (saved to `~/.scribe/kits/<name>.yaml`). Use `--skills`, `--mcp-servers`, and `--registry` to populate it. Reference the kit by name in a project's `.scribe.yaml` under `kits:`. |
-| `scribe kit list` | List local kits from `~/.scribe/kits/*.yaml`. Supports `--fields` and `--json` for agent-readable output. |
-| `scribe kit show <name>` | Show one local kit, including skills and source metadata. |
+| `scribe kit list` | List local kits from `~/.scribe/kits/*.yaml`. Supports `--fields` and `--json` for agent-readable output. Add `--remote` to include registry-published kits, or `--registry <owner/repo>` to restrict remote discovery to one connected registry. |
+| `scribe kit show <name>` | Show one local kit, including skills and source metadata. Use `scribe kit show <owner/repo>:<kit>` to inspect a registry-published kit without installing it. |
 | `scribe project init` | Create a committed project `.scribe.yaml` for repo-local loadouts. Use `--kits a,b` for non-interactive setup or pick from local kits interactively. |
 
 ## Conflicts and recovery

--- a/docs/projects-and-kits.md
+++ b/docs/projects-and-kits.md
@@ -103,6 +103,26 @@ mcp_servers:
 
 Projects list which kits they want via `kits:` in `.scribe.yaml`. Multiple kits union; the project may add or remove individual skills on top with `add:` / `remove:`. MCP servers can also be declared through kits or directly in `.scribe.yaml` with `mcp:` / `mcp_servers:`; `scribe sync` uses those names to select definitions from project `.mcp.json`. Claude gets enabled server names in `.claude/settings.json`, Codex gets selected definitions in `.codex/config.toml`, and Cursor gets selected definitions in `.cursor/mcp.json`. Existing unmanaged Codex/Cursor entries are preserved; Scribe only replaces entries it previously projected. Scribe does not start MCP server processes.
 
+Registries can publish kits by adding `kits:` entries to their registry `scribe.yaml`. Kit bodies live in the registry repo, conventionally under `kits/<name>.yaml`:
+
+```yaml
+apiVersion: scribe/v1
+kind: Registry
+team:
+  name: acme
+catalog:
+  - name: tdd
+    source: github:acme/skills@main
+kits:
+  - name: laravel-baseline
+    description: Laravel app defaults
+    path: kits/laravel-baseline.yaml
+```
+
+Omit `path` to use `kits/<name>.yaml`. Manifest validation rejects duplicate kit names, kit names that collide with skill catalog entries, and paths outside the registry repo.
+
+Use `scribe kit list --remote` to list kits from connected registries, `scribe kit list --registry <owner/repo>` to restrict discovery, and `scribe kit show <owner/repo>:<kit> --json` to inspect a remote kit body. Remote show classifies each skill ref as same-registry, cross-registry, or local and reports whether referenced registries are connected. `scribe kit install` is not part of this phase.
+
 ### Authoring kits and snippets (today)
 
 Snippet **projection** ships in v1.1.0 — `scribe sync` writes snippet bodies into project agent rules files and Cursor rules. A user-facing snippet authoring CLI is still absent; agents (or you, by hand) write snippet markdown into `~/.scribe/snippets/<name>.md` and reference it from `.scribe.yaml`. The embedded scribe skill (installed automatically the first time you run scribe in any supported agent session — Claude Code, Codex, Cursor, Gemini, or a custom tool registered via `scribe tools add`) knows the snippet schema and will scaffold one for you. **Ask your AI agent.**

--- a/internal/kit/kit.go
+++ b/internal/kit/kit.go
@@ -20,6 +20,54 @@ type Kit struct {
 	Source      *Source  `yaml:"source,omitempty"`
 }
 
+type kitYAML struct {
+	Name        string     `yaml:"name"`
+	Description string     `yaml:"description,omitempty"`
+	Skills      []skillRef `yaml:"skills"`
+	MCPServers  []string   `yaml:"mcp_servers,omitempty"`
+	Source      *Source    `yaml:"source,omitempty"`
+}
+
+type skillRef string
+
+func (s *skillRef) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		*s = skillRef(value.Value)
+		return nil
+	case yaml.MappingNode:
+		var raw struct {
+			Ref string `yaml:"ref"`
+		}
+		if err := value.Decode(&raw); err != nil {
+			return err
+		}
+		if raw.Ref == "" {
+			return errors.New("skill mapping must include ref")
+		}
+		*s = skillRef(raw.Ref)
+		return nil
+	default:
+		return fmt.Errorf("skill ref must be a string or mapping, got YAML kind %d", value.Kind)
+	}
+}
+
+func (k *Kit) UnmarshalYAML(value *yaml.Node) error {
+	var raw kitYAML
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	k.Name = raw.Name
+	k.Description = raw.Description
+	k.Skills = make([]string, 0, len(raw.Skills))
+	for _, ref := range raw.Skills {
+		k.Skills = append(k.Skills, string(ref))
+	}
+	k.MCPServers = raw.MCPServers
+	k.Source = raw.Source
+	return nil
+}
+
 // Source records the registry source for a kit.
 type Source struct {
 	Registry string `yaml:"registry"`
@@ -32,6 +80,11 @@ func Load(path string) (*Kit, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read kit: %w", err)
 	}
+	return Parse(data)
+}
+
+// Parse reads a kit YAML document from bytes.
+func Parse(data []byte) (*Kit, error) {
 	if len(bytes.TrimSpace(data)) == 0 {
 		return &Kit{}, nil
 	}

--- a/internal/kit/ref.go
+++ b/internal/kit/ref.go
@@ -1,0 +1,74 @@
+package kit
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Naoray/scribe/internal/manifest"
+)
+
+// Ref is a parsed skill reference from a kit.
+type Ref struct {
+	Raw      string
+	Registry string
+	Source   manifest.Source
+	Skill    string
+	Local    bool
+	Glob     bool
+}
+
+// ParseSkillRef parses same-registry, cross-registry, pinned github, and local
+// skill references used by registry-published kits.
+func ParseSkillRef(raw, defaultRegistry string) (Ref, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return Ref{}, fmt.Errorf("invalid kit skill ref: empty")
+	}
+
+	if strings.HasPrefix(trimmed, "local:") {
+		skill := strings.TrimPrefix(trimmed, "local:")
+		if skill == "" {
+			return Ref{}, fmt.Errorf("invalid kit skill ref %q: local skill is empty", raw)
+		}
+		return Ref{Raw: raw, Skill: skill, Local: true, Glob: hasGlobMeta(skill)}, nil
+	}
+
+	if strings.HasPrefix(trimmed, "github:") {
+		idx := strings.LastIndex(trimmed, ":")
+		if idx <= len("github:") || idx == len(trimmed)-1 {
+			return Ref{}, fmt.Errorf("invalid kit skill ref %q: expected github:owner/repo@ref:skill", raw)
+		}
+		source, err := manifest.ParseSource(trimmed[:idx])
+		if err != nil {
+			return Ref{}, fmt.Errorf("invalid kit skill ref %q: %w", raw, err)
+		}
+		skill := trimmed[idx+1:]
+		return Ref{
+			Raw:      raw,
+			Registry: source.Owner + "/" + source.Repo,
+			Source:   source,
+			Skill:    skill,
+			Glob:     hasGlobMeta(skill),
+		}, nil
+	}
+
+	if idx := strings.LastIndex(trimmed, ":"); idx >= 0 {
+		registryName := trimmed[:idx]
+		skill := trimmed[idx+1:]
+		if registryName == "" || skill == "" {
+			return Ref{}, fmt.Errorf("invalid kit skill ref %q: expected owner/repo:skill", raw)
+		}
+		if hasGlobMeta(registryName) {
+			return Ref{}, fmt.Errorf("invalid kit skill ref %q: glob registry segment is not supported", raw)
+		}
+		if _, _, err := manifest.ParseOwnerRepo(registryName); err != nil {
+			return Ref{}, fmt.Errorf("invalid kit skill ref %q: %w", raw, err)
+		}
+		return Ref{Raw: raw, Registry: registryName, Skill: skill, Glob: hasGlobMeta(skill)}, nil
+	}
+
+	if strings.Contains(trimmed, "/") {
+		return Ref{}, fmt.Errorf("invalid kit skill ref %q: cross-registry refs must use owner/repo:skill", raw)
+	}
+	return Ref{Raw: raw, Registry: defaultRegistry, Skill: trimmed, Glob: hasGlobMeta(trimmed)}, nil
+}

--- a/internal/kit/ref_test.go
+++ b/internal/kit/ref_test.go
@@ -1,0 +1,100 @@
+package kit
+
+import "testing"
+
+func TestParseSkillRef(t *testing.T) {
+	tests := []struct {
+		name          string
+		raw           string
+		defaultReg    string
+		wantRegistry  string
+		wantSkill     string
+		wantLocal     bool
+		wantGlob      bool
+		wantSourceRef string
+		wantErr       string
+	}{
+		{
+			name:         "same registry",
+			raw:          "tdd",
+			defaultReg:   "acme/skills",
+			wantRegistry: "acme/skills",
+			wantSkill:    "tdd",
+		},
+		{
+			name:         "same registry glob",
+			raw:          "init-*",
+			defaultReg:   "acme/skills",
+			wantRegistry: "acme/skills",
+			wantSkill:    "init-*",
+			wantGlob:     true,
+		},
+		{
+			name:         "cross registry",
+			raw:          "obra/superpowers:debugging",
+			defaultReg:   "acme/skills",
+			wantRegistry: "obra/superpowers",
+			wantSkill:    "debugging",
+		},
+		{
+			name:          "pinned github",
+			raw:           "github:Naoray/skills@v0.4.0:cleanup",
+			defaultReg:    "acme/skills",
+			wantRegistry:  "Naoray/skills",
+			wantSkill:     "cleanup",
+			wantSourceRef: "v0.4.0",
+		},
+		{
+			name:      "local",
+			raw:       "local:private",
+			wantSkill: "private",
+			wantLocal: true,
+		},
+		{
+			name:    "empty",
+			raw:     "",
+			wantErr: "invalid kit skill ref: empty",
+		},
+		{
+			name:    "bad cross registry",
+			raw:     "owner/repo",
+			wantErr: `invalid kit skill ref "owner/repo": cross-registry refs must use owner/repo:skill`,
+		},
+		{
+			name:    "glob registry",
+			raw:     "*/repo:tdd",
+			wantErr: `invalid kit skill ref "*/repo:tdd": glob registry segment is not supported`,
+		},
+		{
+			name:    "bad github",
+			raw:     "github:owner/repo@main",
+			wantErr: `invalid kit skill ref "github:owner/repo@main": expected github:owner/repo@ref:skill`,
+		},
+		{
+			name:    "double colon",
+			raw:     "owner/repo:",
+			wantErr: `invalid kit skill ref "owner/repo:": expected owner/repo:skill`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, err := ParseSkillRef(tt.raw, tt.defaultReg)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseSkillRef: %v", err)
+			}
+			if ref.Registry != tt.wantRegistry || ref.Skill != tt.wantSkill || ref.Local != tt.wantLocal || ref.Glob != tt.wantGlob {
+				t.Fatalf("ref = %+v", ref)
+			}
+			if ref.Source.Ref != tt.wantSourceRef {
+				t.Fatalf("source ref = %q, want %q", ref.Source.Ref, tt.wantSourceRef)
+			}
+		})
+	}
+}

--- a/internal/kit/resolver.go
+++ b/internal/kit/resolver.go
@@ -1,6 +1,7 @@
 package kit
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -16,38 +17,17 @@ import (
 //   - expand globs against installedSkills
 //   - return a deduplicated, sorted skill name slice
 func Resolve(pf *projectfile.ProjectFile, availableKits map[string]*Kit, installedSkills []string) ([]string, error) {
-	if pf == nil {
-		pf = &projectfile.ProjectFile{}
+	resolution, err := ResolveWithDetail(context.Background(), ResolverInput{
+		Project:         pf,
+		Kits:            availableKits,
+		InstalledSkills: installedSkills,
+	})
+	if err != nil {
+		return nil, err
 	}
-
-	patterns := make([]string, 0, len(pf.Add))
-	for _, kitName := range pf.Kits {
-		kit, ok := availableKits[kitName]
-		if !ok {
-			return nil, fmt.Errorf("kit %q not found", kitName)
-		}
-		patterns = append(patterns, kit.Skills...)
-	}
-	patterns = append(patterns, pf.Add...)
-
-	result := make(map[string]struct{})
-	for _, pattern := range patterns {
-		matches, err := expandSkillPattern(pattern, installedSkills)
-		if err != nil {
-			return nil, err
-		}
-		for _, skill := range matches {
-			result[skill] = struct{}{}
-		}
-	}
-
-	for _, skill := range pf.Remove {
-		delete(result, skill)
-	}
-
-	skills := make([]string, 0, len(result))
-	for skill := range result {
-		skills = append(skills, skill)
+	skills := make([]string, 0, len(resolution.Skills))
+	for _, skill := range resolution.Skills {
+		skills = append(skills, skill.Name)
 	}
 	sort.Strings(skills)
 	return skills, nil

--- a/internal/kit/resolver_detail.go
+++ b/internal/kit/resolver_detail.go
@@ -1,0 +1,211 @@
+package kit
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/projectfile"
+)
+
+type ResolvedOrigin string
+
+const (
+	OriginSameRegistry  ResolvedOrigin = "same_registry"
+	OriginCrossRegistry ResolvedOrigin = "cross_registry"
+	OriginLocal         ResolvedOrigin = "local"
+)
+
+type ResolverInput struct {
+	Project         *projectfile.ProjectFile
+	Kits            map[string]*Kit
+	InstalledSkills []string
+	Registries      []config.RegistryConfig
+	NowRegistry     func(context.Context, string) (*manifest.Manifest, error)
+}
+
+type ResolvedSkill struct {
+	Name     string          `json:"name"`
+	Origin   ResolvedOrigin  `json:"origin"`
+	Registry string          `json:"registry,omitempty"`
+	Source   manifest.Source `json:"source,omitempty"`
+	Aliased  bool            `json:"aliased,omitempty"`
+	AliasFor string          `json:"alias_for,omitempty"`
+}
+
+type MissingRef struct {
+	Ref      string `json:"ref"`
+	Registry string `json:"registry,omitempty"`
+	Reason   string `json:"reason"`
+}
+
+type Conflict struct {
+	Name    string `json:"name"`
+	Current string `json:"current"`
+	Next    string `json:"next"`
+}
+
+type Resolution struct {
+	Skills    []ResolvedSkill `json:"skills"`
+	Missing   []MissingRef    `json:"missing,omitempty"`
+	Conflicts []Conflict      `json:"conflicts,omitempty"`
+}
+
+func ResolveWithDetail(ctx context.Context, in ResolverInput) (Resolution, error) {
+	pf := in.Project
+	if pf == nil {
+		pf = &projectfile.ProjectFile{}
+	}
+
+	var refs []kitRefWithRegistry
+	for _, kitName := range pf.Kits {
+		k, ok := in.Kits[kitName]
+		if !ok {
+			return Resolution{}, fmt.Errorf("kit %q not found", kitName)
+		}
+		defaultRegistry := ""
+		if k.Source != nil {
+			defaultRegistry = k.Source.Registry
+		}
+		for _, raw := range k.Skills {
+			refs = append(refs, kitRefWithRegistry{Raw: raw, DefaultRegistry: defaultRegistry, Published: k.Source != nil})
+		}
+	}
+	for _, raw := range pf.Add {
+		refs = append(refs, kitRefWithRegistry{Raw: raw})
+	}
+
+	connected := connectedRegistrySet(in.Registries)
+	installed := installedSkillSet(in.InstalledSkills)
+	result := Resolution{}
+	seen := map[string]ResolvedSkill{}
+	for _, rawRef := range refs {
+		ref, err := ParseSkillRef(rawRef.Raw, rawRef.DefaultRegistry)
+		if err != nil {
+			return Resolution{}, err
+		}
+		if ref.Local {
+			if rawRef.Published {
+				result.Missing = append(result.Missing, MissingRef{Ref: ref.Raw, Reason: "local_ref_forbidden"})
+				continue
+			}
+			addResolvedSkill(&result, seen, ResolvedSkill{Name: ref.Skill, Origin: OriginLocal})
+			continue
+		}
+
+		origin := OriginCrossRegistry
+		if ref.Registry == rawRef.DefaultRegistry || ref.Source.Host != "" {
+			if ref.Registry == rawRef.DefaultRegistry {
+				origin = OriginSameRegistry
+			}
+		}
+		if ref.Registry != "" && rawRef.DefaultRegistry == ref.Registry {
+			origin = OriginSameRegistry
+		}
+		if ref.Registry != "" && !connected[ref.Registry] && ref.Registry != rawRef.DefaultRegistry {
+			result.Missing = append(result.Missing, MissingRef{Ref: ref.Raw, Registry: ref.Registry, Reason: "registry_not_connected"})
+			continue
+		}
+
+		matches, missing, err := resolveRefMatches(ctx, ref, rawRef.DefaultRegistry, in.NowRegistry, installed)
+		if err != nil {
+			return Resolution{}, err
+		}
+		if missing != nil {
+			result.Missing = append(result.Missing, *missing)
+			continue
+		}
+		for _, name := range matches {
+			addResolvedSkill(&result, seen, ResolvedSkill{
+				Name:     name,
+				Origin:   origin,
+				Registry: ref.Registry,
+				Source:   ref.Source,
+			})
+		}
+	}
+
+	for _, skill := range pf.Remove {
+		filtered := result.Skills[:0]
+		for _, resolved := range result.Skills {
+			if resolved.Name != skill {
+				filtered = append(filtered, resolved)
+			}
+		}
+		result.Skills = filtered
+	}
+	sort.Slice(result.Skills, func(i, j int) bool { return result.Skills[i].Name < result.Skills[j].Name })
+	return result, nil
+}
+
+type kitRefWithRegistry struct {
+	Raw             string
+	DefaultRegistry string
+	Published       bool
+}
+
+func connectedRegistrySet(registries []config.RegistryConfig) map[string]bool {
+	set := make(map[string]bool, len(registries))
+	for _, rc := range registries {
+		if rc.Enabled {
+			set[rc.Repo] = true
+		}
+	}
+	return set
+}
+
+func installedSkillSet(skills []string) map[string]bool {
+	set := make(map[string]bool, len(skills))
+	for _, skill := range skills {
+		set[skill] = true
+	}
+	return set
+}
+
+func resolveRefMatches(ctx context.Context, ref Ref, defaultRegistry string, nowRegistry func(context.Context, string) (*manifest.Manifest, error), installed map[string]bool) ([]string, *MissingRef, error) {
+	if !ref.Glob {
+		return []string{ref.Skill}, nil, nil
+	}
+
+	var candidates []string
+	if ref.Registry == "" || ref.Registry == defaultRegistry {
+		for name := range installed {
+			if match, err := filepath.Match(ref.Skill, name); err != nil {
+				return nil, nil, fmt.Errorf("match skill pattern %q: %w", ref.Skill, err)
+			} else if match {
+				candidates = append(candidates, name)
+			}
+		}
+	} else if nowRegistry != nil {
+		m, err := nowRegistry(ctx, ref.Registry)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, entry := range m.Catalog {
+			if match, err := filepath.Match(ref.Skill, entry.Name); err != nil {
+				return nil, nil, fmt.Errorf("match skill pattern %q: %w", ref.Skill, err)
+			} else if match {
+				candidates = append(candidates, entry.Name)
+			}
+		}
+	}
+	sort.Strings(candidates)
+	if len(candidates) == 0 {
+		return nil, &MissingRef{Ref: ref.Raw, Registry: ref.Registry, Reason: "glob_no_matches"}, nil
+	}
+	return candidates, nil, nil
+}
+
+func addResolvedSkill(result *Resolution, seen map[string]ResolvedSkill, skill ResolvedSkill) {
+	if existing, ok := seen[skill.Name]; ok {
+		if existing.Registry != skill.Registry {
+			result.Conflicts = append(result.Conflicts, Conflict{Name: skill.Name, Current: existing.Registry, Next: skill.Registry})
+		}
+		return
+	}
+	seen[skill.Name] = skill
+	result.Skills = append(result.Skills, skill)
+}

--- a/internal/kit/resolver_detail_test.go
+++ b/internal/kit/resolver_detail_test.go
@@ -1,0 +1,119 @@
+package kit
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/projectfile"
+)
+
+func TestResolveWithDetailClassifiesRefs(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name       string
+		kit        *Kit
+		registries []config.RegistryConfig
+		installed  []string
+		wantSkills []string
+		wantMiss   []MissingRef
+	}{
+		{
+			name: "same registry plain and glob",
+			kit: &Kit{
+				Name:   "baseline",
+				Skills: []string{"tdd", "init-*"},
+				Source: &Source{Registry: "acme/skills"},
+			},
+			registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}},
+			installed:  []string{"init-api", "init-web"},
+			wantSkills: []string{"init-api:same_registry:acme/skills", "init-web:same_registry:acme/skills", "tdd:same_registry:acme/skills"},
+		},
+		{
+			name: "cross registry missing",
+			kit: &Kit{
+				Name:   "baseline",
+				Skills: []string{"other/skills:debugging"},
+				Source: &Source{Registry: "acme/skills"},
+			},
+			registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}},
+			wantMiss:   []MissingRef{{Ref: "other/skills:debugging", Registry: "other/skills", Reason: "registry_not_connected"}},
+		},
+		{
+			name: "published local ref forbidden",
+			kit: &Kit{
+				Name:   "baseline",
+				Skills: []string{"local:private"},
+				Source: &Source{Registry: "acme/skills"},
+			},
+			registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}},
+			wantMiss:   []MissingRef{{Ref: "local:private", Reason: "local_ref_forbidden"}},
+		},
+		{
+			name: "connected cross registry",
+			kit: &Kit{
+				Name:   "baseline",
+				Skills: []string{"other/skills:debugging"},
+				Source: &Source{Registry: "acme/skills"},
+			},
+			registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}, {Repo: "other/skills", Enabled: true}},
+			wantSkills: []string{"debugging:cross_registry:other/skills"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveWithDetail(ctx, ResolverInput{
+				Project:         &projectfile.ProjectFile{Kits: []string{"baseline"}},
+				Kits:            map[string]*Kit{"baseline": tt.kit},
+				InstalledSkills: tt.installed,
+				Registries:      tt.registries,
+			})
+			if err != nil {
+				t.Fatalf("ResolveWithDetail: %v", err)
+			}
+			if joinedSkills(got.Skills) != strings.Join(tt.wantSkills, ",") {
+				t.Fatalf("skills = %s, want %s", joinedSkills(got.Skills), strings.Join(tt.wantSkills, ","))
+			}
+			if len(got.Missing) != len(tt.wantMiss) {
+				t.Fatalf("missing = %+v, want %+v", got.Missing, tt.wantMiss)
+			}
+			for i := range tt.wantMiss {
+				if got.Missing[i] != tt.wantMiss[i] {
+					t.Fatalf("missing[%d] = %+v, want %+v", i, got.Missing[i], tt.wantMiss[i])
+				}
+			}
+		})
+	}
+}
+
+func TestResolveWithDetailCrossRegistryGlobUsesCatalog(t *testing.T) {
+	got, err := ResolveWithDetail(context.Background(), ResolverInput{
+		Project: &projectfile.ProjectFile{Kits: []string{"baseline"}},
+		Kits: map[string]*Kit{"baseline": {
+			Name:   "baseline",
+			Skills: []string{"other/skills:init-*"},
+			Source: &Source{Registry: "acme/skills"},
+		}},
+		Registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}, {Repo: "other/skills", Enabled: true}},
+		NowRegistry: func(_ context.Context, registry string) (*manifest.Manifest, error) {
+			return &manifest.Manifest{Catalog: []manifest.Entry{{Name: "init-api"}, {Name: "other"}}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveWithDetail: %v", err)
+	}
+	if joinedSkills(got.Skills) != "init-api:cross_registry:other/skills" {
+		t.Fatalf("skills = %s", joinedSkills(got.Skills))
+	}
+}
+
+func joinedSkills(skills []ResolvedSkill) string {
+	parts := make([]string, 0, len(skills))
+	for _, skill := range skills {
+		parts = append(parts, skill.Name+":"+string(skill.Origin)+":"+skill.Registry)
+	}
+	return strings.Join(parts, ",")
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -19,12 +19,13 @@ const LegacyManifestFilename = "scribe.toml"
 // Manifest represents a parsed scribe.yaml.
 // A file with team: is a registry; package: is a skill package.
 type Manifest struct {
-	APIVersion string   `yaml:"apiVersion"`
-	Kind       string   `yaml:"kind"`
-	Team       *Team    `yaml:"team,omitempty"`
-	Package    *Package `yaml:"package,omitempty"`
-	Catalog    []Entry  `yaml:"catalog"`
-	Targets    *Targets `yaml:"targets,omitempty"`
+	APIVersion string     `yaml:"apiVersion"`
+	Kind       string     `yaml:"kind"`
+	Team       *Team      `yaml:"team,omitempty"`
+	Package    *Package   `yaml:"package,omitempty"`
+	Catalog    []Entry    `yaml:"catalog"`
+	Kits       []KitEntry `yaml:"kits,omitempty"`
+	Targets    *Targets   `yaml:"targets,omitempty"`
 }
 
 type Team struct {
@@ -60,6 +61,22 @@ type Entry struct {
 	Description string            `yaml:"description,omitempty"`
 	Timeout     int               `yaml:"timeout,omitempty"`
 	Group       string            `yaml:"-"` // display-only, set by marketplace discovery
+}
+
+// KitEntry represents one registry-published kit advertised by the manifest.
+type KitEntry struct {
+	Name        string `yaml:"name"`
+	Path        string `yaml:"path,omitempty"`
+	Description string `yaml:"description,omitempty"`
+	Author      string `yaml:"author,omitempty"`
+}
+
+// PathOrDefault returns the kit body path for this entry.
+func (e KitEntry) PathOrDefault() string {
+	if strings.TrimSpace(e.Path) != "" {
+		return e.Path
+	}
+	return "kits/" + e.Name + ".yaml"
 }
 
 // InstallFor returns the install command for toolName. Per-tool commands take
@@ -102,6 +119,9 @@ func Parse(data []byte) (*Manifest, error) {
 	}
 	if m.Catalog == nil {
 		m.Catalog = []Entry{}
+	}
+	if m.Kits == nil {
+		m.Kits = []KitEntry{}
 	}
 	if err := m.Validate(); err != nil {
 		return nil, err
@@ -147,6 +167,25 @@ func (m *Manifest) Validate() error {
 		seen[e.Name] = true
 		if e.Type != "" && e.Type != EntryTypePackage {
 			return fmt.Errorf("unknown entry type %q for %q (expected \"\" or %q)", e.Type, e.Name, EntryTypePackage)
+		}
+	}
+
+	seenKits := make(map[string]bool, len(m.Kits))
+	for _, k := range m.Kits {
+		if k.Name == "" {
+			return errors.New("kit entry has empty name")
+		}
+		if seenKits[k.Name] {
+			return fmt.Errorf("duplicate kit entry name %q", k.Name)
+		}
+		if seen[k.Name] {
+			return fmt.Errorf("kit entry name %q collides with catalog entry", k.Name)
+		}
+		seenKits[k.Name] = true
+
+		kitPath := path.Clean(k.PathOrDefault())
+		if path.IsAbs(kitPath) || kitPath == "." || kitPath == ".." || strings.HasPrefix(kitPath, "../") {
+			return fmt.Errorf("kit entry %q path %q must stay under repository root", k.Name, k.PathOrDefault())
 		}
 	}
 

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -514,3 +514,93 @@ func TestEntryMaintainer(t *testing.T) {
 		t.Errorf("Maintainer() = %q, want empty string", got)
 	}
 }
+
+func TestManifestKitsValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		kits    string
+		wantErr string
+	}{
+		{
+			name: "valid default path",
+			kits: `
+kits:
+  - name: laravel-baseline
+    description: Laravel conventions
+`,
+		},
+		{
+			name: "valid explicit path",
+			kits: `
+kits:
+  - name: laravel-baseline
+    path: published/kits/laravel.yaml
+`,
+		},
+		{
+			name: "duplicate kit name",
+			kits: `
+kits:
+  - name: laravel-baseline
+  - name: laravel-baseline
+`,
+			wantErr: `duplicate kit entry name "laravel-baseline"`,
+		},
+		{
+			name: "skill name collision",
+			kits: `
+kits:
+  - name: deploy
+`,
+			wantErr: `kit entry name "deploy" collides with catalog entry`,
+		},
+		{
+			name: "absolute path rejected",
+			kits: `
+kits:
+  - name: bad
+    path: /tmp/bad.yaml
+`,
+			wantErr: `kit entry "bad" path "/tmp/bad.yaml" must stay under repository root`,
+		},
+		{
+			name: "parent path rejected",
+			kits: `
+kits:
+  - name: bad
+    path: ../bad.yaml
+`,
+			wantErr: `kit entry "bad" path "../bad.yaml" must stay under repository root`,
+		},
+	}
+
+	base := `
+apiVersion: scribe/v1
+kind: Registry
+team:
+  name: test
+catalog:
+  - name: deploy
+    source: github:owner/repo@main
+`
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := manifest.Parse([]byte(base + tt.kits))
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Parse: %v", err)
+				}
+				if len(m.Kits) != 1 {
+					t.Fatalf("kits count = %d, want 1", len(m.Kits))
+				}
+				if m.Kits[0].PathOrDefault() == "" {
+					t.Fatal("PathOrDefault empty")
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/registry/kits.go
+++ b/internal/registry/kits.go
@@ -1,0 +1,84 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Naoray/scribe/internal/kit"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/migrate"
+)
+
+type FileFetcher interface {
+	FetchFile(ctx context.Context, owner, repo, path, ref string) ([]byte, error)
+}
+
+type ManifestKit struct {
+	Registry    string
+	Name        string
+	Path        string
+	Description string
+	Author      string
+}
+
+func ListKits(ctx context.Context, client FileFetcher, registryRepo string) ([]ManifestKit, error) {
+	owner, repo, err := manifest.ParseOwnerRepo(registryRepo)
+	if err != nil {
+		return nil, err
+	}
+	m, _, err := manifest.FetchWithFallback(ctx, client, owner, repo, migrate.Convert)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ManifestKit, 0, len(m.Kits))
+	for _, entry := range m.Kits {
+		out = append(out, ManifestKit{
+			Registry:    registryRepo,
+			Name:        entry.Name,
+			Path:        entry.PathOrDefault(),
+			Description: entry.Description,
+			Author:      entry.Author,
+		})
+	}
+	return out, nil
+}
+
+func FetchKitBody(ctx context.Context, client FileFetcher, registryRepo string, entry manifest.KitEntry) (*kit.Kit, error) {
+	owner, repo, err := manifest.ParseOwnerRepo(registryRepo)
+	if err != nil {
+		return nil, err
+	}
+	path := entry.PathOrDefault()
+	raw, err := client.FetchFile(ctx, owner, repo, path, "HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("fetch kit %s:%s at %s: %w", registryRepo, entry.Name, path, err)
+	}
+	k, err := kit.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	if k.Name == "" {
+		k.Name = entry.Name
+	}
+	if k.Source == nil {
+		k.Source = &kit.Source{Registry: registryRepo}
+	}
+	return k, nil
+}
+
+func FindKit(ctx context.Context, client FileFetcher, registryRepo, name string) (manifest.KitEntry, error) {
+	owner, repo, err := manifest.ParseOwnerRepo(registryRepo)
+	if err != nil {
+		return manifest.KitEntry{}, err
+	}
+	m, _, err := manifest.FetchWithFallback(ctx, client, owner, repo, migrate.Convert)
+	if err != nil {
+		return manifest.KitEntry{}, err
+	}
+	for _, entry := range m.Kits {
+		if entry.Name == name {
+			return entry, nil
+		}
+	}
+	return manifest.KitEntry{}, fmt.Errorf("kit %q not found in registry %s", name, registryRepo)
+}


### PR DESCRIPTION
Adds phase 1 registry kit support: registry manifests can advertise kits, remote kit list/show can inspect connected registries, and kit refs now get parsed/classified without installing anything.

You can now run:

```sh
scribe kit list --remote --json
scribe kit list --registry acme/skills --json
scribe kit show acme/skills:laravel-baseline --json
```

Also added manifest validation for kit names/paths, focused resolver/ref tests, JSON schemas, docs, and changelog entry.

Tests: `go test ./...`