### PR TITLE
feat: add local registry index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - Add `visibility` to registry config as a foundation for future opt-in registry discovery; no telemetry is added.
+- Add a local public registry index at `~/.scribe/index/registries.json`, updated by connect/sync and readable with `scribe registry index --json`.
 
 ## v1.3.0 — 2026-05-09
 

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -21,6 +21,7 @@ func newRegistryCommand() *cobra.Command {
 	cmd.AddCommand(newRegistryDisableCommand())
 	cmd.AddCommand(newRegistryForgetCommand())
 	cmd.AddCommand(newRegistryResyncCommand())
+	cmd.AddCommand(newRegistryIndexCommand())
 	cmd.AddCommand(newRegistryAddCommand())
 	cmd.AddCommand(newRegistryCreateCommand())
 	cmd.AddCommand(newRegistryMigrateCommand())

--- a/cmd/registry_forget.go
+++ b/cmd/registry_forget.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/registryindex"
 )
 
 func newRegistryForgetCommand() *cobra.Command {
@@ -63,6 +66,15 @@ func forgetRegistry(repo string) error {
 	cfg.Registries = kept
 	st.ClearRegistryFailure(resolved)
 	st.ClearRemovedByRegistry(resolved)
+	if path, err := registryindex.Path(); err == nil {
+		if _, statErr := os.Stat(path); statErr == nil {
+			if err := registryindex.Remove(path, resolved); err != nil {
+				return err
+			}
+		} else if !os.IsNotExist(statErr) {
+			return statErr
+		}
+	}
 
 	if err := cfg.Save(); err != nil {
 		return err

--- a/cmd/registry_index.go
+++ b/cmd/registry_index.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/registryindex"
+)
+
+func newRegistryIndexCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "index",
+		Short: "Show cached public registry index",
+		Args:  cobra.NoArgs,
+		RunE:  runRegistryIndex,
+	}
+	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	return markJSONSupported(cmd)
+}
+
+func runRegistryIndex(cmd *cobra.Command, args []string) error {
+	path, err := registryindex.Path()
+	if err != nil {
+		return err
+	}
+	idx, err := registryindex.Load(path)
+	if err != nil {
+		return err
+	}
+
+	jsonFlag := jsonFlagPassed(cmd)
+	if jsonFlag {
+		renderer := jsonRendererForCommand(cmd, jsonFlag)
+		if err := renderer.Result(idx); err != nil {
+			return err
+		}
+		return renderer.Flush()
+	}
+
+	if len(idx.Registries) == 0 {
+		fmt.Fprintln(os.Stdout, "No public registries indexed.")
+		return nil
+	}
+	for _, entry := range idx.Registries {
+		fmt.Fprintf(os.Stdout, "%s (%d skills, %d kits)\n", entry.Repo, entry.SkillCount, entry.KitCount)
+	}
+	return nil
+}

