### PR TITLE
feat: resolve cross-registry kit refs

### DIFF
--- a/cmd/kit.go
+++ b/cmd/kit.go
@@ -524,8 +524,9 @@ func runKitInstall(cmd *cobra.Command, ref string, opts *kitInstallOptions) erro
 }
 
 type kitInstallDep struct {
-	Name  string
-	Alias string
+	Name   string
+	Alias  string
+	Source string
 }
 
 func installableKitRefs(k *kit.Kit, registryRepo string, cfg *config.Config) (map[string][]kitInstallDep, []kitRefOutput, []string, error) {
@@ -564,10 +565,14 @@ func installableKitRefs(k *kit.Kit, registryRepo string, cfg *config.Config) (ma
 			missing = append(missing, kitRefOutput{Raw: raw, Skill: ref.Skill, Origin: origin, Registry: ref.Registry, Connected: true, Glob: true, Reason: "glob_deferred"})
 			continue
 		}
-		key := ref.Registry + ":" + ref.Skill
+		source := ""
+		if ref.Source.Host != "" {
+			source = ref.Source.String()
+		}
+		key := ref.Registry + ":" + ref.Skill + ":" + source
 		if !seen[key] {
 			seen[key] = true
-			deps[ref.Registry] = append(deps[ref.Registry], kitInstallDep{Name: ref.Skill, Alias: k.SkillAliases[raw]})
+			deps[ref.Registry] = append(deps[ref.Registry], kitInstallDep{Name: ref.Skill, Alias: k.SkillAliases[raw], Source: source})
 		}
 	}
 	for registryName := range deps {
@@ -594,18 +599,23 @@ func runKitInstallDeps(cmd *cobra.Command, factory *app.Factory, depsByRegistry 
 		}
 		skillNames := make([]string, 0, len(deps))
 		aliases := map[string]string{}
+		pinnedSources := map[string]string{}
 		for _, dep := range deps {
 			skillNames = append(skillNames, dep.Name)
 			if dep.Alias != "" {
 				aliases[dep.Name] = dep.Alias
 			}
+			if dep.Source != "" {
+				pinnedSources[dep.Name] = dep.Source
+			}
 		}
 		bag := &workflow.Bag{
-			Args:             skillNames,
-			RepoFlag:         registryRepo,
-			Factory:          factory,
-			FilterRegistries: filterRegistries,
-			SkillAliases:     aliases,
+			Args:               skillNames,
+			RepoFlag:           registryRepo,
+			Factory:            factory,
+			FilterRegistries:   filterRegistries,
+			SkillAliases:       aliases,
+			PinnedSkillSources: pinnedSources,
 		}
 		if err := workflow.Run(cmd.Context(), workflow.InstallSteps(), bag); err != nil {
 			return handleNameConflictError(cmd, err)
@@ -708,13 +718,16 @@ func runKitSync(cmd *cobra.Command, opts *kitInstallOptions) error {
 				return err
 			}
 		}
+		kitPath := filepath.Join(scribeDir, "kits", localName+".yaml")
+		if err := ensureKitFileUnmodified(localName, kitPath, installed.ContentHash); err != nil {
+			return err
+		}
 		installedSkills := flattenKitDeps(depsByRegistry)
 		if !opts.noDeps {
 			if err := runKitInstallDepsFn(cmd, factory, depsByRegistry); err != nil {
 				return err
 			}
 		}
-		kitPath := filepath.Join(scribeDir, "kits", localName+".yaml")
 		if err := kit.Save(kitPath, k); err != nil {
 			return err
 		}
@@ -801,6 +814,26 @@ func hashKitFile(name, path string) (string, error) {
 		return "", err
 	}
 	return lockfile.HashFiles([]lockfile.File{{Path: name + ".yaml", Content: data}})
+}
+
+func ensureKitFileUnmodified(name, path, expectedHash string) error {
+	if expectedHash == "" {
+		return nil
+	}
+	currentHash, err := hashKitFile(name, path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if currentHash == expectedHash {
+		return nil
+	}
+	return clierrors.Wrap(fmt.Errorf("kit %q has local edits at %s", name, path), "KIT_LOCAL_EDIT_CONFLICT", clierrors.ExitConflict,
+		clierrors.WithResource(path),
+		clierrors.WithRemediation("Move or restore the local kit file before running `scribe kit sync` again."),
+	)
 }
 
 func remoteKitListItems(cmd *cobra.Command, opts *kitListOptions, local map[string]*kit.Kit) ([]kitListItem, error) {

--- a/cmd/kit.go
+++ b/cmd/kit.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -14,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Naoray/scribe/internal/app"
+	"github.com/Naoray/scribe/internal/cli/envelope"
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/cli/fields"
 	"github.com/Naoray/scribe/internal/cli/output"
@@ -43,9 +45,10 @@ type kitListOptions struct {
 }
 
 type kitInstallOptions struct {
-	alias  string
-	noDeps bool
-	json   bool
+	alias         string
+	noDeps        bool
+	noInteraction bool
+	json          bool
 }
 
 type kitCreateOutput struct {
@@ -81,12 +84,13 @@ type kitShowOutput struct {
 }
 
 type kitInstallOutput struct {
-	Name            string         `json:"name"`
-	Registry        string         `json:"registry"`
-	Path            string         `json:"path"`
-	Rev             string         `json:"rev"`
-	SkillsInstalled []string       `json:"skills_installed,omitempty"`
-	MissingRefs     []kitRefOutput `json:"missing_refs,omitempty"`
+	Name              string         `json:"name"`
+	Registry          string         `json:"registry"`
+	Path              string         `json:"path"`
+	Rev               string         `json:"rev"`
+	SkillsInstalled   []string       `json:"skills_installed,omitempty"`
+	MissingRefs       []kitRefOutput `json:"missing_refs,omitempty"`
+	MissingRegistries []string       `json:"missing_registries,omitempty"`
 }
 
 type kitSourceOutput struct {
@@ -110,6 +114,7 @@ var listRemoteKitsFn = registry.ListKits
 var findRemoteKitFn = registry.FindKit
 var fetchRemoteKitFn = registry.FetchKitBody
 var runKitInstallDepsFn = runKitInstallDeps
+var confirmKitMissingRegistriesFn = confirmKitMissingRegistries
 var remoteKitRevFn = func(ctx context.Context, client *gh.Client, registryRepo string) (string, error) {
 	owner, repo, err := manifest.ParseOwnerRepo(registryRepo)
 	if err != nil {
@@ -152,6 +157,7 @@ func newKitCommand() *cobra.Command {
 	cmd.AddCommand(newKitListCommand())
 	cmd.AddCommand(newKitShowCommand())
 	cmd.AddCommand(newKitInstallCommand())
+	cmd.AddCommand(newKitSyncCommand())
 	return cmd
 }
 
@@ -211,12 +217,32 @@ func newKitInstallCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.json = jsonFlagPassed(cmd)
+			opts.noInteraction = noInteractionFlagPassed(cmd)
 			return runKitInstall(cmd, args[0], opts)
 		},
 	}
 	cmd.Flags().StringVar(&opts.alias, "alias", "", "Install incoming kit under this local name")
-	cmd.Flags().BoolVar(&opts.noDeps, "no-deps", false, "Install kit body without installing same-registry skills")
+	cmd.Flags().BoolVar(&opts.noDeps, "no-deps", false, "Install kit body without installing referenced skills")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output machine-readable JSON")
+	addNoInteractionFlag(cmd, "Disable interactive prompts", false)
+	return markJSONSupported(cmd)
+}
+
+func newKitSyncCommand() *cobra.Command {
+	opts := &kitInstallOptions{}
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Refresh installed registry kits",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.json = jsonFlagPassed(cmd)
+			opts.noInteraction = noInteractionFlagPassed(cmd)
+			return runKitSync(cmd, opts)
+		},
+	}
+	cmd.Flags().BoolVar(&opts.noDeps, "no-deps", false, "Refresh kit bodies without installing referenced skills")
+	cmd.Flags().BoolVar(&opts.json, "json", false, "Output machine-readable JSON")
+	addNoInteractionFlag(cmd, "Disable interactive prompts", false)
 	return markJSONSupported(cmd)
 }
 
@@ -416,12 +442,36 @@ func runKitInstall(cmd *cobra.Command, ref string, opts *kitInstallOptions) erro
 	k.Source.Registry = registryRepo
 	k.Source.Rev = rev
 
-	sameRegistry, missingRefs, err := installableKitRefs(k.Skills, registryRepo, cfg)
+	depsByRegistry, missingRefs, missingRegistries, err := installableKitRefs(k, registryRepo, cfg)
 	if err != nil {
 		return err
 	}
-	if !opts.noDeps && len(sameRegistry) > 0 {
-		if err := runKitInstallDepsFn(cmd, factory, registryRepo, sameRegistry); err != nil {
+	if len(missingRegistries) > 0 {
+		if opts.noInteraction {
+			out := kitInstallOutput{Name: localName, Registry: registryRepo, Rev: rev, MissingRefs: missingRefs, MissingRegistries: missingRegistries}
+			if opts.json {
+				_ = renderMutatorEnvelope(cmd, out, envelope.StatusPartialSuccess)
+			}
+			return clierrors.Wrap(clierrors.ErrPartialSuccess, "KIT_MISSING_REGISTRIES", clierrors.ExitPartial,
+				clierrors.WithMessage("kit references registries that are not connected"),
+				clierrors.WithRemediation("Run `scribe registry connect <owner/repo>` for each missing registry, then retry."),
+				clierrors.WithRendered(opts.json),
+			)
+		}
+		if err := confirmKitMissingRegistriesFn(cmd, cfg, missingRegistries); err != nil {
+			return err
+		}
+		depsByRegistry, missingRefs, missingRegistries, err = installableKitRefs(k, registryRepo, cfg)
+		if err != nil {
+			return err
+		}
+		if len(missingRegistries) > 0 {
+			return clierrors.Wrap(fmt.Errorf("registries still missing: %s", strings.Join(missingRegistries, ", ")), "KIT_MISSING_REGISTRIES", clierrors.ExitPartial)
+		}
+	}
+	installedSkills := flattenKitDeps(depsByRegistry)
+	if !opts.noDeps {
+		if err := runKitInstallDepsFn(cmd, factory, depsByRegistry); err != nil {
 			return err
 		}
 	}
@@ -448,12 +498,13 @@ func runKitInstall(cmd *cobra.Command, ref string, opts *kitInstallOptions) erro
 	}
 
 	out := kitInstallOutput{
-		Name:            localName,
-		Registry:        registryRepo,
-		Path:            kitPath,
-		Rev:             rev,
-		SkillsInstalled: sameRegistry,
-		MissingRefs:     missingRefs,
+		Name:              localName,
+		Registry:          registryRepo,
+		Path:              kitPath,
+		Rev:               rev,
+		SkillsInstalled:   installedSkills,
+		MissingRefs:       missingRefs,
+		MissingRegistries: missingRegistries,
 	}
 	if opts.json {
 		r := jsonRendererForCommand(cmd, true)
@@ -463,8 +514,8 @@ func runKitInstall(cmd *cobra.Command, ref string, opts *kitInstallOptions) erro
 		return r.Flush()
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Installed kit %s from %s\n", localName, registryRepo)
-	if len(sameRegistry) > 0 && !opts.noDeps {
-		fmt.Fprintf(cmd.OutOrStdout(), "Installed skills: %s\n", strings.Join(sameRegistry, ", "))
+	if len(installedSkills) > 0 && !opts.noDeps {
+		fmt.Fprintf(cmd.OutOrStdout(), "Installed skills: %s\n", strings.Join(installedSkills, ", "))
 	}
 	for _, missing := range missingRefs {
 		fmt.Fprintf(cmd.ErrOrStderr(), "warning: deferred %s (%s)\n", missing.Raw, missing.Reason)
@@ -472,11 +523,17 @@ func runKitInstall(cmd *cobra.Command, ref string, opts *kitInstallOptions) erro
 	return nil
 }
 
-func installableKitRefs(rawRefs []string, registryRepo string, cfg *config.Config) ([]string, []kitRefOutput, error) {
-	var same []string
+type kitInstallDep struct {
+	Name  string
+	Alias string
+}
+
+func installableKitRefs(k *kit.Kit, registryRepo string, cfg *config.Config) (map[string][]kitInstallDep, []kitRefOutput, []string, error) {
+	deps := map[string][]kitInstallDep{}
 	var missing []kitRefOutput
 	seen := map[string]bool{}
-	for _, raw := range rawRefs {
+	missingRegistrySet := map[string]bool{}
+	for _, raw := range k.Skills {
 		ref, err := kit.ParseSkillRef(raw, registryRepo)
 		if err != nil {
 			missing = append(missing, kitRefOutput{Raw: raw, Reason: err.Error()})
@@ -486,49 +543,240 @@ func installableKitRefs(rawRefs []string, registryRepo string, cfg *config.Confi
 			missing = append(missing, kitRefOutput{Raw: raw, Skill: ref.Skill, Origin: string(kit.OriginLocal), Local: true, Reason: "local_ref_forbidden"})
 			continue
 		}
+		origin := string(kit.OriginSameRegistry)
 		if ref.Registry != registryRepo {
-			reason := "cross_registry_deferred"
-			if !registryConnected(cfg, ref.Registry) {
-				reason = "registry_not_connected"
-			}
+			origin = string(kit.OriginCrossRegistry)
+		}
+		if !registryConnected(cfg, ref.Registry) {
+			missingRegistrySet[ref.Registry] = true
 			missing = append(missing, kitRefOutput{
 				Raw:       raw,
 				Skill:     ref.Skill,
-				Origin:    string(kit.OriginCrossRegistry),
+				Origin:    origin,
 				Registry:  ref.Registry,
-				Connected: registryConnected(cfg, ref.Registry),
+				Connected: false,
 				Glob:      ref.Glob,
-				Reason:    reason,
+				Reason:    "registry_not_connected",
 			})
 			continue
 		}
 		if ref.Glob {
-			missing = append(missing, kitRefOutput{Raw: raw, Skill: ref.Skill, Origin: string(kit.OriginSameRegistry), Registry: registryRepo, Connected: true, Glob: true, Reason: "glob_deferred"})
+			missing = append(missing, kitRefOutput{Raw: raw, Skill: ref.Skill, Origin: origin, Registry: ref.Registry, Connected: true, Glob: true, Reason: "glob_deferred"})
 			continue
 		}
-		if !seen[ref.Skill] {
-			seen[ref.Skill] = true
-			same = append(same, ref.Skill)
+		key := ref.Registry + ":" + ref.Skill
+		if !seen[key] {
+			seen[key] = true
+			deps[ref.Registry] = append(deps[ref.Registry], kitInstallDep{Name: ref.Skill, Alias: k.SkillAliases[raw]})
 		}
 	}
-	sort.Strings(same)
-	return same, missing, nil
+	for registryName := range deps {
+		sort.Slice(deps[registryName], func(i, j int) bool { return deps[registryName][i].Name < deps[registryName][j].Name })
+	}
+	missingRegistries := make([]string, 0, len(missingRegistrySet))
+	for registryName := range missingRegistrySet {
+		missingRegistries = append(missingRegistries, registryName)
+	}
+	sort.Strings(missingRegistries)
+	return deps, missing, missingRegistries, nil
 }
 
-func runKitInstallDeps(cmd *cobra.Command, factory *app.Factory, registryRepo string, skillNames []string) error {
-	if len(skillNames) == 0 {
-		return nil
+func runKitInstallDeps(cmd *cobra.Command, factory *app.Factory, depsByRegistry map[string][]kitInstallDep) error {
+	registries := make([]string, 0, len(depsByRegistry))
+	for registryRepo := range depsByRegistry {
+		registries = append(registries, registryRepo)
 	}
-	bag := &workflow.Bag{
-		Args:             skillNames,
-		RepoFlag:         registryRepo,
-		Factory:          factory,
-		FilterRegistries: filterRegistries,
+	sort.Strings(registries)
+	for _, registryRepo := range registries {
+		deps := depsByRegistry[registryRepo]
+		if len(deps) == 0 {
+			continue
+		}
+		skillNames := make([]string, 0, len(deps))
+		aliases := map[string]string{}
+		for _, dep := range deps {
+			skillNames = append(skillNames, dep.Name)
+			if dep.Alias != "" {
+				aliases[dep.Name] = dep.Alias
+			}
+		}
+		bag := &workflow.Bag{
+			Args:             skillNames,
+			RepoFlag:         registryRepo,
+			Factory:          factory,
+			FilterRegistries: filterRegistries,
+			SkillAliases:     aliases,
+		}
+		if err := workflow.Run(cmd.Context(), workflow.InstallSteps(), bag); err != nil {
+			return handleNameConflictError(cmd, err)
+		}
+		if err := saveWorkflowState(bag); err != nil {
+			return err
+		}
 	}
-	if err := workflow.Run(cmd.Context(), workflow.InstallSteps(), bag); err != nil {
-		return handleNameConflictError(cmd, err)
+	return nil
+}
+
+func runKitSync(cmd *cobra.Command, opts *kitInstallOptions) error {
+	if opts == nil {
+		opts = &kitInstallOptions{}
 	}
-	return saveWorkflowState(bag)
+	factory := commandFactory()
+	cfg, err := factory.Config()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	st, err := factory.State()
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
+	client, err := factory.Client()
+	if err != nil {
+		return fmt.Errorf("load github client: %w", err)
+	}
+	scribeDir, err := paths.ScribeDir()
+	if err != nil {
+		return fmt.Errorf("resolve scribe dir: %w", err)
+	}
+
+	names := make([]string, 0, len(st.Kits))
+	for name := range st.Kits {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var outputs []kitInstallOutput
+	for _, localName := range names {
+		installed := st.Kits[localName]
+		registryRepo := installed.SourceRegistry
+		if registryRepo == "" {
+			registryRepo = installed.Source
+		}
+		if registryRepo == "" {
+			continue
+		}
+		if !registryConnected(cfg, registryRepo) {
+			return clierrors.Wrap(fmt.Errorf("registry %q is not connected", registryRepo), "REGISTRY_NOT_CONNECTED", clierrors.ExitNotFound,
+				clierrors.WithResource(registryRepo),
+				clierrors.WithRemediation("Run `scribe registry connect "+registryRepo+"` first."),
+			)
+		}
+		remoteName := installed.Name
+		if remoteName == "" {
+			remoteName = localName
+		}
+		entry, err := findRemoteKitFn(cmd.Context(), client, registryRepo, remoteName)
+		if err != nil {
+			return clierrors.Wrap(err, "KIT_NOT_FOUND", clierrors.ExitNotFound,
+				clierrors.WithResource(registryRepo+":"+remoteName),
+				clierrors.WithRemediation("Run `scribe kit list --remote --registry "+registryRepo+"`."),
+			)
+		}
+		k, err := fetchRemoteKitFn(cmd.Context(), client, registryRepo, entry)
+		if err != nil {
+			return err
+		}
+		k.Name = localName
+		rev, err := remoteKitRevFn(cmd.Context(), client, registryRepo)
+		if err != nil {
+			return err
+		}
+		if k.Source == nil {
+			k.Source = &kit.Source{}
+		}
+		k.Source.Registry = registryRepo
+		k.Source.Rev = rev
+		depsByRegistry, missingRefs, missingRegistries, err := installableKitRefs(k, registryRepo, cfg)
+		if err != nil {
+			return err
+		}
+		if len(missingRegistries) > 0 {
+			if opts.noInteraction {
+				out := kitInstallOutput{Name: localName, Registry: registryRepo, Rev: rev, MissingRefs: missingRefs, MissingRegistries: missingRegistries}
+				if opts.json {
+					_ = renderMutatorEnvelope(cmd, out, envelope.StatusPartialSuccess)
+				}
+				return clierrors.Wrap(clierrors.ErrPartialSuccess, "KIT_MISSING_REGISTRIES", clierrors.ExitPartial,
+					clierrors.WithMessage("kit references registries that are not connected"),
+					clierrors.WithRendered(opts.json),
+				)
+			}
+			if err := confirmKitMissingRegistriesFn(cmd, cfg, missingRegistries); err != nil {
+				return err
+			}
+			depsByRegistry, missingRefs, missingRegistries, err = installableKitRefs(k, registryRepo, cfg)
+			if err != nil {
+				return err
+			}
+		}
+		installedSkills := flattenKitDeps(depsByRegistry)
+		if !opts.noDeps {
+			if err := runKitInstallDepsFn(cmd, factory, depsByRegistry); err != nil {
+				return err
+			}
+		}
+		kitPath := filepath.Join(scribeDir, "kits", localName+".yaml")
+		if err := kit.Save(kitPath, k); err != nil {
+			return err
+		}
+		contentHash, err := hashKitFile(localName, kitPath)
+		if err != nil {
+			return err
+		}
+		recordInstalledKit(st, localName, registryRepo, rev, contentHash, k.Skills)
+		outputs = append(outputs, kitInstallOutput{
+			Name:              localName,
+			Registry:          registryRepo,
+			Path:              kitPath,
+			Rev:               rev,
+			SkillsInstalled:   installedSkills,
+			MissingRefs:       missingRefs,
+			MissingRegistries: missingRegistries,
+		})
+	}
+	if err := st.Save(); err != nil {
+		return err
+	}
+	if opts.json {
+		return renderMutatorEnvelope(cmd, map[string]any{"kits": outputs}, envelope.StatusOK)
+	}
+	for _, out := range outputs {
+		fmt.Fprintf(cmd.OutOrStdout(), "Synced kit %s from %s\n", out.Name, out.Registry)
+	}
+	return nil
+}
+
+func flattenKitDeps(depsByRegistry map[string][]kitInstallDep) []string {
+	var installed []string
+	for registryRepo, deps := range depsByRegistry {
+		for _, dep := range deps {
+			name := dep.Name
+			if dep.Alias != "" {
+				name = dep.Alias
+			}
+			installed = append(installed, registryRepo+":"+name)
+		}
+	}
+	sort.Strings(installed)
+	return installed
+}
+
+func confirmKitMissingRegistries(cmd *cobra.Command, cfg *config.Config, registries []string) error {
+	fmt.Fprintf(cmd.ErrOrStderr(), "Kit references unconnected registries: %s\nConnect them now? [y/N] ", strings.Join(registries, ", "))
+	answer, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	if answer != "y" && answer != "yes" {
+		return clierrors.Wrap(clierrors.ErrPartialSuccess, "KIT_MISSING_REGISTRIES", clierrors.ExitPartial,
+			clierrors.WithMessage("kit references registries that are not connected"),
+			clierrors.WithRemediation("Run `scribe registry connect <owner/repo>` for each missing registry, then retry."),
+		)
+	}
+	for _, repo := range registries {
+		cfg.AddRegistry(config.RegistryConfig{Repo: repo, Enabled: true, Type: config.RegistryTypeGitHub})
+	}
+	if err := cfg.Save(); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	return nil
 }
 
 func recordInstalledKit(st *state.State, name, registryRepo, rev, contentHash string, skills []string) {

--- a/cmd/kit_install_test.go
+++ b/cmd/kit_install_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -360,6 +361,60 @@ func TestKitInstallAliasMappingPassesSkillAlias(t *testing.T) {
 	}
 }
 
+func TestKitInstallPinnedGitHubRefPassesPinnedSource(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	oldFactory := commandFactory
+	oldFind := findRemoteKitFn
+	oldFetch := fetchRemoteKitFn
+	oldRev := remoteKitRevFn
+	oldDeps := runKitInstallDepsFn
+	t.Cleanup(func() {
+		commandFactory = oldFactory
+		findRemoteKitFn = oldFind
+		fetchRemoteKitFn = oldFetch
+		remoteKitRevFn = oldRev
+		runKitInstallDepsFn = oldDeps
+	})
+	st := stateFixture(t, home)
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) {
+				return &config.Config{Registries: []config.RegistryConfig{
+					{Repo: "acme/skills", Enabled: true},
+					{Repo: "other/skills", Enabled: true},
+				}}, nil
+			},
+			State:  func() (*state.State, error) { return st, nil },
+			Client: func() (*gh.Client, error) { return gh.NewClient(context.Background(), ""), nil },
+		}
+	}
+	findRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, _, name string) (manifest.KitEntry, error) {
+		return manifest.KitEntry{Name: name}, nil
+	}
+	fetchRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, registryRepo string, entry manifest.KitEntry) (*kit.Kit, error) {
+		return &kit.Kit{Name: entry.Name, Skills: []string{"github:other/skills@v1.2.3:tdd"}, Source: &kit.Source{Registry: registryRepo}}, nil
+	}
+	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "abc123", nil }
+	var gotDeps map[string][]kitInstallDep
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep) error {
+		gotDeps = depsByRegistry
+		return nil
+	}
+
+	cmd := newKitInstallCommand()
+	cmd.SetArgs([]string{"acme/skills:baseline"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("kit install: %v", err)
+	}
+	want := map[string][]kitInstallDep{"other/skills": {{Name: "tdd", Source: "github:other/skills@v1.2.3"}}}
+	if !reflect.DeepEqual(gotDeps, want) {
+		t.Fatalf("deps = %#v, want %#v", gotDeps, want)
+	}
+}
+
 func TestKitSyncRefreshesInstalledRegistryKit(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -415,5 +470,87 @@ func TestKitSyncRefreshesInstalledRegistryKit(t *testing.T) {
 	want := map[string][]kitInstallDep{"acme/skills": {{Name: "tdd"}}}
 	if !reflect.DeepEqual(gotDeps, want) {
 		t.Fatalf("deps = %#v, want %#v", gotDeps, want)
+	}
+}
+
+func TestKitSyncRefusesToOverwriteLocallyEditedKit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	oldFactory := commandFactory
+	oldFind := findRemoteKitFn
+	oldFetch := fetchRemoteKitFn
+	oldRev := remoteKitRevFn
+	oldDeps := runKitInstallDepsFn
+	t.Cleanup(func() {
+		commandFactory = oldFactory
+		findRemoteKitFn = oldFind
+		fetchRemoteKitFn = oldFetch
+		remoteKitRevFn = oldRev
+		runKitInstallDepsFn = oldDeps
+	})
+	st := stateFixture(t, home)
+	kitDir := filepath.Join(home, ".scribe", "kits")
+	if err := os.MkdirAll(kitDir, 0o755); err != nil {
+		t.Fatalf("mkdir kit dir: %v", err)
+	}
+	kitPath := filepath.Join(kitDir, "baseline.yaml")
+	original := []byte("name: baseline\nskills:\n  - tdd\n")
+	if err := os.WriteFile(kitPath, original, 0o644); err != nil {
+		t.Fatalf("write original kit: %v", err)
+	}
+	hash, err := hashKitFile("baseline", kitPath)
+	if err != nil {
+		t.Fatalf("hash original kit: %v", err)
+	}
+	st.Kits["baseline"] = state.InstalledKit{Name: "baseline", SourceRegistry: "acme/skills", Rev: "old", ContentHash: hash}
+	edited := []byte("name: baseline\nskills:\n  - tdd\n  - local-edit\n")
+	if err := os.WriteFile(kitPath, edited, 0o644); err != nil {
+		t.Fatalf("write edited kit: %v", err)
+	}
+
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) {
+				return &config.Config{Registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}}}, nil
+			},
+			State:  func() (*state.State, error) { return st, nil },
+			Client: func() (*gh.Client, error) { return gh.NewClient(context.Background(), ""), nil },
+		}
+	}
+	findRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, _, name string) (manifest.KitEntry, error) {
+		return manifest.KitEntry{Name: name}, nil
+	}
+	fetchRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, registryRepo string, entry manifest.KitEntry) (*kit.Kit, error) {
+		return &kit.Kit{Name: entry.Name, Skills: []string{"tdd", "upstream"}, Source: &kit.Source{Registry: registryRepo}}, nil
+	}
+	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "new", nil }
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, _ map[string][]kitInstallDep) error {
+		t.Fatal("dependencies should not install after local kit conflict")
+		return nil
+	}
+
+	cmd := newKitSyncCommand()
+	cmd.SetArgs([]string{"--json"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("expected local edit conflict")
+	}
+	if got := clierrors.ExitCode(err); got != clierrors.ExitConflict {
+		t.Fatalf("exit = %d, want %d; err=%v", got, clierrors.ExitConflict, err)
+	}
+	if !strings.Contains(err.Error(), "local edits") {
+		t.Fatalf("error = %v, want local edits message", err)
+	}
+	got, err := os.ReadFile(kitPath)
+	if err != nil {
+		t.Fatalf("read kit path: %v", err)
+	}
+	if string(got) != string(edited) {
+		t.Fatalf("kit file was overwritten:\n%s", got)
+	}
+	if st.Kits["baseline"].Rev != "old" {
+		t.Fatalf("state rev = %q, want old", st.Kits["baseline"].Rev)
 	}
 }

