### PR TITLE
feat: install registry kits

### DIFF
--- a/cmd/kit.go
+++ b/cmd/kit.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,16 +9,23 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/Naoray/scribe/internal/app"
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/cli/fields"
 	"github.com/Naoray/scribe/internal/cli/output"
 	"github.com/Naoray/scribe/internal/config"
+	gh "github.com/Naoray/scribe/internal/github"
 	"github.com/Naoray/scribe/internal/kit"
+	"github.com/Naoray/scribe/internal/lockfile"
+	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/paths"
 	"github.com/Naoray/scribe/internal/registry"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/workflow"
 )
 
 type kitCreateOptions struct {
@@ -32,6 +40,12 @@ type kitCreateOptions struct {
 type kitListOptions struct {
 	remote   bool
 	registry string
+}
+
+type kitInstallOptions struct {
+	alias  string
+	noDeps bool
+	json   bool
 }
 
 type kitCreateOutput struct {
@@ -66,6 +80,15 @@ type kitShowOutput struct {
 	Refs        []kitRefOutput   `json:"refs,omitempty"`
 }
 
+type kitInstallOutput struct {
+	Name            string         `json:"name"`
+	Registry        string         `json:"registry"`
+	Path            string         `json:"path"`
+	Rev             string         `json:"rev"`
+	SkillsInstalled []string       `json:"skills_installed,omitempty"`
+	MissingRefs     []kitRefOutput `json:"missing_refs,omitempty"`
+}
+
 type kitSourceOutput struct {
 	Registry string `json:"registry"`
 	Rev      string `json:"rev,omitempty"`
@@ -86,6 +109,18 @@ type kitRefOutput struct {
 var listRemoteKitsFn = registry.ListKits
 var findRemoteKitFn = registry.FindKit
 var fetchRemoteKitFn = registry.FetchKitBody
+var runKitInstallDepsFn = runKitInstallDeps
+var remoteKitRevFn = func(ctx context.Context, client *gh.Client, registryRepo string) (string, error) {
+	owner, repo, err := manifest.ParseOwnerRepo(registryRepo)
+	if err != nil {
+		return "", err
+	}
+	sha, err := client.LatestCommitSHA(ctx, owner, repo, "main")
+	if err != nil {
+		return "HEAD", nil
+	}
+	return sha, nil
+}
 
 var kitListFieldSet = fields.FieldSet[kitListItem]{
 	"name": func(item kitListItem) any {
@@ -116,6 +151,7 @@ func newKitCommand() *cobra.Command {
 	cmd.AddCommand(newKitCreateCommand())
 	cmd.AddCommand(newKitListCommand())
 	cmd.AddCommand(newKitShowCommand())
+	cmd.AddCommand(newKitInstallCommand())
 	return cmd
 }
 
@@ -164,6 +200,23 @@ func newKitShowCommand() *cobra.Command {
 		RunE:  runKitShow,
 	}
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	return markJSONSupported(cmd)
+}
+
+func newKitInstallCommand() *cobra.Command {
+	opts := &kitInstallOptions{}
+	cmd := &cobra.Command{
+		Use:   "install <registry>:<kit>",
+		Short: "Install a kit from a connected registry",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.json = jsonFlagPassed(cmd)
+			return runKitInstall(cmd, args[0], opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.alias, "alias", "", "Install incoming kit under this local name")
+	cmd.Flags().BoolVar(&opts.noDeps, "no-deps", false, "Install kit body without installing same-registry skills")
+	cmd.Flags().BoolVar(&opts.json, "json", false, "Output machine-readable JSON")
 	return markJSONSupported(cmd)
 }
 
@@ -304,6 +357,202 @@ func runKitShow(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(cmd.OutOrStdout(), "Skills (%d): %s\n", len(out.Skills), strings.Join(out.Skills, ", "))
 	fmt.Fprintf(cmd.OutOrStdout(), "Source: %s\n", kitSourceLabel(out.Source))
 	return nil
+}
+
+func runKitInstall(cmd *cobra.Command, ref string, opts *kitInstallOptions) error {
+	if opts == nil {
+		opts = &kitInstallOptions{}
+	}
+	registryRepo, kitName, err := parseSkillRef(ref)
+	if err != nil {
+		return err
+	}
+	if opts.alias != "" {
+		if err := validateKitName(opts.alias); err != nil {
+			return err
+		}
+	}
+	localName := kitName
+	if opts.alias != "" {
+		localName = opts.alias
+	}
+	factory := commandFactory()
+	cfg, err := factory.Config()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	if !registryConnected(cfg, registryRepo) {
+		return clierrors.Wrap(fmt.Errorf("registry %q is not connected", registryRepo), "REGISTRY_NOT_CONNECTED", clierrors.ExitNotFound,
+			clierrors.WithResource(registryRepo),
+			clierrors.WithRemediation("Run `scribe registry connect "+registryRepo+"` first."),
+		)
+	}
+	client, err := factory.Client()
+	if err != nil {
+		return fmt.Errorf("load github client: %w", err)
+	}
+	entry, err := findRemoteKitFn(cmd.Context(), client, registryRepo, kitName)
+	if err != nil {
+		return clierrors.Wrap(err, "KIT_NOT_FOUND", clierrors.ExitNotFound,
+			clierrors.WithResource(ref),
+			clierrors.WithRemediation("Run `scribe kit list --remote --registry "+registryRepo+"`."),
+		)
+	}
+	k, err := fetchRemoteKitFn(cmd.Context(), client, registryRepo, entry)
+	if err != nil {
+		return err
+	}
+	if k.Name == "" {
+		k.Name = kitName
+	}
+	k.Name = localName
+	rev, err := remoteKitRevFn(cmd.Context(), client, registryRepo)
+	if err != nil {
+		return err
+	}
+	if k.Source == nil {
+		k.Source = &kit.Source{}
+	}
+	k.Source.Registry = registryRepo
+	k.Source.Rev = rev
+
+	sameRegistry, missingRefs, err := installableKitRefs(k.Skills, registryRepo, cfg)
+	if err != nil {
+		return err
+	}
+	if !opts.noDeps && len(sameRegistry) > 0 {
+		if err := runKitInstallDepsFn(cmd, factory, registryRepo, sameRegistry); err != nil {
+			return err
+		}
+	}
+
+	scribeDir, err := paths.ScribeDir()
+	if err != nil {
+		return fmt.Errorf("resolve scribe dir: %w", err)
+	}
+	kitPath := filepath.Join(scribeDir, "kits", localName+".yaml")
+	if err := kit.Save(kitPath, k); err != nil {
+		return err
+	}
+	contentHash, err := hashKitFile(localName, kitPath)
+	if err != nil {
+		return err
+	}
+	st, err := factory.State()
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
+	recordInstalledKit(st, localName, registryRepo, rev, contentHash, k.Skills)
+	if err := st.Save(); err != nil {
+		return err
+	}
+
+	out := kitInstallOutput{
+		Name:            localName,
+		Registry:        registryRepo,
+		Path:            kitPath,
+		Rev:             rev,
+		SkillsInstalled: sameRegistry,
+		MissingRefs:     missingRefs,
+	}
+	if opts.json {
+		r := jsonRendererForCommand(cmd, true)
+		if err := r.Result(out); err != nil {
+			return err
+		}
+		return r.Flush()
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Installed kit %s from %s\n", localName, registryRepo)
+	if len(sameRegistry) > 0 && !opts.noDeps {
+		fmt.Fprintf(cmd.OutOrStdout(), "Installed skills: %s\n", strings.Join(sameRegistry, ", "))
+	}
+	for _, missing := range missingRefs {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: deferred %s (%s)\n", missing.Raw, missing.Reason)
+	}
+	return nil
+}
+
+func installableKitRefs(rawRefs []string, registryRepo string, cfg *config.Config) ([]string, []kitRefOutput, error) {
+	var same []string
+	var missing []kitRefOutput
+	seen := map[string]bool{}
+	for _, raw := range rawRefs {
+		ref, err := kit.ParseSkillRef(raw, registryRepo)
+		if err != nil {
+			missing = append(missing, kitRefOutput{Raw: raw, Reason: err.Error()})
+			continue
+		}
+		if ref.Local {
+			missing = append(missing, kitRefOutput{Raw: raw, Skill: ref.Skill, Origin: string(kit.OriginLocal), Local: true, Reason: "local_ref_forbidden"})
+			continue
+		}
+		if ref.Registry != registryRepo {
+			reason := "cross_registry_deferred"
+			if !registryConnected(cfg, ref.Registry) {
+				reason = "registry_not_connected"
+			}
+			missing = append(missing, kitRefOutput{
+				Raw:       raw,
+				Skill:     ref.Skill,
+				Origin:    string(kit.OriginCrossRegistry),
+				Registry:  ref.Registry,
+				Connected: registryConnected(cfg, ref.Registry),
+				Glob:      ref.Glob,
+				Reason:    reason,
+			})
+			continue
+		}
+		if ref.Glob {
+			missing = append(missing, kitRefOutput{Raw: raw, Skill: ref.Skill, Origin: string(kit.OriginSameRegistry), Registry: registryRepo, Connected: true, Glob: true, Reason: "glob_deferred"})
+			continue
+		}
+		if !seen[ref.Skill] {
+			seen[ref.Skill] = true
+			same = append(same, ref.Skill)
+		}
+	}
+	sort.Strings(same)
+	return same, missing, nil
+}
+
+func runKitInstallDeps(cmd *cobra.Command, factory *app.Factory, registryRepo string, skillNames []string) error {
+	if len(skillNames) == 0 {
+		return nil
+	}
+	bag := &workflow.Bag{
+		Args:             skillNames,
+		RepoFlag:         registryRepo,
+		Factory:          factory,
+		FilterRegistries: filterRegistries,
+	}
+	if err := workflow.Run(cmd.Context(), workflow.InstallSteps(), bag); err != nil {
+		return handleNameConflictError(cmd, err)
+	}
+	return saveWorkflowState(bag)
+}
+
+func recordInstalledKit(st *state.State, name, registryRepo, rev, contentHash string, skills []string) {
+	if st.Kits == nil {
+		st.Kits = map[string]state.InstalledKit{}
+	}
+	st.Kits[name] = state.InstalledKit{
+		Name:           name,
+		SourceRegistry: registryRepo,
+		Rev:            rev,
+		ContentHash:    contentHash,
+		InstalledAt:    time.Now().UTC(),
+		Source:         registryRepo,
+		Version:        rev,
+		Skills:         append([]string(nil), skills...),
+	}
+}
+
+func hashKitFile(name, path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return lockfile.HashFiles([]lockfile.File{{Path: name + ".yaml", Content: data}})
 }
 
 func remoteKitListItems(cmd *cobra.Command, opts *kitListOptions, local map[string]*kit.Kit) ([]kitListItem, error) {

--- a/cmd/kit_install_test.go
+++ b/cmd/kit_install_test.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/app"
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/Naoray/scribe/internal/config"
+	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/kit"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/registry"
+	"github.com/Naoray/scribe/internal/state"
+)
+
+func TestKitInstallWritesKitStateAndInstallsSameRegistryDeps(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	oldFactory := commandFactory
+	oldFind := findRemoteKitFn
+	oldFetch := fetchRemoteKitFn
+	oldRev := remoteKitRevFn
+	oldDeps := runKitInstallDepsFn
+	t.Cleanup(func() {
+		commandFactory = oldFactory
+		findRemoteKitFn = oldFind
+		fetchRemoteKitFn = oldFetch
+		remoteKitRevFn = oldRev
+		runKitInstallDepsFn = oldDeps
+	})
+
+	st := stateFixture(t, home)
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) {
+				return &config.Config{Registries: []config.RegistryConfig{
+					{Repo: "acme/skills", Enabled: true},
+					{Repo: "other/skills", Enabled: true},
+				}}, nil
+			},
+			State: func() (*state.State, error) {
+				return st, nil
+			},
+			Client: func() (*gh.Client, error) {
+				return gh.NewClient(context.Background(), ""), nil
+			},
+		}
+	}
+	findRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, _, name string) (manifest.KitEntry, error) {
+		return manifest.KitEntry{Name: name, Path: "kits/" + name + ".yaml"}, nil
+	}
+	fetchRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, registryRepo string, entry manifest.KitEntry) (*kit.Kit, error) {
+		return &kit.Kit{
+			Name:        entry.Name,
+			Description: "Baseline",
+			Skills:      []string{"tdd", "other/skills:debugging", "missing/skills:qa"},
+			Source:      &kit.Source{Registry: registryRepo},
+		}, nil
+	}
+	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) {
+		return "abc123", nil
+	}
+	var gotRegistry string
+	var gotDeps []string
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, registryRepo string, skillNames []string) error {
+		gotRegistry = registryRepo
+		gotDeps = append([]string(nil), skillNames...)
+		return nil
+	}
+
+	cmd := newKitInstallCommand()
+	cmd.SetArgs([]string{"acme/skills:baseline", "--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("kit install: %v", err)
+	}
+	if gotRegistry != "acme/skills" || !reflect.DeepEqual(gotDeps, []string{"tdd"}) {
+		t.Fatalf("deps registry=%q deps=%v", gotRegistry, gotDeps)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".scribe", "kits", "baseline.yaml")); err != nil {
+		t.Fatalf("installed kit missing: %v", err)
+	}
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	installed := loaded.Kits["baseline"]
+	if installed.SourceRegistry != "acme/skills" || installed.Rev != "abc123" || installed.ContentHash == "" {
+		t.Fatalf("installed kit state = %+v", installed)
+	}
+
+	var env testEnvelope
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v\n%s", err, out.String())
+	}
+	var data struct {
+		MissingRefs []struct {
+			Raw    string `json:"raw"`
+			Reason string `json:"reason"`
+		} `json:"missing_refs"`
+	}
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if len(data.MissingRefs) != 2 {
+		t.Fatalf("missing refs = %#v", data.MissingRefs)
+	}
+	if data.MissingRefs[0].Reason != "cross_registry_deferred" || data.MissingRefs[1].Reason != "registry_not_connected" {
+		t.Fatalf("missing refs = %#v", data.MissingRefs)
+	}
+}
+
+func TestKitInstallMissingRegistry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	oldFactory := commandFactory
+	t.Cleanup(func() { commandFactory = oldFactory })
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) { return &config.Config{}, nil },
+		}
+	}
+
+	cmd := newKitInstallCommand()
+	cmd.SetArgs([]string{"acme/skills:baseline"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := clierrors.ExitCode(err); got != clierrors.ExitNotFound {
+		t.Fatalf("exit = %d, want %d; err=%v", got, clierrors.ExitNotFound, err)
+	}
+}
+
+func TestKitInstallMissingKit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	oldFactory := commandFactory
+	oldFind := findRemoteKitFn
+	t.Cleanup(func() {
+		commandFactory = oldFactory
+		findRemoteKitFn = oldFind
+	})
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) {
+				return &config.Config{Registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}}}, nil
+			},
+			Client: func() (*gh.Client, error) {
+				return gh.NewClient(context.Background(), ""), nil
+			},
+		}
+	}
+	findRemoteKitFn = func(context.Context, registry.FileFetcher, string, string) (manifest.KitEntry, error) {
+		return manifest.KitEntry{}, os.ErrNotExist
+	}
+
+	cmd := newKitInstallCommand()
+	cmd.SetArgs([]string{"acme/skills:missing"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := clierrors.ExitCode(err); got != clierrors.ExitNotFound {
+		t.Fatalf("exit = %d, want %d; err=%v", got, clierrors.ExitNotFound, err)
+	}
+}

--- a/cmd/kit_schema.go
+++ b/cmd/kit_schema.go
@@ -63,7 +63,38 @@ const kitShowOutputSchema = `{
   }
 }`
 
+const kitInstallOutputSchema = `{
+  "type": "object",
+  "required": ["name", "registry", "path", "rev"],
+  "properties": {
+    "name": {"type": "string"},
+    "registry": {"type": "string"},
+    "path": {"type": "string"},
+    "rev": {"type": "string"},
+    "skills_installed": {"type": "array", "items": {"type": "string"}},
+    "missing_refs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["raw", "reason"],
+        "properties": {
+          "raw": {"type": "string"},
+          "skill": {"type": "string"},
+          "origin": {"type": "string", "enum": ["same_registry", "cross_registry", "local"]},
+          "registry": {"type": "string"},
+          "connected": {"type": "boolean"},
+          "glob": {"type": "boolean"},
+          "local": {"type": "boolean"},
+          "source": {"type": "string"},
+          "reason": {"type": "string"}
+        }
+      }
+    }
+  }
+}`
+
 func init() {
 	clischema.Register("scribe kit list", kitListOutputSchema)
 	clischema.Register("scribe kit show", kitShowOutputSchema)
+	clischema.Register("scribe kit install", kitInstallOutputSchema)
 }

--- a/cmd/project_sync.go
+++ b/cmd/project_sync.go
@@ -36,6 +36,7 @@ type projectSyncOptions struct {
 type projectSyncOutput struct {
 	ProjectRoot      string   `json:"project_root"`
 	KitsWritten      []string `json:"kits_written,omitempty"`
+	KitsPinned       []string `json:"kits_pinned,omitempty"`
 	SkillsVendored   []string `json:"skills_vendored,omitempty"`
 	RegistryPinned   []string `json:"registry_pinned,omitempty"`
 	BootstrapSkipped []string `json:"bootstrap_skipped,omitempty"`
@@ -100,7 +101,8 @@ func runProjectSync(cmd *cobra.Command, opts *projectSyncOptions) error {
 		return err
 	}
 	out := projectSyncOutput{ProjectRoot: projectRoot}
-	if err := syncProjectKits(projectRoot, scribeDir, pf.Kits, globalKits, opts, &out); err != nil {
+	kitPins, err := syncProjectKits(projectRoot, scribeDir, pf.Kits, globalKits, st, opts, &out)
+	if err != nil {
 		return err
 	}
 	skillNames := resolveProjectSkillNames(pf, globalKits)
@@ -112,7 +114,7 @@ func runProjectSync(cmd *cobra.Command, opts *projectSyncOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := writeProjectLock(projectRoot, lockEntries, opts, &out); err != nil {
+	if err := writeProjectLock(projectRoot, kitPins, lockEntries, opts, &out); err != nil {
 		return err
 	}
 	if opts.check && len(out.Drift) > 0 {
@@ -135,11 +137,12 @@ func runProjectSync(cmd *cobra.Command, opts *projectSyncOptions) error {
 	return nil
 }
 
-func syncProjectKits(projectRoot, scribeDir string, kitNames []string, global map[string]*kit.Kit, opts *projectSyncOptions, out *projectSyncOutput) error {
+func syncProjectKits(projectRoot, scribeDir string, kitNames []string, global map[string]*kit.Kit, st *state.State, opts *projectSyncOptions, out *projectSyncOutput) ([]lockfile.ProjectKit, error) {
+	pins := make([]lockfile.ProjectKit, 0, len(kitNames))
 	for _, name := range sortedProjectStrings(kitNames) {
 		k, ok := global[name]
 		if !ok {
-			return clierrors.Wrap(fmt.Errorf("kit %q not found", name), "PROJECT_KIT_NOT_FOUND", clierrors.ExitNotFound,
+			return nil, clierrors.Wrap(fmt.Errorf("kit %q not found", name), "PROJECT_KIT_NOT_FOUND", clierrors.ExitNotFound,
 				clierrors.WithRemediation("Create the kit locally or remove it from .scribe.yaml."),
 			)
 		}
@@ -148,13 +151,45 @@ func syncProjectKits(projectRoot, scribeDir string, kitNames []string, global ma
 		_ = k
 		changed, err := copyFileIfChanged(src, dst, opts)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if changed {
 			out.KitsWritten = append(out.KitsWritten, name)
 		}
+		if pin, ok := projectKitPinFromState(name, k, st); ok {
+			pins = append(pins, pin)
+			out.KitsPinned = append(out.KitsPinned, name)
+		}
 	}
-	return nil
+	return pins, nil
+}
+
+func projectKitPinFromState(name string, k *kit.Kit, st *state.State) (lockfile.ProjectKit, bool) {
+	if st == nil || k == nil || st.Kits == nil {
+		return lockfile.ProjectKit{}, false
+	}
+	installed, ok := st.Kits[name]
+	if !ok {
+		return lockfile.ProjectKit{}, false
+	}
+	registry := installed.SourceRegistry
+	if registry == "" && k.Source != nil {
+		registry = k.Source.Registry
+	}
+	rev := installed.Rev
+	if rev == "" && k.Source != nil {
+		rev = k.Source.Rev
+	}
+	if registry == "" || rev == "" || installed.ContentHash == "" {
+		return lockfile.ProjectKit{}, false
+	}
+	return lockfile.ProjectKit{
+		Name:           name,
+		SourceRegistry: registry,
+		CommitSHA:      rev,
+		ContentHash:    installed.ContentHash,
+		SkillsRefs:     append([]string(nil), k.Skills...),
+	}, true
 }
 
 func syncProjectSkills(projectRoot, storeDir string, skillNames []string, vendorSet map[string]bool, st *state.State, opts *projectSyncOptions, out *projectSyncOutput) ([]lockfile.ProjectEntry, error) {
@@ -334,12 +369,13 @@ func installableDir(name string, installed state.InstalledSkill) (string, error)
 	return filepath.Join(dir, name), nil
 }
 
-func writeProjectLock(projectRoot string, entries []lockfile.ProjectEntry, opts *projectSyncOptions, out *projectSyncOutput) error {
+func writeProjectLock(projectRoot string, kits []lockfile.ProjectKit, entries []lockfile.ProjectEntry, opts *projectSyncOptions, out *projectSyncOutput) error {
 	store := projectstore.Project(projectRoot)
 	lf := &lockfile.ProjectLockfile{
 		FormatVersion: lockfile.SchemaVersion,
 		Kind:          lockfile.ProjectKind,
 		GeneratedBy:   "scribe",
+		Kits:          kits,
 		Entries:       entries,
 	}
 	data, err := lf.Encode()

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -72,6 +72,13 @@ func TestProjectSyncVendorsProjectSkillAndPinsRegistrySkill(t *testing.T) {
 
 	st := stateFixture(t, home)
 	st.Installed["review"] = state.InstalledSkill{Origin: state.OriginProject}
+	st.Kits["core"] = state.InstalledKit{
+		Name:           "core",
+		SourceRegistry: "acme/skills",
+		Rev:            "kitsha",
+		ContentHash:    "kithash",
+		Skills:         []string{"deploy"},
+	}
 	st.Installed["deploy"] = state.InstalledSkill{
 		InstalledHash: "hash",
 		Sources: []state.SkillSource{{
@@ -117,6 +124,9 @@ func TestProjectSyncVendorsProjectSkillAndPinsRegistrySkill(t *testing.T) {
 	}
 	if entry.SourceRegistry != "acme/skills" || entry.SourceRepo != "acme/source" || entry.Path != "skills/deploy" {
 		t.Fatalf("entry = %+v", entry)
+	}
+	if len(lf.Kits) != 1 || lf.Kits[0].Name != "core" || lf.Kits[0].CommitSHA != "kitsha" || lf.Kits[0].SkillsRefs[0] != "deploy" {
+		t.Fatalf("kit pins = %+v", lf.Kits)
 	}
 }
 
@@ -260,6 +270,9 @@ func stateFixture(t *testing.T, home string) *state.State {
 	}
 	if st.Installed == nil {
 		st.Installed = map[string]state.InstalledSkill{}
+	}
+	if st.Kits == nil {
+		st.Kits = map[string]state.InstalledKit{}
 	}
 	return st
 }

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -28,6 +28,7 @@ type ProjectLockfile struct {
 	Kind          string         `yaml:"kind"`
 	GeneratedAt   string         `yaml:"generated_at,omitempty"`
 	GeneratedBy   string         `yaml:"generated_by,omitempty"`
+	Kits          []ProjectKit   `yaml:"kits,omitempty"`
 	Entries       []ProjectEntry `yaml:"entries"`
 }
 
@@ -48,6 +49,14 @@ type ProjectEntry struct {
 	Update     string            `yaml:"update,omitempty" json:"update,omitempty"`
 	Installs   map[string]string `yaml:"installs,omitempty" json:"installs,omitempty"`
 	Updates    map[string]string `yaml:"updates,omitempty" json:"updates,omitempty"`
+}
+
+type ProjectKit struct {
+	Name           string   `yaml:"name" json:"name"`
+	SourceRegistry string   `yaml:"source_registry" json:"source_registry"`
+	CommitSHA      string   `yaml:"commit_sha" json:"commit_sha"`
+	ContentHash    string   `yaml:"content_hash" json:"content_hash"`
+	SkillsRefs     []string `yaml:"skills_refs,omitempty" json:"skills_refs,omitempty"`
 }
 
 type Update struct {
@@ -167,6 +176,25 @@ func (lf *ProjectLockfile) Validate() error {
 	}
 	if strings.TrimSpace(lf.Kind) != ProjectKind {
 		return fmt.Errorf("project lockfile kind is %q (expected %q)", lf.Kind, ProjectKind)
+	}
+	seenKits := make(map[string]bool, len(lf.Kits))
+	for _, kit := range lf.Kits {
+		if strings.TrimSpace(kit.Name) == "" {
+			return errors.New("project lockfile kit has empty name")
+		}
+		if seenKits[kit.Name] {
+			return fmt.Errorf("duplicate project lockfile kit %q", kit.Name)
+		}
+		seenKits[kit.Name] = true
+		if strings.TrimSpace(kit.SourceRegistry) == "" {
+			return fmt.Errorf("project lockfile kit %q missing source_registry", kit.Name)
+		}
+		if strings.TrimSpace(kit.CommitSHA) == "" {
+			return fmt.Errorf("project lockfile kit %q missing commit_sha", kit.Name)
+		}
+		if strings.TrimSpace(kit.ContentHash) == "" {
+			return fmt.Errorf("project lockfile kit %q has invalid content_hash", kit.Name)
+		}
 	}
 	seen := make(map[string]bool, len(lf.Entries))
 	for _, entry := range lf.Entries {

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -40,6 +40,13 @@ func TestParseProjectEncodeValidate(t *testing.T) {
 format_version: 1
 kind: ProjectLock
 generated_by: scribe@test
+kits:
+  - name: baseline
+    source_registry: acme/registry
+    commit_sha: kitsha
+    content_hash: ` + hashA + `
+    skills_refs:
+      - deploy
 entries:
   - name: deploy
     source_registry: acme/registry
@@ -67,11 +74,14 @@ entries:
 	if entry.SourceRepo != "acme/skills" || entry.Path != "skills/deploy" || entry.Installs["claude"] == "" {
 		t.Fatalf("unexpected project entry: %+v", entry)
 	}
+	if len(lf.Kits) != 1 || lf.Kits[0].Name != "baseline" || lf.Kits[0].SkillsRefs[0] != "deploy" {
+		t.Fatalf("unexpected project kits: %+v", lf.Kits)
+	}
 	encoded, err := lf.Encode()
 	if err != nil {
 		t.Fatalf("Encode() error = %v", err)
 	}
-	if !strings.Contains(string(encoded), "kind: ProjectLock") || !strings.Contains(string(encoded), "source_repo: acme/skills") {
+	if !strings.Contains(string(encoded), "kind: ProjectLock") || !strings.Contains(string(encoded), "kits:") || !strings.Contains(string(encoded), "source_repo: acme/skills") {
 		t.Fatalf("encoded project lockfile missing fields: %s", encoded)
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -49,9 +49,14 @@ const (
 
 // InstalledKit indexes an installed kit definition in the local state file.
 type InstalledKit struct {
-	Source  string   `json:"source,omitempty"`
-	Version string   `json:"version,omitempty"`
-	Skills  []string `json:"skills,omitempty"`
+	Name           string    `json:"name,omitempty"`
+	SourceRegistry string    `json:"source_registry,omitempty"`
+	Rev            string    `json:"rev,omitempty"`
+	ContentHash    string    `json:"content_hash,omitempty"`
+	InstalledAt    time.Time `json:"installed_at,omitempty"`
+	Source         string    `json:"source,omitempty"`
+	Version        string    `json:"version,omitempty"`
+	Skills         []string  `json:"skills,omitempty"`
 }
 
 // InstalledSnippet indexes an installed snippet definition in the local state file.

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -1019,6 +1019,13 @@ func validateProjectRegistriesConnected(lf *lockfile.ProjectLockfile, connected 
 			)
 		}
 	}
+	for _, kit := range lf.Kits {
+		if !set[kit.SourceRegistry] {
+			return clierrors.Wrap(fmt.Errorf("registry %q is not connected", kit.SourceRegistry), "PROJECT_REGISTRY_NOT_CONNECTED", clierrors.ExitPerm,
+				clierrors.WithRemediation("Run `scribe registry connect "+kit.SourceRegistry+"` before `scribe sync`."),
+			)
+		}
+	}
 	return nil
 }
 

--- a/internal/workflow/sync_test.go
+++ b/internal/workflow/sync_test.go
@@ -77,6 +77,26 @@ func TestStepFilterRegistries_WithFilterFunc(t *testing.T) {
 	}
 }
 
+func TestValidateProjectRegistriesConnectedChecksKitPins(t *testing.T) {
+	lf := &lockfile.ProjectLockfile{
+		FormatVersion: lockfile.SchemaVersion,
+		Kind:          lockfile.ProjectKind,
+		Kits: []lockfile.ProjectKit{{
+			Name:           "baseline",
+			SourceRegistry: "acme/skills",
+			CommitSHA:      "abc123",
+			ContentHash:    "hash",
+		}},
+	}
+	err := validateProjectRegistriesConnected(lf, []string{"other/skills"})
+	if err == nil {
+		t.Fatal("expected missing registry error")
+	}
+	if !strings.Contains(err.Error(), `registry "acme/skills" is not connected`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestStepResolveKitFilter_WithProjectFile(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
Adds scribe kit install <registry>:<kit> for connected registries. The command fetches the remote kit, installs same-registry skill refs through the existing install workflow, writes the local kit YAML with source metadata, and records kit install state. Cross-registry refs are reported as deferred/missing for now.

Project lockfiles now support kits[], and scribe project sync writes kit pins when the project uses an installed registry kit. Team-share registry validation also checks kit pins.

Tests: go test ./...