--- a/cmd/registry_index_test.go
+++ b/cmd/registry_index_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegistryIndexJSONEnvelope(t *testing.T) {
+	home := t.TempDir()
+	indexDir := filepath.Join(home, ".scribe", "index")
+	if err := os.MkdirAll(indexDir, 0o755); err != nil {
+		t.Fatalf("mkdir index dir: %v", err)
+	}
+	data := `{
+  "version": 1,
+  "updated_at": "2026-05-11T08:42:11Z",
+  "registries": [
+    {
+      "repo": "acme/skills",
+      "source_repo": "acme/skills",
+      "visibility": "public",
+      "default_branch": "main",
+      "head_sha": "abc123",
+      "manifest_present": true,
+      "manifest": {"api_version": "scribe/v1", "kind": "Registry", "team_name": "Acme", "present": true},
+      "skill_count": 2,
+      "kit_count": 1,
+      "last_fetched_at": "2026-05-11T08:42:11Z"
+    }
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(indexDir, "registries.json"), []byte(data), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+
+	stdout, stderr, code := runScribeHelperWithHome(t, home, []string{"registry", "index", "--json"})
+	if code != 0 {
+		t.Fatalf("exit code = %d\nstderr=%s\nstdout=%s", code, stderr, stdout)
+	}
+	var env struct {
+		Data struct {
+			Registries []struct {
+				Repo       string `json:"repo"`
+				HeadSHA    string `json:"head_sha"`
+				SkillCount int    `json:"skill_count"`
+				KitCount   int    `json:"kit_count"`
+			} `json:"registries"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v\nstdout=%s", err, stdout)
+	}
+	if len(env.Data.Registries) != 1 || env.Data.Registries[0].Repo != "acme/skills" {
+		t.Fatalf("registries = %#v", env.Data.Registries)
+	}
+	if env.Data.Registries[0].HeadSHA != "abc123" || env.Data.Registries[0].SkillCount != 2 || env.Data.Registries[0].KitCount != 1 {
+		t.Fatalf("registry = %#v", env.Data.Registries[0])
+	}
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,6 +43,7 @@ Connect, create, share, and audit the skill registries this machine pulls from. 
 | `scribe registry create` | Scaffold a new registry repo on GitHub interactively |
 | `scribe registry add [name]` | Share a local skill into a connected registry |
 | `scribe registry list` | Show connected registries with skill counts |
+| `scribe registry index` | Show the local cache of public registries under `~/.scribe/index/registries.json` |
 | `scribe registry enable <repo>` / `disable <repo>` | Toggle a connected registry without forgetting it |
 | `scribe registry forget <repo>` | Disconnect a registry (does not remove already-installed skills) |
 | `scribe registry resync <repo>` | Force-fetch a registry's catalog from upstream |