--- a/cmd/kit_install_test.go
+++ b/cmd/kit_install_test.go
@@ -62,18 +62,16 @@ func TestKitInstallWritesKitStateAndInstallsSameRegistryDeps(t *testing.T) {
 		return &kit.Kit{
 			Name:        entry.Name,
 			Description: "Baseline",
-			Skills:      []string{"tdd", "other/skills:debugging", "missing/skills:qa"},
+			Skills:      []string{"tdd", "other/skills:debugging"},
 			Source:      &kit.Source{Registry: registryRepo},
 		}, nil
 	}
 	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) {
 		return "abc123", nil
 	}
-	var gotRegistry string
-	var gotDeps []string
-	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, registryRepo string, skillNames []string) error {
-		gotRegistry = registryRepo
-		gotDeps = append([]string(nil), skillNames...)
+	var gotDeps map[string][]kitInstallDep
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep) error {
+		gotDeps = depsByRegistry
 		return nil
 	}
 
@@ -85,8 +83,12 @@ func TestKitInstallWritesKitStateAndInstallsSameRegistryDeps(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("kit install: %v", err)
 	}
-	if gotRegistry != "acme/skills" || !reflect.DeepEqual(gotDeps, []string{"tdd"}) {
-		t.Fatalf("deps registry=%q deps=%v", gotRegistry, gotDeps)
+	wantDeps := map[string][]kitInstallDep{
+		"acme/skills":  {{Name: "tdd"}},
+		"other/skills": {{Name: "debugging"}},
+	}
+	if !reflect.DeepEqual(gotDeps, wantDeps) {
+		t.Fatalf("deps = %#v, want %#v", gotDeps, wantDeps)
 	}
 	if _, err := os.Stat(filepath.Join(home, ".scribe", "kits", "baseline.yaml")); err != nil {
 		t.Fatalf("installed kit missing: %v", err)
@@ -113,10 +115,7 @@ func TestKitInstallWritesKitStateAndInstallsSameRegistryDeps(t *testing.T) {
 	if err := json.Unmarshal(env.Data, &data); err != nil {
 		t.Fatalf("unmarshal data: %v", err)
 	}
-	if len(data.MissingRefs) != 2 {
-		t.Fatalf("missing refs = %#v", data.MissingRefs)
-	}
-	if data.MissingRefs[0].Reason != "cross_registry_deferred" || data.MissingRefs[1].Reason != "registry_not_connected" {
+	if len(data.MissingRefs) != 0 {
 		t.Fatalf("missing refs = %#v", data.MissingRefs)
 	}
 }
@@ -174,5 +173,247 @@ func TestKitInstallMissingKit(t *testing.T) {
 	}
 	if got := clierrors.ExitCode(err); got != clierrors.ExitNotFound {
 		t.Fatalf("exit = %d, want %d; err=%v", got, clierrors.ExitNotFound, err)
+	}
+}
+
+func TestKitInstallNoInteractionReturnsMissingRegistries(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	oldFactory := commandFactory
+	oldFind := findRemoteKitFn
+	oldFetch := fetchRemoteKitFn
+	oldRev := remoteKitRevFn
+	t.Cleanup(func() {
+		commandFactory = oldFactory
+		findRemoteKitFn = oldFind
+		fetchRemoteKitFn = oldFetch
+		remoteKitRevFn = oldRev
+	})
+	st := stateFixture(t, home)
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) {
+				return &config.Config{Registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}}}, nil
+			},
+			State:  func() (*state.State, error) { return st, nil },
+			Client: func() (*gh.Client, error) { return gh.NewClient(context.Background(), ""), nil },
+		}
+	}
+	findRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, _, name string) (manifest.KitEntry, error) {
+		return manifest.KitEntry{Name: name}, nil
+	}
+	fetchRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, registryRepo string, entry manifest.KitEntry) (*kit.Kit, error) {
+		return &kit.Kit{Name: entry.Name, Skills: []string{"other/skills:debugging"}, Source: &kit.Source{Registry: registryRepo}}, nil
+	}
+	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "abc123", nil }
+
+	cmd := newKitInstallCommand()
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"acme/skills:baseline", "--json", "--no-interaction"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected partial error")
+	}
+	if got := clierrors.ExitCode(err); got != clierrors.ExitPartial {
+		t.Fatalf("exit = %d, want %d; err=%v", got, clierrors.ExitPartial, err)
+	}
+	var env testEnvelope
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v\n%s", err, out.String())
+	}
+	var data struct {
+		MissingRegistries []string `json:"missing_registries"`
+		MissingRefs       []struct {
+			Raw    string `json:"raw"`
+			Reason string `json:"reason"`
+		} `json:"missing_refs"`
+	}
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if !reflect.DeepEqual(data.MissingRegistries, []string{"other/skills"}) {
+		t.Fatalf("missing registries = %#v", data.MissingRegistries)
+	}
+	if len(data.MissingRefs) != 1 || data.MissingRefs[0].Reason != "registry_not_connected" {
+		t.Fatalf("missing refs = %#v", data.MissingRefs)
+	}
+}
+
+func TestKitInstallConnectPromptInstallsCrossRegistryRefs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	oldFactory := commandFactory
+	oldFind := findRemoteKitFn
+	oldFetch := fetchRemoteKitFn
+	oldRev := remoteKitRevFn
+	oldDeps := runKitInstallDepsFn
+	oldConfirm := confirmKitMissingRegistriesFn
+	t.Cleanup(func() {
+		commandFactory = oldFactory
+		findRemoteKitFn = oldFind
+		fetchRemoteKitFn = oldFetch
+		remoteKitRevFn = oldRev
+		runKitInstallDepsFn = oldDeps
+		confirmKitMissingRegistriesFn = oldConfirm
+	})
+	st := stateFixture(t, home)
+	cfg := &config.Config{Registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}}}
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) { return cfg, nil },
+			State:  func() (*state.State, error) { return st, nil },
+			Client: func() (*gh.Client, error) { return gh.NewClient(context.Background(), ""), nil },
+		}
+	}
+	findRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, _, name string) (manifest.KitEntry, error) {
+		return manifest.KitEntry{Name: name}, nil
+	}
+	fetchRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, registryRepo string, entry manifest.KitEntry) (*kit.Kit, error) {
+		return &kit.Kit{Name: entry.Name, Skills: []string{"other/skills:debugging"}, Source: &kit.Source{Registry: registryRepo}}, nil
+	}
+	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "abc123", nil }
+	confirmKitMissingRegistriesFn = func(_ *cobra.Command, cfg *config.Config, registries []string) error {
+		if !reflect.DeepEqual(registries, []string{"other/skills"}) {
+			t.Fatalf("registries = %#v", registries)
+		}
+		cfg.AddRegistry(config.RegistryConfig{Repo: "other/skills", Enabled: true})
+		return nil
+	}
+	var gotDeps map[string][]kitInstallDep
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep) error {
+		gotDeps = depsByRegistry
+		return nil
+	}
+
+	cmd := newKitInstallCommand()
+	cmd.SetArgs([]string{"acme/skills:baseline"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("kit install: %v", err)
+	}
+	want := map[string][]kitInstallDep{"other/skills": {{Name: "debugging"}}}
+	if !reflect.DeepEqual(gotDeps, want) {
+		t.Fatalf("deps = %#v, want %#v", gotDeps, want)
+	}
+}
+
+func TestKitInstallAliasMappingPassesSkillAlias(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	oldFactory := commandFactory
+	oldFind := findRemoteKitFn
+	oldFetch := fetchRemoteKitFn
+	oldRev := remoteKitRevFn
+	oldDeps := runKitInstallDepsFn
+	t.Cleanup(func() {
+		commandFactory = oldFactory
+		findRemoteKitFn = oldFind
+		fetchRemoteKitFn = oldFetch
+		remoteKitRevFn = oldRev
+		runKitInstallDepsFn = oldDeps
+	})
+	st := stateFixture(t, home)
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) {
+				return &config.Config{Registries: []config.RegistryConfig{
+					{Repo: "acme/skills", Enabled: true},
+					{Repo: "other/skills", Enabled: true},
+				}}, nil
+			},
+			State:  func() (*state.State, error) { return st, nil },
+			Client: func() (*gh.Client, error) { return gh.NewClient(context.Background(), ""), nil },
+		}
+	}
+	findRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, _, name string) (manifest.KitEntry, error) {
+		return manifest.KitEntry{Name: name}, nil
+	}
+	fetchRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, registryRepo string, entry manifest.KitEntry) (*kit.Kit, error) {
+		return &kit.Kit{
+			Name:         entry.Name,
+			Skills:       []string{"other/skills:tdd"},
+			SkillAliases: map[string]string{"other/skills:tdd": "other-tdd"},
+			Source:       &kit.Source{Registry: registryRepo},
+		}, nil
+	}
+	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "abc123", nil }
+	var gotDeps map[string][]kitInstallDep
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep) error {
+		gotDeps = depsByRegistry
+		return nil
+	}
+
+	cmd := newKitInstallCommand()
+	cmd.SetArgs([]string{"acme/skills:baseline"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("kit install: %v", err)
+	}
+	want := map[string][]kitInstallDep{"other/skills": {{Name: "tdd", Alias: "other-tdd"}}}
+	if !reflect.DeepEqual(gotDeps, want) {
+		t.Fatalf("deps = %#v, want %#v", gotDeps, want)
+	}
+}
+
+func TestKitSyncRefreshesInstalledRegistryKit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	oldFactory := commandFactory
+	oldFind := findRemoteKitFn
+	oldFetch := fetchRemoteKitFn
+	oldRev := remoteKitRevFn
+	oldDeps := runKitInstallDepsFn
+	t.Cleanup(func() {
+		commandFactory = oldFactory
+		findRemoteKitFn = oldFind
+		fetchRemoteKitFn = oldFetch
+		remoteKitRevFn = oldRev
+		runKitInstallDepsFn = oldDeps
+	})
+	st := stateFixture(t, home)
+	st.Kits["baseline"] = state.InstalledKit{Name: "baseline", SourceRegistry: "acme/skills", Rev: "old"}
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) {
+				return &config.Config{Registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}}}, nil
+			},
+			State:  func() (*state.State, error) { return st, nil },
+			Client: func() (*gh.Client, error) { return gh.NewClient(context.Background(), ""), nil },
+		}
+	}
+	findRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, _, name string) (manifest.KitEntry, error) {
+		return manifest.KitEntry{Name: name}, nil
+	}
+	fetchRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, registryRepo string, entry manifest.KitEntry) (*kit.Kit, error) {
+		return &kit.Kit{Name: entry.Name, Skills: []string{"tdd"}, Source: &kit.Source{Registry: registryRepo}}, nil
+	}
+	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "new", nil }
+	var gotDeps map[string][]kitInstallDep
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep) error {
+		gotDeps = depsByRegistry
+		return nil
+	}
+
+	cmd := newKitSyncCommand()
+	cmd.SetArgs([]string{"--json"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("kit sync: %v", err)
+	}
+	if st.Kits["baseline"].Rev != "new" || st.Kits["baseline"].ContentHash == "" {
+		t.Fatalf("kit state = %+v", st.Kits["baseline"])
+	}
+	if _, err := os.Stat(filepath.Join(home, ".scribe", "kits", "baseline.yaml")); err != nil {
+		t.Fatalf("synced kit missing: %v", err)
+	}
+	want := map[string][]kitInstallDep{"acme/skills": {{Name: "tdd"}}}
+	if !reflect.DeepEqual(gotDeps, want) {
+		t.Fatalf("deps = %#v, want %#v", gotDeps, want)
 	}
 }

--- a/cmd/kit_schema.go
+++ b/cmd/kit_schema.go
@@ -72,6 +72,7 @@ const kitInstallOutputSchema = `{
     "path": {"type": "string"},
     "rev": {"type": "string"},
     "skills_installed": {"type": "array", "items": {"type": "string"}},
+    "missing_registries": {"type": "array", "items": {"type": "string"}},
     "missing_refs": {
       "type": "array",
       "items": {
@@ -93,8 +94,20 @@ const kitInstallOutputSchema = `{
   }
 }`
 
+const kitSyncOutputSchema = `{
+  "type": "object",
+  "required": ["kits"],
+  "properties": {
+    "kits": {
+      "type": "array",
+      "items": ` + kitInstallOutputSchema + `
+    }
+  }
+}`
+
 func init() {
 	clischema.Register("scribe kit list", kitListOutputSchema)
 	clischema.Register("scribe kit show", kitShowOutputSchema)
 	clischema.Register("scribe kit install", kitInstallOutputSchema)
+	clischema.Register("scribe kit sync", kitSyncOutputSchema)
 }

--- a/cmd/project_sync.go
+++ b/cmd/project_sync.go
@@ -417,7 +417,11 @@ func resolveProjectSkillNames(pf *projectfile.ProjectFile, kits map[string]*kit.
 	for _, kitName := range pf.Kits {
 		if k, ok := kits[kitName]; ok {
 			for _, skill := range k.Skills {
-				add(skill)
+				if alias := k.SkillAliases[skill]; alias != "" {
+					add(alias)
+					continue
+				}
+				add(projectSkillName(skill))
 			}
 		}
 	}

--- a/internal/kit/kit.go
+++ b/internal/kit/kit.go
@@ -13,11 +13,12 @@ import (
 
 // Kit is a named bundle of Scribe skills.
 type Kit struct {
-	Name        string   `yaml:"name"`
-	Description string   `yaml:"description,omitempty"`
-	Skills      []string `yaml:"skills"`
-	MCPServers  []string `yaml:"mcp_servers,omitempty"`
-	Source      *Source  `yaml:"source,omitempty"`
+	Name         string            `yaml:"name"`
+	Description  string            `yaml:"description,omitempty"`
+	Skills       []string          `yaml:"-"`
+	SkillAliases map[string]string `yaml:"-"`
+	MCPServers   []string          `yaml:"mcp_servers,omitempty"`
+	Source       *Source           `yaml:"source,omitempty"`
 }
 
 type kitYAML struct {
@@ -28,16 +29,20 @@ type kitYAML struct {
 	Source      *Source    `yaml:"source,omitempty"`
 }
 
-type skillRef string
+type skillRef struct {
+	Ref   string `yaml:"ref"`
+	Alias string `yaml:"alias,omitempty"`
+}
 
 func (s *skillRef) UnmarshalYAML(value *yaml.Node) error {
 	switch value.Kind {
 	case yaml.ScalarNode:
-		*s = skillRef(value.Value)
+		*s = skillRef{Ref: value.Value}
 		return nil
 	case yaml.MappingNode:
 		var raw struct {
-			Ref string `yaml:"ref"`
+			Ref   string `yaml:"ref"`
+			Alias string `yaml:"alias,omitempty"`
 		}
 		if err := value.Decode(&raw); err != nil {
 			return err
@@ -45,11 +50,21 @@ func (s *skillRef) UnmarshalYAML(value *yaml.Node) error {
 		if raw.Ref == "" {
 			return errors.New("skill mapping must include ref")
 		}
-		*s = skillRef(raw.Ref)
+		*s = skillRef{Ref: raw.Ref, Alias: raw.Alias}
 		return nil
 	default:
 		return fmt.Errorf("skill ref must be a string or mapping, got YAML kind %d", value.Kind)
 	}
+}
+
+func (s skillRef) MarshalYAML() (any, error) {
+	if s.Alias == "" {
+		return s.Ref, nil
+	}
+	return struct {
+		Ref   string `yaml:"ref"`
+		Alias string `yaml:"alias,omitempty"`
+	}{Ref: s.Ref, Alias: s.Alias}, nil
 }
 
 func (k *Kit) UnmarshalYAML(value *yaml.Node) error {
@@ -60,12 +75,33 @@ func (k *Kit) UnmarshalYAML(value *yaml.Node) error {
 	k.Name = raw.Name
 	k.Description = raw.Description
 	k.Skills = make([]string, 0, len(raw.Skills))
+	k.SkillAliases = nil
 	for _, ref := range raw.Skills {
-		k.Skills = append(k.Skills, string(ref))
+		k.Skills = append(k.Skills, ref.Ref)
+		if ref.Alias != "" {
+			if k.SkillAliases == nil {
+				k.SkillAliases = map[string]string{}
+			}
+			k.SkillAliases[ref.Ref] = ref.Alias
+		}
 	}
 	k.MCPServers = raw.MCPServers
 	k.Source = raw.Source
 	return nil
+}
+
+func (k Kit) MarshalYAML() (any, error) {
+	raw := kitYAML{
+		Name:        k.Name,
+		Description: k.Description,
+		Skills:      make([]skillRef, 0, len(k.Skills)),
+		MCPServers:  k.MCPServers,
+		Source:      k.Source,
+	}
+	for _, ref := range k.Skills {
+		raw.Skills = append(raw.Skills, skillRef{Ref: ref, Alias: k.SkillAliases[ref]})
+	}
+	return raw, nil
 }
 
 // Source records the registry source for a kit.

--- a/internal/kit/kit_test.go
+++ b/internal/kit/kit_test.go
@@ -103,3 +103,22 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 		t.Fatalf("round trip = %#v, want %#v", got, want)
 	}
 }
+
+func TestLoadParsesSkillAliasMappings(t *testing.T) {
+	got, err := Parse([]byte(`
+name: baseline
+skills:
+  - tdd
+  - ref: other/skills:tdd
+    alias: other-tdd
+`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if !reflect.DeepEqual(got.Skills, []string{"tdd", "other/skills:tdd"}) {
+		t.Fatalf("skills = %#v", got.Skills)
+	}
+	if got.SkillAliases["other/skills:tdd"] != "other-tdd" {
+		t.Fatalf("aliases = %#v", got.SkillAliases)
+	}
+}

--- a/internal/kit/resolver_detail.go
+++ b/internal/kit/resolver_detail.go
@@ -71,7 +71,7 @@ func ResolveWithDetail(ctx context.Context, in ResolverInput) (Resolution, error
 			defaultRegistry = k.Source.Registry
 		}
 		for _, raw := range k.Skills {
-			refs = append(refs, kitRefWithRegistry{Raw: raw, DefaultRegistry: defaultRegistry, Published: k.Source != nil})
+			refs = append(refs, kitRefWithRegistry{Raw: raw, Alias: k.SkillAliases[raw], DefaultRegistry: defaultRegistry, Published: k.Source != nil})
 		}
 	}
 	for _, raw := range pf.Add {
@@ -118,12 +118,25 @@ func ResolveWithDetail(ctx context.Context, in ResolverInput) (Resolution, error
 			result.Missing = append(result.Missing, *missing)
 			continue
 		}
+		if rawRef.Alias != "" && len(matches) != 1 {
+			return Resolution{}, fmt.Errorf("alias %q for %q requires exactly one resolved skill", rawRef.Alias, rawRef.Raw)
+		}
 		for _, name := range matches {
+			localName := name
+			aliasFor := ""
+			aliased := false
+			if rawRef.Alias != "" {
+				localName = rawRef.Alias
+				aliasFor = name
+				aliased = true
+			}
 			addResolvedSkill(&result, seen, ResolvedSkill{
-				Name:     name,
+				Name:     localName,
 				Origin:   origin,
 				Registry: ref.Registry,
 				Source:   ref.Source,
+				Aliased:  aliased,
+				AliasFor: aliasFor,
 			})
 		}
 	}
@@ -143,6 +156,7 @@ func ResolveWithDetail(ctx context.Context, in ResolverInput) (Resolution, error
 
 type kitRefWithRegistry struct {
 	Raw             string
+	Alias           string
 	DefaultRegistry string
 	Published       bool
 }

--- a/internal/kit/resolver_detail_test.go
+++ b/internal/kit/resolver_detail_test.go
@@ -110,6 +110,31 @@ func TestResolveWithDetailCrossRegistryGlobUsesCatalog(t *testing.T) {
 	}
 }
 
+func TestResolveWithDetailAliasAvoidsNameConflict(t *testing.T) {
+	got, err := ResolveWithDetail(context.Background(), ResolverInput{
+		Project: &projectfile.ProjectFile{Kits: []string{"baseline"}},
+		Kits: map[string]*Kit{"baseline": {
+			Name:         "baseline",
+			Skills:       []string{"tdd", "other/skills:tdd"},
+			SkillAliases: map[string]string{"other/skills:tdd": "other-tdd"},
+			Source:       &Source{Registry: "acme/skills"},
+		}},
+		Registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}, {Repo: "other/skills", Enabled: true}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveWithDetail: %v", err)
+	}
+	if joinedSkills(got.Skills) != "other-tdd:cross_registry:other/skills,tdd:same_registry:acme/skills" {
+		t.Fatalf("skills = %s", joinedSkills(got.Skills))
+	}
+	if len(got.Conflicts) != 0 {
+		t.Fatalf("conflicts = %#v", got.Conflicts)
+	}
+	if !got.Skills[0].Aliased || got.Skills[0].AliasFor != "tdd" {
+		t.Fatalf("aliased skill = %+v", got.Skills[0])
+	}
+}
+
 func joinedSkills(skills []ResolvedSkill) string {
 	parts := make([]string, 0, len(skills))
 	for _, skill := range skills {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -155,6 +155,9 @@ type InstalledSkill struct {
 	// legacy entries defaults to KindSkill; the first sync after upgrade
 	// may flip an entry to KindPackage via the reclassification pass.
 	Kind Kind `json:"kind,omitempty"`
+	// AliasFor records the upstream skill name when this local entry was
+	// installed under a kit-defined alias.
+	AliasFor string `json:"alias_for,omitempty"`
 
 	// Package-specific fields (omitted for regular skills).
 	Type       string            `json:"type,omitempty"`
@@ -245,6 +248,7 @@ type legacyInstalledSkill struct {
 	Origin        Origin            `json:"origin,omitempty"`
 	ToolsMode     ToolsMode         `json:"tools_mode,omitempty"`
 	Kind          Kind              `json:"kind,omitempty"`
+	AliasFor      string            `json:"alias_for,omitempty"`
 	Projections   []ProjectionEntry `json:"projections,omitempty"`
 }
 
@@ -733,6 +737,7 @@ func legacyToSkill(ls legacyInstalledSkill) InstalledSkill {
 		ManagedPaths:  append([]string(nil), ls.Paths...),
 		Origin:        ls.Origin,
 		Kind:          kind,
+		AliasFor:      ls.AliasFor,
 		Type:          ls.Type,
 		InstallCmd:    ls.InstallCmd,
 		UpdateCmd:     ls.UpdateCmd,

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -90,6 +90,10 @@ type Syncer struct {
 	// Used by registry kits to avoid same-name collisions across sources.
 	SkillAliases map[string]string
 
+	// PinnedSkillSources overrides catalog source refs for named skills during
+	// kit dependency installs.
+	PinnedSkillSources map[string]string
+
 	// OnRegistryFetched runs after a registry manifest has been fetched and
 	// applied successfully. Callers use this for local metadata caches.
 	OnRegistryFetched func(repo string, m *manifest.Manifest) error
@@ -192,7 +196,10 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 	treeCache := map[string][]provider.TreeEntry{}
 
 	for i := range m.Catalog {
-		entry := &m.Catalog[i]
+		entry := m.Catalog[i]
+		if pinned := s.PinnedSkillSources[entry.Name]; pinned != "" {
+			entry.Source = pinned
+		}
 		// Use bare name for lookup — flat storage model.
 		installedPtr := lookupInstalled(st, entry.Name)
 		locallyModified := false
@@ -222,33 +229,37 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 					}
 				}
 			case src.IsBranch():
-				key := src.Owner + "/" + src.Repo + "/" + src.Ref
-				tree, ok := treeCache[key]
-				if !ok {
-					fetched, terr := s.Client.GetTree(ctx, src.Owner, src.Repo, src.Ref)
-					if terr == nil {
-						treeCache[key] = fetched
-						tree = fetched
+				if isCommitSHA(src.Ref) {
+					latestSHA = src.Ref
+				} else {
+					key := src.Owner + "/" + src.Repo + "/" + src.Ref
+					tree, ok := treeCache[key]
+					if !ok {
+						fetched, terr := s.Client.GetTree(ctx, src.Owner, src.Repo, src.Ref)
+						if terr == nil {
+							treeCache[key] = fetched
+							tree = fetched
+						}
 					}
-				}
-				if len(tree) > 0 {
-					blobSHAs = resolveSkillBlobSHAs(tree, *entry)
-					if resolvedSHA, found := blobSHAs[skillBlobTarget(*entry)]; found {
-						latestSHA = resolvedSHA
-					} else {
-						latestSHA = missingSkillBlobSHA
+					if len(tree) > 0 {
+						blobSHAs = resolveSkillBlobSHAs(tree, entry)
+						if resolvedSHA, found := blobSHAs[skillBlobTarget(entry)]; found {
+							latestSHA = resolvedSHA
+						} else {
+							latestSHA = missingSkillBlobSHA
+						}
 					}
 				}
 			}
 		}
 
-		status := compareEntry(*entry, installedPtr, latestSHA, teamRepo, locallyModified)
+		status := compareEntry(entry, installedPtr, latestSHA, teamRepo, locallyModified)
 		statuses = append(statuses, SkillStatus{
 			Name:       entry.Name,
 			Status:     status,
 			Installed:  installedPtr,
-			Entry:      entry,
-			LoadoutRef: loadoutRef(*entry),
+			Entry:      &entry,
+			LoadoutRef: loadoutRef(entry),
 			Maintainer: entry.Maintainer(),
 			IsPackage:  entry.IsPackage(),
 			LatestSHA:  latestSHA,
@@ -1899,4 +1910,17 @@ func entrySource(e *manifest.Entry) string {
 		return ""
 	}
 	return e.Source
+}
+
+func isCommitSHA(ref string) bool {
+	if len(ref) != 40 {
+		return false
+	}
+	for _, r := range ref {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -86,6 +86,10 @@ type Syncer struct {
 	// real directory already exists at the original tool projection path.
 	AliasName string
 
+	// SkillAliases installs named incoming skills under fixed local names.
+	// Used by registry kits to avoid same-name collisions across sources.
+	SkillAliases map[string]string
+
 	// OnRegistryFetched runs after a registry manifest has been fetched and
 	// applied successfully. Callers use this for local metadata caches.
 	OnRegistryFetched func(repo string, m *manifest.Manifest) error
@@ -871,7 +875,15 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 			}
 
 			installName := sk.Name
-			if conflict, ok := s.firstRealDirectoryConflict(sk.Name, effectiveTools); ok {
+			aliasFor := ""
+			if alias := strings.TrimSpace(s.SkillAliases[sk.Name]); alias != "" {
+				installName = alias
+				aliasFor = sk.Name
+				if installed == nil {
+					installed = lookupInstalled(st, installName)
+				}
+			}
+			if conflict, ok := s.firstRealDirectoryConflict(installName, effectiveTools); ok {
 				resolution, err := s.resolveNameConflict(conflict, st, effectiveTools)
 				if err != nil {
 					return err
@@ -973,6 +985,7 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 				Paths:         append([]string(nil), managedPaths...),
 				Projections:   mergeProjection(installed, s.ProjectRoot, toolNames),
 				ManagedPaths:  managedPaths,
+				AliasFor:      aliasFor,
 			})
 			// Save after each successful install — partial sync is safe.
 			if err := st.Save(); err != nil {

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -1414,6 +1414,42 @@ func TestRunWithDiff_NameConflictAliasInstallsIncomingUnderAlias(t *testing.T) {
 	assertConflictResolutionEvent(t, events, sync.NameConflictActionAlias, "qa-registry")
 }
 
+func TestRunWithDiff_SkillAliasesInstallUnderAlias(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	syncer := &sync.Syncer{
+		Client:       &syncTestFetcher{files: []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# tdd\n")}}},
+		Tools:        []tools.Tool{testProjectionTool{root: filepath.Join(home, ".test-tool")}},
+		SkillAliases: map[string]string{"tdd": "other-tdd"},
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{}}
+
+	if err := syncer.RunWithDiff(context.Background(), "other/skills", []sync.SkillStatus{{
+		Name:   "tdd",
+		Status: sync.StatusMissing,
+		Entry:  &manifest.Entry{Name: "tdd", Source: "github:other/skills@main"},
+	}}, st); err != nil {
+		t.Fatalf("RunWithDiff: %v", err)
+	}
+	if _, ok := st.Installed["tdd"]; ok {
+		t.Fatal("source name should not be installed")
+	}
+	installed, ok := st.Installed["other-tdd"]
+	if !ok {
+		t.Fatal("alias should be installed")
+	}
+	if installed.AliasFor != "tdd" {
+		t.Fatalf("AliasFor = %q, want tdd", installed.AliasFor)
+	}
+	if len(installed.Sources) != 1 || installed.Sources[0].Registry != "other/skills" {
+		t.Fatalf("sources = %#v", installed.Sources)
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".test-tool", "other-tdd")); err != nil {
+		t.Fatalf("alias projection missing: %v", err)
+	}
+}
+
 func TestRunWithDiff_NameConflictAliasCollisionReturnsConflict(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -55,8 +55,9 @@ func (f *syncTestFetcher) GetTree(ctx context.Context, owner, repo, ref string) 
 
 // mockProvider implements provider.Provider for tests.
 type mockProvider struct {
-	entries []manifest.Entry
-	files   []tools.SkillFile
+	entries        []manifest.Entry
+	files          []tools.SkillFile
+	fetchedSources []string
 }
 
 func (m *mockProvider) Discover(_ context.Context, repo string) (*provider.DiscoverResult, error) {
@@ -64,11 +65,46 @@ func (m *mockProvider) Discover(_ context.Context, repo string) (*provider.Disco
 }
 
 func (m *mockProvider) Fetch(_ context.Context, entry manifest.Entry) ([]provider.File, error) {
+	m.fetchedSources = append(m.fetchedSources, entry.Source)
 	out := make([]provider.File, len(m.files))
 	for i, f := range m.files {
 		out[i] = provider.File{Path: f.Path, Content: f.Content}
 	}
 	return out, nil
+}
+
+func TestRunPinnedSkillSourceOverridesManifestSource(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	commit := "0123456789abcdef0123456789abcdef01234567"
+	provider := &mockProvider{
+		entries: []manifest.Entry{{Name: "tdd", Source: "github:other/skills@main"}},
+		files:   []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# tdd\n")}},
+	}
+	syncer := &sync.Syncer{
+		Client:             &sync.NoopFetcher{},
+		Provider:           provider,
+		Tools:              []tools.Tool{testProjectionTool{root: filepath.Join(home, ".test-tool")}},
+		PinnedSkillSources: map[string]string{"tdd": "github:other/skills@" + commit},
+		SkillFilter:        []string{"tdd"},
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{}}
+
+	if err := syncer.Run(context.Background(), "other/skills", st); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !reflect.DeepEqual(provider.fetchedSources, []string{"github:other/skills@" + commit}) {
+		t.Fatalf("fetched sources = %#v", provider.fetchedSources)
+	}
+	installed := st.Installed["tdd"]
+	if len(installed.Sources) != 1 {
+		t.Fatalf("sources = %#v", installed.Sources)
+	}
+	source := installed.Sources[0]
+	if source.Registry != "other/skills" || source.SourceRepo != "other/skills" || source.Ref != commit || source.LastSHA != commit {
+		t.Fatalf("source = %#v", source)
+	}
 }
 
 func TestRunProject_ProjectsVendoredBoostSkillWithoutClaude(t *testing.T) {

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -33,7 +33,8 @@ type Bag struct {
 	InstallAllFlag bool   // --all: install all available skills without prompting
 	ForceBudget    bool   // --force: allow projection over agent description-byte budgets
 	AliasName      string // --alias: install incoming skill under another name on projection conflict
-	LazyGitHub     bool   // skip eager GitHub client/provider setup for local-only flows
+	SkillAliases   map[string]string
+	LazyGitHub     bool // skip eager GitHub client/provider setup for local-only flows
 	Factory        *app.Factory
 
 	// SkillFilter is populated by StepSelectSkills with the names the user chose.

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -23,19 +23,20 @@ type RepositoryVisibilityClient interface {
 // Each step reads/writes only its relevant fields.
 type Bag struct {
 	// Inputs (set by cmd/ before Run)
-	Args           []string
-	JSONFlag       bool
-	RepoFlag       string // --registry filter
-	RemoteFlag     bool   // --remote: show available skills from registries
-	BrowseFlag     bool   // browse mode: remote catalog UI with install-first actions
-	InitialQuery   string // initial search/filter text for TUI surfaces
-	TrustAllFlag   bool   // --trust-all: approve all package commands without prompting
-	InstallAllFlag bool   // --all: install all available skills without prompting
-	ForceBudget    bool   // --force: allow projection over agent description-byte budgets
-	AliasName      string // --alias: install incoming skill under another name on projection conflict
-	SkillAliases   map[string]string
-	LazyGitHub     bool // skip eager GitHub client/provider setup for local-only flows
-	Factory        *app.Factory
+	Args               []string
+	JSONFlag           bool
+	RepoFlag           string // --registry filter
+	RemoteFlag         bool   // --remote: show available skills from registries
+	BrowseFlag         bool   // browse mode: remote catalog UI with install-first actions
+	InitialQuery       string // initial search/filter text for TUI surfaces
+	TrustAllFlag       bool   // --trust-all: approve all package commands without prompting
+	InstallAllFlag     bool   // --all: install all available skills without prompting
+	ForceBudget        bool   // --force: allow projection over agent description-byte budgets
+	AliasName          string // --alias: install incoming skill under another name on projection conflict
+	SkillAliases       map[string]string
+	PinnedSkillSources map[string]string
+	LazyGitHub         bool // skip eager GitHub client/provider setup for local-only flows
+	Factory            *app.Factory
 
 	// SkillFilter is populated by StepSelectSkills with the names the user chose.
 	// If non-empty, StepSyncSkills passes it to the Syncer so only those skills

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -876,19 +876,20 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 	resolved := map[string]sync.SkillStatus{}
 
 	syncer := &sync.Syncer{
-		Client:           sync.WrapGitHubClient(b.Client),
-		Provider:         b.Provider,
-		Tools:            b.Tools,
-		Executor:         &sync.ShellExecutor{},
-		TrustAll:         b.TrustAllFlag,
-		ForceBudget:      b.ForceBudget,
-		AliasName:        b.AliasName,
-		SkillAliases:     b.SkillAliases,
-		SkillFilter:      b.SkillFilter,
-		KitFilter:        b.KitFilter,
-		KitFilterEnabled: b.KitFilterEnabled,
-		ProjectRoot:      b.ProjectRoot,
-		SkipMissing:      workflowSkipMissing(b),
+		Client:             sync.WrapGitHubClient(b.Client),
+		Provider:           b.Provider,
+		Tools:              b.Tools,
+		Executor:           &sync.ShellExecutor{},
+		TrustAll:           b.TrustAllFlag,
+		ForceBudget:        b.ForceBudget,
+		AliasName:          b.AliasName,
+		SkillAliases:       b.SkillAliases,
+		PinnedSkillSources: b.PinnedSkillSources,
+		SkillFilter:        b.SkillFilter,
+		KitFilter:          b.KitFilter,
+		KitFilterEnabled:   b.KitFilterEnabled,
+		ProjectRoot:        b.ProjectRoot,
+		SkipMissing:        workflowSkipMissing(b),
 		OnRegistryFetched: func(repo string, m *manifest.Manifest) error {
 			return updateRegistryIndex(ctx, b, repo, m)
 		},

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -883,6 +883,7 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 		TrustAll:         b.TrustAllFlag,
 		ForceBudget:      b.ForceBudget,
 		AliasName:        b.AliasName,
+		SkillAliases:     b.SkillAliases,
 		SkillFilter:      b.SkillFilter,
 		KitFilter:        b.KitFilter,
 		KitFilterEnabled: b.KitFilterEnabled,


### PR DESCRIPTION
Implements phase 3 for registry kits: kit installs now resolve connected cross-registry refs instead of deferring them, surface missing registries as structured partial output under `--no-interaction`, and preserve kit alias mappings through install/sync/state.

Also adds `scribe kit sync` to refresh installed registry kits from their source registry, update the local kit body/source pin, and refresh referenced deps.

Tests:
- `go test ./...`