--- a/docs/registry-visibility.md
+++ b/docs/registry-visibility.md
@@ -17,3 +17,17 @@ Only `public` registries are eligible for future public discovery features. `pri
 - `github` -> `unknown`
 
 Scribe does not phone home about registries in this phase. Visibility is local plumbing only.
+
+## Local Public Registry Index
+
+Scribe keeps a local-only cache of public registries at `~/.scribe/index/registries.json`. `scribe registry connect` and successful `scribe sync` runs update this file for registries whose stored visibility is `public`.
+
+The index stores public repo identity and manifest metadata:
+- repo and source repo
+- visibility
+- default branch and current head SHA
+- manifest presence, kind, and team name
+- skill and kit counts
+- last fetched timestamp
+
+`private` and `unknown` registries are skipped. If the file is missing, Scribe treats it as an empty index. If the file is corrupt, commands that read or update it report the parse error and tell the user to remove the file or reconnect public registries to rebuild.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -461,6 +461,22 @@ func (c *Client) RepositoryIsPrivate(ctx context.Context, owner, repo string) (b
 	return r.GetPrivate(), nil
 }
 
+// RepositoryDefaultBranch returns a repository's default branch.
+func (c *Client) RepositoryDefaultBranch(ctx context.Context, owner, repo string) (string, error) {
+	if c == nil || c.gh == nil {
+		return "", errors.New("github client is not initialized")
+	}
+	r, _, err := c.gh.Repositories.Get(ctx, owner, repo)
+	if err != nil {
+		return "", wrapErr(err, fmt.Sprintf("registry metadata %s/%s", owner, repo))
+	}
+	branch := r.GetDefaultBranch()
+	if branch == "" {
+		branch = "main"
+	}
+	return branch, nil
+}
+
 // LatestRelease fetches the latest published release for a repository.
 func (c *Client) LatestRelease(ctx context.Context, owner, repo string) (*github.RepositoryRelease, error) {
 	release, _, err := c.gh.Repositories.GetLatestRelease(ctx, owner, repo)

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -56,20 +56,20 @@ func (p *GitHubProvider) Discover(ctx context.Context, repo string) (*DiscoverRe
 	}
 
 	// Step 1: Try scribe.yaml.
-	entries, err := p.discoverScribeYAML(ctx, owner, repoName)
+	m, err := p.discoverScribeYAML(ctx, owner, repoName)
 	if err == nil {
-		return &DiscoverResult{Entries: entries, IsTeam: true}, nil
+		return &DiscoverResult{Entries: m.Catalog, IsTeam: true, Manifest: m}, nil
 	}
 
 	// Step 2: Try scribe.toml (legacy).
-	entries, err = p.discoverScribeTOML(ctx, owner, repoName)
+	m, err = p.discoverScribeTOML(ctx, owner, repoName)
 	if err == nil {
 		p.warn(fmt.Sprintf("%s uses legacy scribe.toml format — consider migrating to scribe.yaml", repo))
-		return &DiscoverResult{Entries: entries, IsTeam: true}, nil
+		return &DiscoverResult{Entries: m.Catalog, IsTeam: true, Manifest: m}, nil
 	}
 
 	// Step 3: Try .claude-plugin/marketplace.json.
-	entries, err = p.discoverMarketplace(ctx, owner, repoName)
+	entries, err := p.discoverMarketplace(ctx, owner, repoName)
 	if err == nil {
 		return &DiscoverResult{Entries: entries, IsTeam: false}, nil
 	}
@@ -83,7 +83,7 @@ func (p *GitHubProvider) Discover(ctx context.Context, repo string) (*DiscoverRe
 	return nil, fmt.Errorf("%s: no skills found (looked for scribe.yaml, scribe.toml, marketplace.json, and SKILL.md files)", repo)
 }
 
-func (p *GitHubProvider) discoverScribeYAML(ctx context.Context, owner, repo string) ([]manifest.Entry, error) {
+func (p *GitHubProvider) discoverScribeYAML(ctx context.Context, owner, repo string) (*manifest.Manifest, error) {
 	raw, err := p.client.FetchFile(ctx, owner, repo, manifest.ManifestFilename, "HEAD")
 	if err != nil {
 		return nil, err
@@ -92,10 +92,10 @@ func (p *GitHubProvider) discoverScribeYAML(ctx context.Context, owner, repo str
 	if err != nil {
 		return nil, err
 	}
-	return m.Catalog, nil
+	return m, nil
 }
 
-func (p *GitHubProvider) discoverScribeTOML(ctx context.Context, owner, repo string) ([]manifest.Entry, error) {
+func (p *GitHubProvider) discoverScribeTOML(ctx context.Context, owner, repo string) (*manifest.Manifest, error) {
 	raw, err := p.client.FetchFile(ctx, owner, repo, manifest.LegacyManifestFilename, "HEAD")
 	if err != nil {
 		return nil, err
@@ -104,7 +104,7 @@ func (p *GitHubProvider) discoverScribeTOML(ctx context.Context, owner, repo str
 	if err != nil {
 		return nil, err
 	}
-	return m.Catalog, nil
+	return m, nil
 }
 
 func (p *GitHubProvider) discoverMarketplace(ctx context.Context, owner, repo string) ([]manifest.Entry, error) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -13,8 +13,9 @@ type File = tools.SkillFile
 
 // DiscoverResult holds the output of a Discover call.
 type DiscoverResult struct {
-	Entries []manifest.Entry
-	IsTeam  bool // true if discovery found a scribe.yaml/toml with a team section
+	Entries  []manifest.Entry
+	IsTeam   bool // true if discovery found a scribe.yaml/toml with a team section
+	Manifest *manifest.Manifest
 }
 
 // Provider abstracts how skills are discovered and fetched from a repository.

--- a/internal/registryindex/index.go
+++ b/internal/registryindex/index.go
@@ -1,0 +1,212 @@
+package registryindex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/paths"
+)
+
+const Version = 1
+
+type MetadataClient interface {
+	RepositoryDefaultBranch(ctx context.Context, owner, repo string) (string, error)
+	LatestCommitSHA(ctx context.Context, owner, repo, branch string) (string, error)
+}
+
+type ManifestMetadata struct {
+	APIVersion string `json:"api_version,omitempty"`
+	Kind       string `json:"kind,omitempty"`
+	TeamName   string `json:"team_name,omitempty"`
+	Present    bool   `json:"present"`
+}
+
+type Registry struct {
+	Repo            string           `json:"repo"`
+	SourceRepo      string           `json:"source_repo"`
+	Visibility      string           `json:"visibility"`
+	DefaultBranch   string           `json:"default_branch,omitempty"`
+	HeadSHA         string           `json:"head_sha,omitempty"`
+	ManifestPresent bool             `json:"manifest_present"`
+	Manifest        ManifestMetadata `json:"manifest"`
+	SkillCount      int              `json:"skill_count"`
+	KitCount        int              `json:"kit_count"`
+	LastFetchedAt   time.Time        `json:"last_fetched_at"`
+	Tags            []string         `json:"tags,omitempty"`
+}
+
+type Index struct {
+	Version    int        `json:"version"`
+	UpdatedAt  time.Time  `json:"updated_at"`
+	Registries []Registry `json:"registries"`
+}
+
+func Path() (string, error) {
+	dir, err := paths.ScribeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "index", "registries.json"), nil
+}
+
+func Load(path string) (*Index, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return emptyIndex(), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read registry index %s: %w", path, err)
+	}
+	var idx Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, fmt.Errorf("parse registry index %s: %w (remove the file or reconnect public registries to rebuild)", path, err)
+	}
+	if idx.Version == 0 {
+		idx.Version = Version
+	}
+	if idx.Registries == nil {
+		idx.Registries = []Registry{}
+	}
+	return &idx, nil
+}
+
+func Save(path string, idx *Index) error {
+	if idx == nil {
+		idx = emptyIndex()
+	}
+	idx.Version = Version
+	idx.UpdatedAt = time.Now().UTC()
+	sort.Slice(idx.Registries, func(i, j int) bool {
+		return idx.Registries[i].Repo < idx.Registries[j].Repo
+	})
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create registry index dir: %w", err)
+	}
+	data, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode registry index: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".registries.json.*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp registry index: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp registry index: %w", err)
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp registry index: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp registry index: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("save registry index: %w", err)
+	}
+	return nil
+}
+
+func Upsert(path string, entry Registry) error {
+	idx, err := Load(path)
+	if err != nil {
+		return err
+	}
+	entry.Visibility = config.NormalizeRegistryVisibility(entry.Visibility)
+	if entry.Visibility != config.RegistryVisibilityPublic {
+		idx.remove(entry.Repo)
+		return Save(path, idx)
+	}
+	if entry.SourceRepo == "" {
+		entry.SourceRepo = entry.Repo
+	}
+	if entry.LastFetchedAt.IsZero() {
+		entry.LastFetchedAt = time.Now().UTC()
+	}
+	for i := range idx.Registries {
+		if idx.Registries[i].Repo == entry.Repo {
+			idx.Registries[i] = entry
+			return Save(path, idx)
+		}
+	}
+	idx.Registries = append(idx.Registries, entry)
+	return Save(path, idx)
+}
+
+func Remove(path, repo string) error {
+	idx, err := Load(path)
+	if err != nil {
+		return err
+	}
+	idx.remove(repo)
+	return Save(path, idx)
+}
+
+func BuildEntry(ctx context.Context, rc config.RegistryConfig, m *manifest.Manifest, client MetadataClient) (Registry, error) {
+	rc.Normalize()
+	entry := Registry{
+		Repo:            rc.Repo,
+		SourceRepo:      rc.Repo,
+		Visibility:      rc.Visibility,
+		ManifestPresent: m != nil,
+		LastFetchedAt:   time.Now().UTC(),
+	}
+	if m != nil {
+		entry.Manifest = ManifestMetadata{
+			APIVersion: m.APIVersion,
+			Kind:       m.Kind,
+			Present:    true,
+		}
+		if m.Team != nil {
+			entry.Manifest.TeamName = m.Team.Name
+		}
+		entry.SkillCount = len(m.Catalog)
+		entry.KitCount = len(m.Kits)
+	}
+	if client != nil {
+		owner, repo, err := manifest.ParseOwnerRepo(rc.Repo)
+		if err == nil {
+			branch, metaErr := client.RepositoryDefaultBranch(ctx, owner, repo)
+			if metaErr != nil {
+				return Registry{}, metaErr
+			}
+			entry.DefaultBranch = branch
+			if branch != "" {
+				sha, shaErr := client.LatestCommitSHA(ctx, owner, repo, branch)
+				if shaErr != nil {
+					return Registry{}, shaErr
+				}
+				entry.HeadSHA = sha
+			}
+		}
+	}
+	return entry, nil
+}
+
+func emptyIndex() *Index {
+	return &Index{Version: Version, Registries: []Registry{}}
+}
+
+func (idx *Index) remove(repo string) {
+	kept := idx.Registries[:0]
+	for _, entry := range idx.Registries {
+		if entry.Repo != repo {
+			kept = append(kept, entry)
+		}
+	}
+	idx.Registries = kept
+}

--- a/internal/registryindex/index_test.go
+++ b/internal/registryindex/index_test.go
@@ -1,0 +1,113 @@
+package registryindex
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/manifest"
+)
+
+type metadataClient struct{}
+
+func (metadataClient) RepositoryDefaultBranch(context.Context, string, string) (string, error) {
+	return "main", nil
+}
+
+func (metadataClient) LatestCommitSHA(context.Context, string, string, string) (string, error) {
+	return "abc123", nil
+}
+
+func TestUpsertWritesAndReadsPublicRegistry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "index", "registries.json")
+	entry := Registry{
+		Repo:          "acme/skills",
+		SourceRepo:    "acme/skills",
+		Visibility:    config.RegistryVisibilityPublic,
+		DefaultBranch: "main",
+		HeadSHA:       "abc123",
+		SkillCount:    2,
+		KitCount:      1,
+		LastFetchedAt: time.Now().UTC(),
+	}
+	if err := Upsert(path, entry); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	idx, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(idx.Registries) != 1 {
+		t.Fatalf("registries len = %d, want 1", len(idx.Registries))
+	}
+	got := idx.Registries[0]
+	if got.Repo != "acme/skills" || got.HeadSHA != "abc123" || got.SkillCount != 2 || got.KitCount != 1 {
+		t.Fatalf("registry = %#v", got)
+	}
+	if matches, _ := filepath.Glob(filepath.Join(filepath.Dir(path), "*.tmp")); len(matches) != 0 {
+		t.Fatalf("temp files left behind: %v", matches)
+	}
+}
+
+func TestUpsertSkipsNonPublicRegistry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "registries.json")
+	if err := Upsert(path, Registry{Repo: "acme/private", Visibility: config.RegistryVisibilityPrivate}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	idx, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(idx.Registries) != 0 {
+		t.Fatalf("registries len = %d, want 0", len(idx.Registries))
+	}
+}
+
+func TestLoadMissingAndCorruptIndex(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "missing.json")
+	idx, err := Load(missing)
+	if err != nil {
+		t.Fatalf("Load missing: %v", err)
+	}
+	if idx.Version != Version || len(idx.Registries) != 0 {
+		t.Fatalf("missing index = %#v", idx)
+	}
+
+	corrupt := filepath.Join(dir, "corrupt.json")
+	if err := os.WriteFile(corrupt, []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write corrupt: %v", err)
+	}
+	if _, err := Load(corrupt); err == nil {
+		t.Fatal("Load corrupt error = nil")
+	}
+}
+
+func TestBuildEntryCopiesManifestMetadata(t *testing.T) {
+	m := &manifest.Manifest{
+		APIVersion: "scribe/v1",
+		Kind:       "Registry",
+		Team:       &manifest.Team{Name: "Acme"},
+		Catalog: []manifest.Entry{
+			{Name: "deploy"},
+			{Name: "review"},
+		},
+		Kits: []manifest.KitEntry{{Name: "ops"}},
+	}
+	entry, err := BuildEntry(context.Background(), config.RegistryConfig{
+		Repo:       "acme/skills",
+		Visibility: config.RegistryVisibilityPublic,
+	}, m, metadataClient{})
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+	if !entry.ManifestPresent || !entry.Manifest.Present || entry.Manifest.TeamName != "Acme" {
+		t.Fatalf("manifest metadata = %#v", entry.Manifest)
+	}
+	if entry.SkillCount != 2 || entry.KitCount != 1 || entry.HeadSHA != "abc123" {
+		t.Fatalf("entry = %#v", entry)
+	}
+}

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -86,6 +86,10 @@ type Syncer struct {
 	// real directory already exists at the original tool projection path.
 	AliasName string
 
+	// OnRegistryFetched runs after a registry manifest has been fetched and
+	// applied successfully. Callers use this for local metadata caches.
+	OnRegistryFetched func(repo string, m *manifest.Manifest) error
+
 	// NameConflictResolver is called when a real directory already exists at
 	// the incoming skill name. Nil means non-interactive conflict.
 	NameConflictResolver func(NameConflict) (NameConflictResolution, error)
@@ -294,7 +298,7 @@ func (s *Syncer) Run(ctx context.Context, teamRepo string, st *state.State) erro
 		s.emit(SkillErrorMsg{Name: "<migration>", Err: fmt.Errorf("reclassify legacy packages: %w", err)})
 	}
 
-	statuses, _, err := s.Diff(ctx, teamRepo, st)
+	statuses, m, err := s.Diff(ctx, teamRepo, st)
 	if err != nil {
 		return fmt.Errorf("sync %s: %w", teamRepo, err)
 	}
@@ -334,7 +338,15 @@ func (s *Syncer) Run(ctx context.Context, teamRepo string, st *state.State) erro
 		}
 		applyLockPins(statuses, lf)
 	}
-	return s.apply(ctx, teamRepo, statuses, st)
+	if err := s.apply(ctx, teamRepo, statuses, st); err != nil {
+		return err
+	}
+	if s.OnRegistryFetched != nil {
+		if err := s.OnRegistryFetched(teamRepo, m); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *Syncer) RunProject(ctx context.Context, st *state.State, lf *lockfile.ProjectLockfile) error {

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -9,6 +9,7 @@ import (
 	gh "github.com/Naoray/scribe/internal/github"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/registryindex"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
@@ -59,6 +60,7 @@ type Bag struct {
 	State         *state.State
 	Client        *gh.Client
 	Visibility    RepositoryVisibilityClient
+	RegistryIndex registryindex.MetadataClient
 	Tools         []tools.Tool
 	ProjectRoot   string
 	TeamShareMode bool

--- a/internal/workflow/connect.go
+++ b/internal/workflow/connect.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/registryindex"
 )
 
 // ConnectSteps returns the step list for the connect command.
@@ -46,6 +47,7 @@ func connectBaseSteps(loadConfig bool) []Step {
 		Step{Name: "ValidateManifest", Fn: StepValidateManifest},
 		Step{Name: "InferRegistryType", Fn: StepInferRegistryType},
 		Step{Name: "SaveConfig", Fn: StepSaveConfig},
+		Step{Name: "IndexPublicRegistry", Fn: StepIndexPublicRegistry},
 	)
 	return steps
 }
@@ -81,15 +83,19 @@ func StepFetchManifest(ctx context.Context, b *Bag) error {
 		return fmt.Errorf("could not discover skills in %s: %w", b.RepoArg, err)
 	}
 
-	// Build a minimal manifest from discovered entries.
-	b.manifest = &manifest.Manifest{
-		APIVersion: "scribe/v1",
-		Kind:       "Registry",
-		Catalog:    result.Entries,
-	}
-	// Only set Team if discovery found an actual team manifest (scribe.yaml/toml).
-	if result.IsTeam {
-		b.manifest.Team = &manifest.Team{Name: b.RepoArg}
+	if result.Manifest != nil {
+		b.manifest = result.Manifest
+	} else {
+		// Build a minimal manifest from discovered entries.
+		b.manifest = &manifest.Manifest{
+			APIVersion: "scribe/v1",
+			Kind:       "Registry",
+			Catalog:    result.Entries,
+		}
+		// Only set Team if discovery found an actual team manifest (scribe.yaml/toml).
+		if result.IsTeam {
+			b.manifest.Team = &manifest.Team{Name: b.RepoArg}
+		}
 	}
 	return nil
 }
@@ -150,6 +156,36 @@ func StepSaveConfig(_ context.Context, b *Bag) error {
 		return fmt.Errorf("save config: %w", err)
 	}
 	b.Formatter.OnConnectSaved(b.RepoArg)
+	return nil
+}
+
+func StepIndexPublicRegistry(ctx context.Context, b *Bag) error {
+	return updateRegistryIndex(ctx, b, b.RepoArg, b.manifest)
+}
+
+func updateRegistryIndex(ctx context.Context, b *Bag, repo string, m *manifest.Manifest) error {
+	if b == nil || b.Config == nil {
+		return nil
+	}
+	rc := b.Config.FindRegistry(repo)
+	if rc == nil {
+		return nil
+	}
+	rc.Normalize()
+	if !rc.IsPublic() {
+		return nil
+	}
+	path, err := registryindex.Path()
+	if err != nil {
+		return err
+	}
+	entry, err := registryindex.BuildEntry(ctx, *rc, m, b.RegistryIndex)
+	if err != nil {
+		return fmt.Errorf("update registry index for %s: %w", repo, err)
+	}
+	if err := registryindex.Upsert(path, entry); err != nil {
+		return fmt.Errorf("update registry index for %s: %w", repo, err)
+	}
 	return nil
 }
 

--- a/internal/workflow/connect_test.go
+++ b/internal/workflow/connect_test.go
@@ -2,7 +2,10 @@ package workflow_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/Naoray/scribe/internal/config"
@@ -13,10 +16,18 @@ import (
 )
 
 type connectTestProvider struct {
-	isTeam bool
+	isTeam   bool
+	manifest *manifest.Manifest
 }
 
 func (p connectTestProvider) Discover(context.Context, string) (*provider.DiscoverResult, error) {
+	if p.manifest != nil {
+		return &provider.DiscoverResult{
+			IsTeam:   p.isTeam,
+			Entries:  p.manifest.Catalog,
+			Manifest: p.manifest,
+		}, nil
+	}
 	return &provider.DiscoverResult{
 		IsTeam: p.isTeam,
 		Entries: []manifest.Entry{
@@ -38,11 +49,100 @@ func (c connectVisibilityClient) RepositoryIsPrivate(context.Context, string, st
 	return c.private, c.err
 }
 
+type connectIndexClient struct{}
+
+func (connectIndexClient) RepositoryDefaultBranch(context.Context, string, string) (string, error) {
+	return "main", nil
+}
+
+func (connectIndexClient) LatestCommitSHA(context.Context, string, string, string) (string, error) {
+	return "abc123", nil
+}
+
 func TestConnectSteps_EndsWithShowAvailable(t *testing.T) {
 	steps := workflow.ConnectSteps()
 	last := steps[len(steps)-1]
 	if last.Name != "ShowAvailable" {
 		t.Errorf("expected last step ShowAvailable, got %s (connect must not auto-install)", last.Name)
+	}
+}
+
+func TestStepIndexPublicRegistryWritesLocalIndex(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	bag := &workflow.Bag{
+		Config: &config.Config{},
+		Provider: connectTestProvider{
+			isTeam: true,
+			manifest: &manifest.Manifest{
+				APIVersion: "scribe/v1",
+				Kind:       "Registry",
+				Team:       &manifest.Team{Name: "Acme"},
+				Catalog:    []manifest.Entry{{Name: "deploy"}, {Name: "review"}},
+				Kits:       []manifest.KitEntry{{Name: "ops"}},
+			},
+		},
+		Visibility:    connectVisibilityClient{private: false},
+		RegistryIndex: connectIndexClient{},
+		RepoArg:       "acme/skills",
+	}
+
+	for _, step := range []func(context.Context, *workflow.Bag) error{
+		workflow.StepFetchManifest,
+		workflow.StepValidateManifest,
+		workflow.StepInferRegistryType,
+		workflow.StepIndexPublicRegistry,
+	} {
+		if err := step(context.Background(), bag); err != nil {
+			t.Fatalf("step failed: %v", err)
+		}
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".scribe", "index", "registries.json"))
+	if err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+	var idx struct {
+		Registries []struct {
+			Repo       string `json:"repo"`
+			HeadSHA    string `json:"head_sha"`
+			SkillCount int    `json:"skill_count"`
+			KitCount   int    `json:"kit_count"`
+		} `json:"registries"`
+	}
+	if err := json.Unmarshal(data, &idx); err != nil {
+		t.Fatalf("unmarshal index: %v", err)
+	}
+	if len(idx.Registries) != 1 || idx.Registries[0].Repo != "acme/skills" {
+		t.Fatalf("registries = %#v", idx.Registries)
+	}
+	if idx.Registries[0].HeadSHA != "abc123" || idx.Registries[0].SkillCount != 2 || idx.Registries[0].KitCount != 1 {
+		t.Fatalf("registry = %#v", idx.Registries[0])
+	}
+}
+
+func TestStepIndexPublicRegistrySkipsPrivateAndUnknown(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	for _, visibility := range []string{config.RegistryVisibilityPrivate, config.RegistryVisibilityUnknown} {
+		t.Run(visibility, func(t *testing.T) {
+			bag := &workflow.Bag{
+				Config: &config.Config{Registries: []config.RegistryConfig{{
+					Repo:       "acme/skills",
+					Enabled:    true,
+					Visibility: visibility,
+				}}},
+				RepoArg: "acme/skills",
+			}
+			if err := workflow.StepIndexPublicRegistry(context.Background(), bag); err != nil {
+				t.Fatalf("StepIndexPublicRegistry: %v", err)
+			}
+		})
+	}
+	if _, err := os.Stat(filepath.Join(home, ".scribe", "index", "registries.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("index stat error = %v, want not exist", err)
 	}
 }
 

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -23,6 +23,7 @@ import (
 	gh "github.com/Naoray/scribe/internal/github"
 	"github.com/Naoray/scribe/internal/kit"
 	"github.com/Naoray/scribe/internal/lockfile"
+	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/paths"
 	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/projectstore"
@@ -711,6 +712,9 @@ func StepLoadConfig(ctx context.Context, b *Bag) error {
 	if b.Visibility == nil {
 		b.Visibility = b.Client
 	}
+	if b.RegistryIndex == nil {
+		b.RegistryIndex = b.Client
+	}
 
 	return nil
 }
@@ -884,6 +888,9 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 		KitFilterEnabled: b.KitFilterEnabled,
 		ProjectRoot:      b.ProjectRoot,
 		SkipMissing:      workflowSkipMissing(b),
+		OnRegistryFetched: func(repo string, m *manifest.Manifest) error {
+			return updateRegistryIndex(ctx, b, repo, m)
+		},
 		Emit: func(msg any) {
 			switch m := msg.(type) {
 			case sync.SkillResolvedMsg:


### PR DESCRIPTION
Adds the phase 1 local registry index for public registries.

What changed:
- write `~/.scribe/index/registries.json` with public registry repo identity, manifest metadata, skill/kit counts, default branch, head SHA, and fetch timestamp
- update the index after public `registry connect` and successful `sync`; private/unknown registries skip the index path
- add `scribe registry index --json` for inspecting the local cache
- handle missing index files as empty and corrupt files with an actionable rebuild error
- document the local-only privacy boundary

Tests:
- `go test ./internal/registryindex ./internal/provider ./internal/workflow ./cmd`
- `go test ./...`
