### PR TITLE
kits: publish registry kits and browse them

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -15,6 +16,7 @@ import (
 	gh "github.com/Naoray/scribe/internal/github"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/registry"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
@@ -22,6 +24,7 @@ import (
 )
 
 var discoverEntriesFn = discoverEntries
+var discoverKitEntriesFn = discoverKitEntries
 
 func newBrowseCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -34,6 +37,7 @@ func newBrowseCommand() *cobra.Command {
 	cmd.Flags().String("query", "", "Filter remote skills by query")
 	cmd.Flags().String("install", "", "Install a skill by exact name or owner/repo:skill")
 	cmd.Flags().String("registry", "", "Limit browse/install to one connected registry or GitHub owner/repo")
+	cmd.Flags().Bool("kits", false, "Browse registry kits instead of skills")
 	cmd.Flags().Bool("resync", false, "Overwrite local edits with the upstream version for modified skills")
 	addNoInteractionFlag(cmd, "Disable interactive prompts", false)
 	return markJSONSupported(cmd)
@@ -44,6 +48,7 @@ func runBrowse(cmd *cobra.Command, _ []string) error {
 	installRef, _ := cmd.Flags().GetString("install")
 	registryFilter, _ := cmd.Flags().GetString("registry")
 	resync, _ := cmd.Flags().GetBool("resync")
+	kits, _ := cmd.Flags().GetBool("kits")
 	yes := noInteractionFlagPassed(cmd)
 	useJSON, _ := cmd.Flags().GetBool("json")
 	useJSON = useJSON || !isatty.IsTerminal(os.Stdout.Fd())
@@ -71,7 +76,131 @@ func runBrowse(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	if kits {
+		return runBrowseKitsWithDeps(cmd.Context(), repos, query, installRef, cfg, st, client, useJSON, yes)
+	}
+
 	return runBrowseWithDeps(cmd.Context(), repos, query, installRef, cfg, st, client, targets, useJSON, yes, resync)
+}
+
+type kitBrowseEntry struct {
+	Kit       registry.ManifestKit
+	Installed bool
+}
+
+func runBrowseKitsWithDeps(
+	ctx context.Context,
+	repos []string,
+	query string,
+	installRef string,
+	cfg *config.Config,
+	st *state.State,
+	client *gh.Client,
+	useJSON bool,
+	skipConfirm bool,
+) error {
+	if installRef != "" {
+		opts := &kitInstallOptions{json: useJSON, noInteraction: skipConfirm}
+		if !strings.Contains(installRef, ":") && len(repos) == 1 {
+			installRef = repos[0] + ":" + installRef
+		}
+		return runKitInstall(newKitInstallCommand(), installRef, opts)
+	}
+
+	if !useJSON {
+		bag := &workflow.Bag{
+			JSONFlag:         false,
+			RemoteFlag:       true,
+			BrowseFlag:       true,
+			KitBrowseFlag:    true,
+			InitialQuery:     query,
+			LazyGitHub:       false,
+			Factory:          newCommandFactory(),
+			Config:           cfg,
+			State:            st,
+			Client:           client,
+			FilterRegistries: func(_ string, _ []string) ([]string, error) { return repos, nil },
+		}
+		m := newListModel(ctx, bag)
+		prog := tea.NewProgram(m, tea.WithContext(ctx))
+		_, err := prog.Run()
+		if errors.Is(err, tea.ErrInterrupted) {
+			os.Exit(130)
+		}
+		if err != nil {
+			return fmt.Errorf("TUI error: %w", err)
+		}
+		return nil
+	}
+
+	entries, errs := discoverKitEntriesFn(ctx, repos, client, st)
+	for _, e := range errs {
+		fmt.Fprintf(os.Stderr, "warning: %v\n", e)
+	}
+	if query != "" {
+		entries = filterKitEntries(entries, query)
+	}
+	return emitBrowseKitsJSON(entries)
+}
+
+func discoverKitEntries(ctx context.Context, repos []string, client registry.FileFetcher, st *state.State) ([]kitBrowseEntry, []error) {
+	var entries []kitBrowseEntry
+	var errs []error
+	for _, repo := range repos {
+		kits, err := registry.ListKits(ctx, client, repo)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", repo, err))
+			continue
+		}
+		for _, remote := range kits {
+			installed := false
+			if st != nil {
+				if local, ok := st.Kits[remote.Name]; ok {
+					source := local.SourceRegistry
+					if source == "" {
+						source = local.Source
+					}
+					installed = source == repo
+				}
+			}
+			entries = append(entries, kitBrowseEntry{Kit: remote, Installed: installed})
+		}
+	}
+	return entries, errs
+}
+
+func filterKitEntries(entries []kitBrowseEntry, query string) []kitBrowseEntry {
+	q := strings.ToLower(query)
+	var out []kitBrowseEntry
+	for _, e := range entries {
+		if strings.Contains(strings.ToLower(e.Kit.Name), q) || strings.Contains(strings.ToLower(e.Kit.Description), q) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func emitBrowseKitsJSON(entries []kitBrowseEntry) error {
+	type row struct {
+		Name             string `json:"name"`
+		Registry         string `json:"registry"`
+		Path             string `json:"path"`
+		Description      string `json:"description,omitempty"`
+		Author           string `json:"author,omitempty"`
+		InstalledLocally bool   `json:"installed_locally"`
+	}
+	rows := make([]row, 0, len(entries))
+	for _, e := range entries {
+		rows = append(rows, row{
+			Name:             e.Kit.Name,
+			Registry:         e.Kit.Registry,
+			Path:             e.Kit.Path,
+			Description:      e.Kit.Description,
+			Author:           e.Kit.Author,
+			InstalledLocally: e.Installed,
+		})
+	}
+	return json.NewEncoder(os.Stdout).Encode(map[string]any{"results": rows})
 }
 
 func browseRepos(registryFilter string, connected []string) ([]string, error) {

--- a/cmd/browse_test.go
+++ b/cmd/browse_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/registry"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
@@ -53,6 +54,49 @@ func TestRunBrowseWithDeps_JSONQueryFiltersResults(t *testing.T) {
 	}
 	if len(out.Results) != 1 || out.Results[0].Name != "cleanup" {
 		t.Fatalf("results = %+v, want only cleanup", out.Results)
+	}
+}
+
+func TestRunBrowseKitsWithDeps_JSONQueryFiltersResults(t *testing.T) {
+	old := discoverKitEntriesFn
+	defer func() { discoverKitEntriesFn = old }()
+	discoverKitEntriesFn = func(context.Context, []string, registry.FileFetcher, *state.State) ([]kitBrowseEntry, []error) {
+		return []kitBrowseEntry{
+			{Kit: registry.ManifestKit{Registry: "acme/skills", Name: "baseline", Path: "kits/baseline.yaml", Description: "Laravel baseline"}, Installed: true},
+			{Kit: registry.ManifestKit{Registry: "acme/skills", Name: "ops", Path: "kits/ops.yaml", Description: "Ops kit"}},
+		}, nil
+	}
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	err = runBrowseKitsWithDeps(context.Background(), []string{"acme/skills"}, "base", "", nil, &state.State{Kits: map[string]state.InstalledKit{}}, nil, true, true)
+	w.Close()
+	if err != nil {
+		t.Fatalf("runBrowseKitsWithDeps() error = %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	var out struct {
+		Results []struct {
+			Name             string `json:"name"`
+			Registry         string `json:"registry"`
+			InstalledLocally bool   `json:"installed_locally"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal browse kits json: %v", err)
+	}
+	if len(out.Results) != 1 || out.Results[0].Name != "baseline" || !out.Results[0].InstalledLocally {
+		t.Fatalf("results = %+v, want installed baseline only", out.Results)
 	}
 }
 

--- a/cmd/kit.go
+++ b/cmd/kit.go
@@ -51,6 +51,11 @@ type kitInstallOptions struct {
 	json          bool
 }
 
+type kitPushOptions struct {
+	registry string
+	json     bool
+}
+
 type kitCreateOutput struct {
 	Name            string `json:"name"`
 	Path            string `json:"path"`
@@ -91,6 +96,14 @@ type kitInstallOutput struct {
 	SkillsInstalled   []string       `json:"skills_installed,omitempty"`
 	MissingRefs       []kitRefOutput `json:"missing_refs,omitempty"`
 	MissingRegistries []string       `json:"missing_registries,omitempty"`
+}
+
+type kitPushOutput struct {
+	Name      string `json:"name"`
+	Registry  string `json:"registry"`
+	Path      string `json:"path"`
+	CommitSHA string `json:"commit_sha"`
+	CommitURL string `json:"commit_url"`
 }
 
 type kitSourceOutput struct {
@@ -158,6 +171,7 @@ func newKitCommand() *cobra.Command {
 	cmd.AddCommand(newKitShowCommand())
 	cmd.AddCommand(newKitInstallCommand())
 	cmd.AddCommand(newKitSyncCommand())
+	cmd.AddCommand(newKitPushCommand())
 	return cmd
 }
 
@@ -243,6 +257,22 @@ func newKitSyncCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.noDeps, "no-deps", false, "Refresh kit bodies without installing referenced skills")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output machine-readable JSON")
 	addNoInteractionFlag(cmd, "Disable interactive prompts", false)
+	return markJSONSupported(cmd)
+}
+
+func newKitPushCommand() *cobra.Command {
+	opts := &kitPushOptions{}
+	cmd := &cobra.Command{
+		Use:   "push <name>",
+		Short: "Push a local kit to its source registry",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.json = jsonFlagPassed(cmd)
+			return runKitPush(cmd, args[0], opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.registry, "registry", "", "Registry owner/repo to publish to")
+	cmd.Flags().BoolVar(&opts.json, "json", false, "Output machine-readable JSON")
 	return markJSONSupported(cmd)
 }
 
@@ -754,6 +784,122 @@ func runKitSync(cmd *cobra.Command, opts *kitInstallOptions) error {
 	}
 	for _, out := range outputs {
 		fmt.Fprintf(cmd.OutOrStdout(), "Synced kit %s from %s\n", out.Name, out.Registry)
+	}
+	return nil
+}
+
+func runKitPush(cmd *cobra.Command, name string, opts *kitPushOptions) error {
+	if opts == nil {
+		opts = &kitPushOptions{}
+	}
+	if err := validateKitName(name); err != nil {
+		return err
+	}
+	factory := commandFactory()
+	st, err := factory.State()
+	if err != nil {
+		return fmt.Errorf("load state: %w", err)
+	}
+	client, err := factory.Client()
+	if err != nil {
+		return fmt.Errorf("load github client: %w", err)
+	}
+	if client == nil || !client.IsAuthenticated() {
+		return clierrors.Wrap(errors.New("GitHub authentication required"), "PUSH_AUTH_REQUIRED", clierrors.ExitPerm,
+			clierrors.WithRemediation("run `gh auth login` or set GITHUB_TOKEN"),
+		)
+	}
+	scribeDir, err := paths.ScribeDir()
+	if err != nil {
+		return fmt.Errorf("resolve scribe dir: %w", err)
+	}
+	kitPath := filepath.Join(scribeDir, "kits", name+".yaml")
+	body, err := os.ReadFile(kitPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return clierrors.Wrap(fmt.Errorf("kit %q not found", name), "KIT_NOT_FOUND", clierrors.ExitNotFound,
+				clierrors.WithResource(name),
+				clierrors.WithRemediation("Run `scribe kit list` to see local kits."),
+			)
+		}
+		return fmt.Errorf("read kit: %w", err)
+	}
+	k, err := kit.Parse(body)
+	if err != nil {
+		return err
+	}
+	if k.Name == "" {
+		k.Name = name
+	} else if k.Name != name {
+		return clierrors.Wrap(fmt.Errorf("kit file name %q does not match requested kit %q", k.Name, name), "KIT_NAME_MISMATCH", clierrors.ExitValid,
+			clierrors.WithResource(kitPath),
+		)
+	}
+	registryRepo := opts.registry
+	expectedHash := ""
+	if installed, ok := st.Kits[name]; ok {
+		expectedHash = installed.ContentHash
+		if registryRepo == "" {
+			registryRepo = installed.SourceRegistry
+		}
+		if registryRepo == "" {
+			registryRepo = installed.Source
+		}
+	}
+	if registryRepo == "" && k.Source != nil {
+		registryRepo = k.Source.Registry
+	}
+	if registryRepo == "" {
+		return clierrors.Wrap(fmt.Errorf("kit %q has no source registry", name), "PUSH_SOURCE_MISSING", clierrors.ExitPerm,
+			clierrors.WithResource(name),
+			clierrors.WithRemediation("Run `scribe kit push "+name+" --registry <owner/repo>`."),
+		)
+	}
+	if err := validateRegistryKitRefs(k, registryRepo); err != nil {
+		return err
+	}
+	entry := manifest.KitEntry{
+		Name:        name,
+		Path:        "kits/" + name + ".yaml",
+		Description: k.Description,
+	}
+	result, err := registry.PushKit(cmd.Context(), newRegistryPusher(client), name, registryRepo, body, entry, expectedHash)
+	if err != nil {
+		return err
+	}
+	out := kitPushOutput{
+		Name:      name,
+		Registry:  registryRepo,
+		Path:      entry.PathOrDefault(),
+		CommitSHA: result.CommitSHA,
+		CommitURL: result.CommitURL,
+	}
+	if opts.json {
+		r := jsonRendererForCommand(cmd, true)
+		if err := r.Result(out); err != nil {
+			return err
+		}
+		return r.Flush()
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Pushed kit %s to %s at %s\n", out.Name, out.Registry, out.CommitSHA)
+	return nil
+}
+
+func validateRegistryKitRefs(k *kit.Kit, registryRepo string) error {
+	for _, raw := range k.Skills {
+		ref, err := kit.ParseSkillRef(raw, registryRepo)
+		if err != nil {
+			return clierrors.Wrap(err, "KIT_REF_INVALID", clierrors.ExitValid,
+				clierrors.WithResource(raw),
+				clierrors.WithRemediation("Fix the kit skills list before publishing."),
+			)
+		}
+		if ref.Local {
+			return clierrors.Wrap(fmt.Errorf("kit ref %q uses local: refs, which cannot be published", raw), "KIT_LOCAL_REF_FORBIDDEN", clierrors.ExitValid,
+				clierrors.WithResource(raw),
+				clierrors.WithRemediation("Replace local refs with registry refs before publishing."),
+			)
+		}
 	}
 	return nil
 }

--- a/cmd/kit_push_test.go
+++ b/cmd/kit_push_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"testing"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/Naoray/scribe/internal/kit"
+)
+
+func TestKitPushValidatesRegistryPublishableRefs(t *testing.T) {
+	err := validateRegistryKitRefs(&kit.Kit{Name: "baseline", Skills: []string{"local:private"}}, "acme/skills")
+	if clierrors.ExitCode(err) != clierrors.ExitValid {
+		t.Fatalf("exit = %d, want valid; err=%v", clierrors.ExitCode(err), err)
+	}
+}
+
+func TestNewKitCommandIncludesPush(t *testing.T) {
+	root := newKitCommand()
+	for _, cmd := range root.Commands() {
+		if cmd.Name() == "push" {
+			return
+		}
+	}
+	t.Fatal("kit push command not registered")
+}

--- a/cmd/list_tui.go
+++ b/cmd/list_tui.go
@@ -135,6 +135,10 @@ func (m listModel) isBrowseMode() bool {
 	return m.bag != nil && m.bag.BrowseFlag
 }
 
+func (m listModel) isBrowseKitsMode() bool {
+	return m.bag != nil && m.bag.BrowseFlag && m.bag.KitBrowseFlag
+}
+
 func (m listModel) Init() tea.Cmd {
 	return tea.Batch(
 		tea.RequestWindowSize,

--- a/cmd/list_tui_actions.go
+++ b/cmd/list_tui_actions.go
@@ -122,6 +122,10 @@ func (m listModel) runInstall(row listRow) tea.Cmd {
 	ctx := m.ctx
 	bag := m.bag
 	return func() tea.Msg {
+		if bag != nil && bag.KitBrowseFlag {
+			err := runKitInstall(newKitInstallCommand(), row.Group+":"+row.Name, &kitInstallOptions{noInteraction: true})
+			return commandDoneMsg{err: err}
+		}
 		if err := listEnsureRemoteDepsFn(ctx, bag); err != nil {
 			return commandDoneMsg{err: err}
 		}

--- a/cmd/list_tui_render.go
+++ b/cmd/list_tui_render.go
@@ -50,7 +50,9 @@ func tickSpinnerCmd() tea.Cmd {
 func (m listModel) viewLoading() string {
 	frame := spinnerFrames[m.spinnerFrame]
 	msg := "Loading skills..."
-	if m.isBrowseMode() {
+	if m.isBrowseKitsMode() {
+		msg = "Loading registry kits..."
+	} else if m.isBrowseMode() {
 		msg = "Loading registry skills..."
 	}
 	return "\n  " + ltSpinnerStyle.Render(frame) + "  " + ltDimStyle.Render(msg) + "\n"
@@ -87,7 +89,9 @@ func (m listModel) viewListFull() string {
 	if m.commandMode {
 		b.WriteString(ltDimStyle.Render("Command mode · enter run · esc cancel · backspace delete") + "\n")
 	}
-	if m.isBrowseMode() {
+	if m.isBrowseKitsMode() {
+		b.WriteString(ltDimStyle.Render("↑↓ navigate · /search · enter install · q quit") + "\n")
+	} else if m.isBrowseMode() {
 		b.WriteString(ltDimStyle.Render("↑↓ navigate · /search · enter detail · q quit") + "\n")
 	} else {
 		b.WriteString(ltDimStyle.Render("↑↓ navigate · /search · :commands · enter detail · q quit") + "\n")
@@ -152,7 +156,9 @@ func (m listModel) viewSplit() string {
 	case m.substate == listSubstateTools:
 		b.WriteString(ltDimStyle.Render("↑↓ choose · enter toggle/save · esc cancel") + "\n")
 	case m.focus == focusList:
-		if m.isBrowseMode() {
+		if m.isBrowseKitsMode() {
+			b.WriteString(ltDimStyle.Render("↑↓ browse kits · →/enter install · esc close · q quit") + "\n")
+		} else if m.isBrowseMode() {
 			b.WriteString(ltDimStyle.Render("↑↓ browse skills · →/enter install · esc close · q quit") + "\n")
 		} else {
 			b.WriteString(ltDimStyle.Render("↑↓ browse skills · →/enter actions · esc close · q quit") + "\n")
@@ -179,6 +185,9 @@ func (m listModel) renderQueryLine() string {
 	if m.searchMode || m.search != "" {
 		return "/ " + m.search
 	}
+	if m.isBrowseKitsMode() {
+		return ltDimStyle.Render("/ search kits...")
+	}
 	if m.isBrowseMode() {
 		return ltDimStyle.Render("/ search registries...")
 	}
@@ -187,9 +196,15 @@ func (m listModel) renderQueryLine() string {
 
 func (m listModel) renderHeader() string {
 	var b strings.Builder
-	total := ltCountStyle.Render(fmt.Sprintf("%d skills", len(m.rows)))
+	unit := "skills"
+	if m.isBrowseKitsMode() {
+		unit = "kits"
+	}
+	total := ltCountStyle.Render(fmt.Sprintf("%d %s", len(m.rows), unit))
 	title := "Installed Skills"
-	if m.isBrowseMode() {
+	if m.isBrowseKitsMode() {
+		title = "Browse Kits"
+	} else if m.isBrowseMode() {
 		title = "Browse Skills"
 	}
 	b.WriteString(ltHeaderStyle.Render(title) + "  " + total + "\n")
@@ -232,7 +247,11 @@ func wrapText(s string, width int) string {
 
 func (m listModel) renderRows(b *strings.Builder, contentHeight, maxWidth int, compact bool) {
 	if len(m.filtered) == 0 {
-		b.WriteString(ltDimStyle.Render("  (no skills match)") + "\n")
+		label := "skills"
+		if m.isBrowseKitsMode() {
+			label = "kits"
+		}
+		b.WriteString(ltDimStyle.Render("  (no "+label+" match)") + "\n")
 		return
 	}
 
@@ -441,7 +460,11 @@ func (m listModel) renderSummary() string {
 		}
 	}
 	if !hasStatus {
-		return ltDimStyle.Render(fmt.Sprintf("%d skills total", len(m.rows)))
+		unit := "skills"
+		if m.isBrowseKitsMode() {
+			unit = "kits"
+		}
+		return ltDimStyle.Render(fmt.Sprintf("%d %s total", len(m.rows), unit))
 	}
 	order := []sync.Status{sync.StatusCurrent, sync.StatusModified, sync.StatusOutdated, sync.StatusConflicted, sync.StatusMissing, sync.StatusExtra}
 	var parts []string

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Naoray/scribe/internal/budget"
 	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/kit"
 	"github.com/Naoray/scribe/internal/paths"
 	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/skillmd"
@@ -27,6 +28,9 @@ const (
 	IssueMigrationBudgetOverflow     IssueKind = "migration_budget_overflow"
 	IssueProjectionDrift             IssueKind = "projection_drift"
 	IssueSnippetProjectionDrift      IssueKind = "snippet_projection_drift"
+	IssueKitOrphaned                 IssueKind = "kit_orphaned"
+	IssueKitRegistryForgotten        IssueKind = "kit_registry_forgotten"
+	IssueKitRefBroken                IssueKind = "kit_ref_broken"
 )
 
 type Issue struct {
@@ -53,7 +57,9 @@ func InspectManagedSkills(cfg *config.Config, st *state.State, name string) (Rep
 	names := managedSkillNames(st, name)
 	if len(names) == 0 {
 		if name == "" {
-			return Report{Issues: inspectProjectSnippetDrift(cfg)}, nil
+			issues := inspectProjectSnippetDrift(cfg)
+			issues = append(issues, inspectRegistryKits(cfg, st)...)
+			return Report{Issues: issues}, nil
 		}
 		return Report{}, nil
 	}
@@ -82,6 +88,7 @@ func InspectManagedSkills(cfg *config.Config, st *state.State, name string) (Rep
 	if name == "" {
 		issues = append(issues, inspectGlobalListingBudget(st)...)
 		issues = append(issues, inspectProjectSnippetDrift(cfg)...)
+		issues = append(issues, inspectRegistryKits(cfg, st)...)
 	}
 
 	sort.SliceStable(issues, func(i, j int) bool {
@@ -98,6 +105,101 @@ func InspectManagedSkills(cfg *config.Config, st *state.State, name string) (Rep
 	})
 
 	return Report{Issues: issues}, nil
+}
+
+func inspectRegistryKits(cfg *config.Config, st *state.State) []Issue {
+	if st == nil || len(st.Kits) == 0 {
+		return nil
+	}
+	scribeDir, err := paths.ScribeDir()
+	if err != nil {
+		return []Issue{{
+			Kind:    IssueKitOrphaned,
+			Status:  "error",
+			Message: fmt.Sprintf("resolve scribe dir: %v", err),
+		}}
+	}
+	names := make([]string, 0, len(st.Kits))
+	for name := range st.Kits {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var issues []Issue
+	for _, name := range names {
+		installed := st.Kits[name]
+		sourceRegistry := installed.SourceRegistry
+		if sourceRegistry == "" {
+			sourceRegistry = installed.Source
+		}
+		kitPath := filepath.Join(scribeDir, "kits", name+".yaml")
+		loaded, err := kit.Load(kitPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				issues = append(issues, Issue{
+					Skill:   "kit:" + name,
+					Kind:    IssueKitOrphaned,
+					Status:  "error",
+					Message: fmt.Sprintf("installed kit state points to missing file %s; run `scribe kit sync` or remove stale state", kitPath),
+				})
+				continue
+			}
+			issues = append(issues, Issue{
+				Skill:   "kit:" + name,
+				Kind:    IssueKitOrphaned,
+				Status:  "error",
+				Message: fmt.Sprintf("read kit file %s: %v", kitPath, err),
+			})
+			continue
+		}
+		if sourceRegistry == "" {
+			issues = append(issues, Issue{
+				Skill:   "kit:" + name,
+				Kind:    IssueKitRegistryForgotten,
+				Status:  "warn",
+				Message: "installed kit has no source registry metadata; reinstall it from a registry",
+			})
+			continue
+		}
+		if cfg == nil || cfg.FindRegistry(sourceRegistry) == nil {
+			issues = append(issues, Issue{
+				Skill:   "kit:" + name,
+				Kind:    IssueKitRegistryForgotten,
+				Status:  "warn",
+				Message: fmt.Sprintf("source registry %s is not connected; run `scribe registry connect %s`", sourceRegistry, sourceRegistry),
+			})
+		}
+		for _, raw := range loaded.Skills {
+			ref, err := kit.ParseSkillRef(raw, sourceRegistry)
+			if err != nil {
+				issues = append(issues, Issue{
+					Skill:   "kit:" + name,
+					Kind:    IssueKitRefBroken,
+					Status:  "error",
+					Message: fmt.Sprintf("invalid ref %q: %v", raw, err),
+				})
+				continue
+			}
+			if ref.Local {
+				issues = append(issues, Issue{
+					Skill:   "kit:" + name,
+					Kind:    IssueKitRefBroken,
+					Status:  "error",
+					Message: fmt.Sprintf("registry kit contains local ref %q; replace with registry ref", raw),
+				})
+				continue
+			}
+			if ref.Registry != "" && ref.Registry != sourceRegistry && (cfg == nil || cfg.FindRegistry(ref.Registry) == nil) {
+				issues = append(issues, Issue{
+					Skill:   "kit:" + name,
+					Kind:    IssueKitRefBroken,
+					Status:  "warn",
+					Message: fmt.Sprintf("cross-registry ref %q points to forgotten registry %s; run `scribe registry connect %s`", raw, ref.Registry, ref.Registry),
+				})
+			}
+		}
+	}
+	return issues
 }
 
 func inspectProjectSnippetDrift(cfg *config.Config) []Issue {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -351,6 +351,75 @@ description: Keep daily notes and summaries.
 	}
 }
 
+func TestInspectManagedSkillsReportsRegistryKitIssues(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	kitsDir := filepath.Join(home, ".scribe", "kits")
+	if err := os.MkdirAll(kitsDir, 0o755); err != nil {
+		t.Fatalf("mkdir kits: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(kitsDir, "baseline.yaml"), []byte("name: baseline\nskills:\n  - other/skills:debugging\n"), 0o644); err != nil {
+		t.Fatalf("write kit: %v", err)
+	}
+	st := &state.State{
+		Installed: map[string]state.InstalledSkill{},
+		Kits: map[string]state.InstalledKit{
+			"baseline": {Name: "baseline", SourceRegistry: "acme/skills"},
+			"missing":  {Name: "missing", SourceRegistry: "acme/skills"},
+		},
+	}
+	cfg := &config.Config{Registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}}}
+
+	report, err := InspectManagedSkills(cfg, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+
+	if !hasIssue(report, "kit:baseline", IssueKitRefBroken) {
+		t.Fatalf("missing cross-registry ref issue: %+v", report.Issues)
+	}
+	if !hasIssue(report, "kit:missing", IssueKitOrphaned) {
+		t.Fatalf("missing orphaned kit issue: %+v", report.Issues)
+	}
+}
+
+func TestInspectManagedSkillsReportsForgottenKitRegistry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	kitsDir := filepath.Join(home, ".scribe", "kits")
+	if err := os.MkdirAll(kitsDir, 0o755); err != nil {
+		t.Fatalf("mkdir kits: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(kitsDir, "baseline.yaml"), []byte("name: baseline\nskills:\n  - tdd\n"), 0o644); err != nil {
+		t.Fatalf("write kit: %v", err)
+	}
+	st := &state.State{
+		Installed: map[string]state.InstalledSkill{},
+		Kits:      map[string]state.InstalledKit{"baseline": {Name: "baseline", SourceRegistry: "acme/skills"}},
+	}
+
+	report, err := InspectManagedSkills(&config.Config{}, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+	if !hasIssue(report, "kit:baseline", IssueKitRegistryForgotten) {
+		t.Fatalf("missing forgotten registry issue: %+v", report.Issues)
+	}
+}
+
+func hasIssue(report Report, skill string, kind IssueKind) bool {
+	for _, issue := range report.Issues {
+		if issue.Skill == skill && issue.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
 // TestInspectStillReportsDriftForInspectableTool guards against regressing
 // drift detection while fixing the opacity bug. A real inspectable tool with
 // a missing projection on disk must still surface as projection_drift.

--- a/internal/registry/push.go
+++ b/internal/registry/push.go
@@ -12,7 +12,9 @@ import (
 
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/lockfile"
 	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/migrate"
 	"github.com/Naoray/scribe/internal/state"
 )
 
@@ -21,6 +23,11 @@ type GitHubPusher interface {
 	GetTree(ctx context.Context, owner, repo, ref string) ([]TreeEntry, error)
 	LatestCommitSHA(ctx context.Context, owner, repo, branch string) (string, error)
 	PushFilesAtomic(ctx context.Context, owner, repo, branch string, files map[string][]byte, message, expectedHead string) (CommitResult, error)
+}
+
+type KitPusher interface {
+	GitHubPusher
+	FetchFile(ctx context.Context, owner, repo, path, ref string) ([]byte, error)
 }
 
 // TreeEntry is a Git tree entry used for conflict checks.
@@ -41,7 +48,7 @@ type githubPusher struct {
 }
 
 // NewGitHubPusher adapts the shared GitHub client to the push interface.
-func NewGitHubPusher(client *gh.Client) GitHubPusher {
+func NewGitHubPusher(client *gh.Client) KitPusher {
 	return githubPusher{client: client}
 }
 
@@ -55,6 +62,10 @@ func (p githubPusher) GetTree(ctx context.Context, owner, repo, ref string) ([]T
 		out[i] = TreeEntry{Path: entry.Path, Type: entry.Type, SHA: entry.SHA}
 	}
 	return out, nil
+}
+
+func (p githubPusher) FetchFile(ctx context.Context, owner, repo, path, ref string) ([]byte, error) {
+	return p.client.FetchFile(ctx, owner, repo, path, ref)
 }
 
 func (p githubPusher) LatestCommitSHA(ctx context.Context, owner, repo, branch string) (string, error) {
@@ -75,6 +86,72 @@ type PushResult struct {
 	Registry  string
 	CommitSHA string
 	CommitURL string
+}
+
+// PushKit publishes one local kit YAML file and updates the registry manifest.
+func PushKit(ctx context.Context, client KitPusher, kitName, registryRepo string, body []byte, entry manifest.KitEntry, expectedContentHash string) (PushResult, error) {
+	owner, repo, err := manifest.ParseOwnerRepo(registryRepo)
+	if err != nil {
+		return PushResult{}, clierrors.Wrap(err, "PUSH_INVALID_REGISTRY", clierrors.ExitConflict,
+			clierrors.WithRemediation("install or create the kit with a valid registry source"),
+		)
+	}
+	pathName := strings.Trim(strings.TrimSpace(entry.Path), "/")
+	if pathName == "" {
+		pathName = "kits/" + kitName + ".yaml"
+	}
+	entry.Path = pathName
+	if entry.Name == "" {
+		entry.Name = kitName
+	}
+
+	headSHA, err := client.LatestCommitSHA(ctx, owner, repo, "main")
+	if err != nil {
+		return PushResult{}, err
+	}
+	m, _, err := manifest.FetchWithFallback(ctx, client, owner, repo, migrate.Convert)
+	if err != nil {
+		return PushResult{}, fmt.Errorf("fetch manifest: %w", err)
+	}
+	if expectedContentHash != "" {
+		if remote, err := client.FetchFile(ctx, owner, repo, pathName, "HEAD"); err == nil {
+			remoteHash := hashKitBody(kitName, remote)
+			if remoteHash != expectedContentHash {
+				return PushResult{}, clierrors.Wrap(errors.New("remote kit has changed since it was installed"), "PUSH_CONFLICT", clierrors.ExitConflict,
+					clierrors.WithResource(kitName),
+					clierrors.WithRemediation("run `scribe kit sync` and reapply your local edits before pushing"),
+				)
+			}
+		}
+	}
+	upsertManifestKit(m, entry)
+	encoded, err := m.Encode()
+	if err != nil {
+		return PushResult{}, fmt.Errorf("encode manifest: %w", err)
+	}
+	commit, err := client.PushFilesAtomic(ctx, owner, repo, "main", map[string][]byte{
+		pathName:                  body,
+		manifest.ManifestFilename: encoded,
+	}, fmt.Sprintf("Update %s kit", kitName), headSHA)
+	if err != nil {
+		return PushResult{}, err
+	}
+	return PushResult{Skill: kitName, Registry: registryRepo, CommitSHA: commit.SHA, CommitURL: commit.URL}, nil
+}
+
+func upsertManifestKit(m *manifest.Manifest, entry manifest.KitEntry) {
+	for i := range m.Kits {
+		if m.Kits[i].Name == entry.Name {
+			m.Kits[i] = entry
+			return
+		}
+	}
+	m.Kits = append(m.Kits, entry)
+}
+
+func hashKitBody(name string, body []byte) string {
+	hash, _ := lockfile.HashFiles([]lockfile.File{{Path: name + ".yaml", Content: body}})
+	return hash
 }
 
 // PushSkill publishes all files in skillDir back to source in one commit.

--- a/internal/registry/push.go
+++ b/internal/registry/push.go
@@ -113,18 +113,13 @@ func PushKit(ctx context.Context, client KitPusher, kitName, registryRepo string
 	if err != nil {
 		return PushResult{}, fmt.Errorf("fetch manifest: %w", err)
 	}
-	if expectedContentHash != "" {
-		if remote, err := client.FetchFile(ctx, owner, repo, pathName, "HEAD"); err == nil {
-			remoteHash := hashKitBody(kitName, remote)
-			if remoteHash != expectedContentHash {
-				return PushResult{}, clierrors.Wrap(errors.New("remote kit has changed since it was installed"), "PUSH_CONFLICT", clierrors.ExitConflict,
-					clierrors.WithResource(kitName),
-					clierrors.WithRemediation("run `scribe kit sync` and reapply your local edits before pushing"),
-				)
-			}
-		}
+	if err := verifyRemoteKitBaseline(ctx, client, owner, repo, kitName, pathName, m, expectedContentHash); err != nil {
+		return PushResult{}, err
 	}
 	upsertManifestKit(m, entry)
+	if err := m.Validate(); err != nil {
+		return PushResult{}, fmt.Errorf("validate manifest: %w", err)
+	}
 	encoded, err := m.Encode()
 	if err != nil {
 		return PushResult{}, fmt.Errorf("encode manifest: %w", err)
@@ -137,6 +132,42 @@ func PushKit(ctx context.Context, client KitPusher, kitName, registryRepo string
 		return PushResult{}, err
 	}
 	return PushResult{Skill: kitName, Registry: registryRepo, CommitSHA: commit.SHA, CommitURL: commit.URL}, nil
+}
+
+func verifyRemoteKitBaseline(ctx context.Context, client KitPusher, owner, repo, kitName, pathName string, m *manifest.Manifest, expectedContentHash string) error {
+	if expectedContentHash == "" && manifestHasKit(m, kitName) {
+		return pushKitConflict(kitName, errors.New("kit has no recorded remote baseline"))
+	}
+	remote, err := client.FetchFile(ctx, owner, repo, pathName, "HEAD")
+	if err != nil {
+		if isRemoteNotFound(err) {
+			if expectedContentHash != "" {
+				return pushKitConflict(kitName, errors.New("remote kit is missing"))
+			}
+			return nil
+		}
+		return fmt.Errorf("fetch remote kit baseline: %w", err)
+	}
+	if expectedContentHash == "" {
+		return pushKitConflict(kitName, errors.New("kit has no recorded remote baseline"))
+	}
+	if remoteHash := hashKitBody(kitName, remote); remoteHash != expectedContentHash {
+		return pushKitConflict(kitName, errors.New("remote kit has changed since it was installed"))
+	}
+	return nil
+}
+
+func manifestHasKit(m *manifest.Manifest, kitName string) bool {
+	for _, kit := range m.Kits {
+		if kit.Name == kitName {
+			return true
+		}
+	}
+	return false
+}
+
+func isRemoteNotFound(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || clierrors.ExitCode(err) == clierrors.ExitNotFound
 }
 
 func upsertManifestKit(m *manifest.Manifest, entry manifest.KitEntry) {
@@ -152,6 +183,13 @@ func upsertManifestKit(m *manifest.Manifest, entry manifest.KitEntry) {
 func hashKitBody(name string, body []byte) string {
 	hash, _ := lockfile.HashFiles([]lockfile.File{{Path: name + ".yaml", Content: body}})
 	return hash
+}
+
+func pushKitConflict(kitName string, err error) error {
+	return clierrors.Wrap(err, "PUSH_CONFLICT", clierrors.ExitConflict,
+		clierrors.WithResource(kitName),
+		clierrors.WithRemediation("run `scribe kit sync` and reapply your local edits before pushing"),
+	)
 }
 
 // PushSkill publishes all files in skillDir back to source in one commit.

--- a/internal/registry/push_test.go
+++ b/internal/registry/push_test.go
@@ -18,11 +18,17 @@ type fakePusher struct {
 	err        error
 	files      map[string][]byte
 	remote     map[string][]byte
+	fetchErr   map[string]error
 	expected   string
 	pushCalled bool
 }
 
 func (f *fakePusher) FetchFile(_ context.Context, _, _, path, _ string) ([]byte, error) {
+	if f.fetchErr != nil {
+		if err, ok := f.fetchErr[path]; ok {
+			return nil, err
+		}
+	}
 	if f.remote != nil {
 		if body, ok := f.remote[path]; ok {
 			return body, nil
@@ -154,6 +160,81 @@ func TestPushKitRefusesRemoteKitDivergence(t *testing.T) {
 	}
 	if client.pushCalled {
 		t.Fatal("PushFilesAtomic called despite remote divergence")
+	}
+}
+
+func TestPushKitRefusesExistingRemoteKitWithoutBaseline(t *testing.T) {
+	body := []byte("name: baseline\nskills:\n  - tdd\n")
+	client := &fakePusher{
+		head: "head-sha",
+		remote: map[string][]byte{
+			"scribe.yaml":        []byte("apiVersion: scribe/v1\nkind: Registry\nteam:\n  name: Acme\ncatalog: []\nkits:\n  - name: baseline\n"),
+			"kits/baseline.yaml": []byte("name: baseline\nskills:\n  - tdd\n"),
+		},
+	}
+
+	_, err := PushKit(context.Background(), client, "baseline", "acme/skills", body, manifest.KitEntry{Name: "baseline"}, "")
+	if clierrors.ExitCode(err) != clierrors.ExitConflict {
+		t.Fatalf("exit = %d, want conflict; err=%v", clierrors.ExitCode(err), err)
+	}
+	if client.pushCalled {
+		t.Fatal("PushFilesAtomic called without a remote baseline")
+	}
+}
+
+func TestPushKitRefusesMissingRemoteKitWithBaseline(t *testing.T) {
+	body := []byte("name: baseline\nskills:\n  - tdd\n")
+	client := &fakePusher{
+		head: "head-sha",
+		remote: map[string][]byte{
+			"scribe.yaml": []byte("apiVersion: scribe/v1\nkind: Registry\nteam:\n  name: Acme\ncatalog: []\nkits:\n  - name: baseline\n"),
+		},
+	}
+
+	_, err := PushKit(context.Background(), client, "baseline", "acme/skills", body, manifest.KitEntry{Name: "baseline"}, "sha256:old")
+	if clierrors.ExitCode(err) != clierrors.ExitConflict {
+		t.Fatalf("exit = %d, want conflict; err=%v", clierrors.ExitCode(err), err)
+	}
+	if client.pushCalled {
+		t.Fatal("PushFilesAtomic called despite missing remote kit")
+	}
+}
+
+func TestPushKitPropagatesRemoteKitReadErrorWithBaseline(t *testing.T) {
+	body := []byte("name: baseline\nskills:\n  - tdd\n")
+	networkErr := clierrors.Wrap(errors.New("offline"), "GH_NETWORK_FAILED", clierrors.ExitNetwork)
+	client := &fakePusher{
+		head: "head-sha",
+		remote: map[string][]byte{
+			"scribe.yaml": []byte("apiVersion: scribe/v1\nkind: Registry\nteam:\n  name: Acme\ncatalog: []\nkits:\n  - name: baseline\n"),
+		},
+		fetchErr: map[string]error{"kits/baseline.yaml": networkErr},
+	}
+
+	_, err := PushKit(context.Background(), client, "baseline", "acme/skills", body, manifest.KitEntry{Name: "baseline"}, "sha256:old")
+	if clierrors.ExitCode(err) != clierrors.ExitNetwork {
+		t.Fatalf("exit = %d, want network; err=%v", clierrors.ExitCode(err), err)
+	}
+	if client.pushCalled {
+		t.Fatal("PushFilesAtomic called despite unreadable remote kit")
+	}
+}
+
+func TestPushKitValidatesManifestAfterUpsert(t *testing.T) {
+	body := []byte("name: baseline\nskills:\n  - tdd\n")
+	client := &fakePusher{
+		head: "head-sha",
+		remote: map[string][]byte{
+			"scribe.yaml": []byte("apiVersion: scribe/v1\nkind: Registry\nteam:\n  name: Acme\ncatalog:\n  - name: baseline\n    path: skills/baseline/SKILL.md\n"),
+		},
+	}
+
+	_, err := PushKit(context.Background(), client, "baseline", "acme/skills", body, manifest.KitEntry{Name: "baseline"}, "")
+	if err == nil {
+		t.Fatal("PushKit() error = nil, want manifest validation error")
+	}
+	if client.pushCalled {
+		t.Fatal("PushFilesAtomic called despite invalid manifest")
 	}
 }
 

--- a/internal/registry/push_test.go
+++ b/internal/registry/push_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/state"
 )
 
@@ -16,8 +17,18 @@ type fakePusher struct {
 	head       string
 	err        error
 	files      map[string][]byte
+	remote     map[string][]byte
 	expected   string
 	pushCalled bool
+}
+
+func (f *fakePusher) FetchFile(_ context.Context, _, _, path, _ string) ([]byte, error) {
+	if f.remote != nil {
+		if body, ok := f.remote[path]; ok {
+			return body, nil
+		}
+	}
+	return nil, os.ErrNotExist
 }
 
 func (f *fakePusher) GetTree(context.Context, string, string, string) ([]TreeEntry, error) {
@@ -90,6 +101,59 @@ func TestPushSkillRefusesRemoteDivergence(t *testing.T) {
 	}
 	if client.pushCalled {
 		t.Fatal("push should not be called on conflict")
+	}
+}
+
+func TestPushKitUpdatesManifestAndKitBody(t *testing.T) {
+	body := []byte("name: baseline\ndescription: Base kit\nskills:\n  - tdd\n")
+	client := &fakePusher{
+		head: "head-sha",
+		remote: map[string][]byte{
+			"scribe.yaml": []byte("apiVersion: scribe/v1\nkind: Registry\nteam:\n  name: Acme\ncatalog: []\n"),
+		},
+	}
+
+	result, err := PushKit(context.Background(), client, "baseline", "acme/skills", body, manifest.KitEntry{
+		Name:        "baseline",
+		Description: "Base kit",
+	}, "")
+	if err != nil {
+		t.Fatalf("PushKit() error = %v", err)
+	}
+	if result.CommitSHA != "abc123" || result.Registry != "acme/skills" {
+		t.Fatalf("result = %+v", result)
+	}
+	if client.expected != "head-sha" {
+		t.Fatalf("expected head = %q, want head-sha", client.expected)
+	}
+	if string(client.files["kits/baseline.yaml"]) != string(body) {
+		t.Fatalf("kit body not pushed: %#v", client.files)
+	}
+	m, err := manifest.Parse(client.files["scribe.yaml"])
+	if err != nil {
+		t.Fatalf("parse pushed manifest: %v\n%s", err, client.files["scribe.yaml"])
+	}
+	if len(m.Kits) != 1 || m.Kits[0].Name != "baseline" || m.Kits[0].PathOrDefault() != "kits/baseline.yaml" {
+		t.Fatalf("manifest kits = %+v", m.Kits)
+	}
+}
+
+func TestPushKitRefusesRemoteKitDivergence(t *testing.T) {
+	body := []byte("name: baseline\nskills:\n  - tdd\n")
+	client := &fakePusher{
+		head: "head-sha",
+		remote: map[string][]byte{
+			"scribe.yaml":        []byte("apiVersion: scribe/v1\nkind: Registry\nteam:\n  name: Acme\ncatalog: []\nkits:\n  - name: baseline\n"),
+			"kits/baseline.yaml": []byte("name: baseline\nskills:\n  - changed\n"),
+		},
+	}
+
+	_, err := PushKit(context.Background(), client, "baseline", "acme/skills", body, manifest.KitEntry{Name: "baseline"}, "sha256:old")
+	if clierrors.ExitCode(err) != clierrors.ExitConflict {
+		t.Fatalf("exit = %d, want conflict; err=%v", clierrors.ExitCode(err), err)
+	}
+	if client.pushCalled {
+		t.Fatal("PushFilesAtomic called despite remote divergence")
 	}
 }
 

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -28,6 +28,7 @@ type Bag struct {
 	RepoFlag           string // --registry filter
 	RemoteFlag         bool   // --remote: show available skills from registries
 	BrowseFlag         bool   // browse mode: remote catalog UI with install-first actions
+	KitBrowseFlag      bool   // browse mode shows registry kits instead of skills
 	InitialQuery       string // initial search/filter text for TUI surfaces
 	TrustAllFlag       bool   // --trust-all: approve all package commands without prompting
 	InstallAllFlag     bool   // --all: install all available skills without prompting

--- a/internal/workflow/list_load.go
+++ b/internal/workflow/list_load.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Naoray/scribe/internal/discovery"
 	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/registry"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
@@ -40,6 +41,9 @@ type ListRow struct {
 }
 
 func BuildRows(ctx context.Context, bag *Bag) ([]ListRow, []string, error) {
+	if bag.KitBrowseFlag {
+		return BuildKitBrowseRows(ctx, bag)
+	}
 	localSkills, err := discovery.OnDisk(bag.State)
 	if err != nil {
 		return nil, nil, err
@@ -128,6 +132,66 @@ func BuildRows(ctx context.Context, bag *Bag) ([]ListRow, []string, error) {
 	}
 
 	rows = append(rows, BuildLocalRowsExcluding(localSkills, matchedLocal, bag.State)...)
+	return rows, warnings, nil
+}
+
+func BuildKitBrowseRows(ctx context.Context, bag *Bag) ([]ListRow, []string, error) {
+	repos := bag.Config.TeamRepos()
+	if bag.FilterRegistries != nil {
+		filtered, err := bag.FilterRegistries(bag.RepoFlag, repos)
+		if err != nil {
+			return nil, nil, err
+		}
+		repos = filtered
+	}
+
+	installed := map[string]state.InstalledKit{}
+	if bag.State != nil {
+		for name, kit := range bag.State.Kits {
+			installed[name] = kit
+		}
+	}
+
+	var rows []ListRow
+	var warnings []string
+	for _, repo := range repos {
+		kits, err := registry.ListKits(ctx, bag.Client, repo)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: %v", repo, err))
+			continue
+		}
+		for _, remote := range kits {
+			status := sync.StatusMissing
+			if local, ok := installed[remote.Name]; ok {
+				source := local.SourceRegistry
+				if source == "" {
+					source = local.Source
+				}
+				if source == repo {
+					status = sync.StatusCurrent
+				}
+			}
+			rows = append(rows, ListRow{
+				Name:      remote.Name,
+				Group:     repo,
+				Status:    status,
+				HasStatus: true,
+				Version:   remote.Path,
+				Author:    remote.Author,
+				Entry: &manifest.Entry{
+					Name:        remote.Name,
+					Description: remote.Description,
+					Author:      remote.Author,
+				},
+			})
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Group != rows[j].Group {
+			return rows[i].Group < rows[j].Group
+		}
+		return rows[i].Name < rows[j].Name
+	})
 	return rows, warnings, nil
 }
 


### PR DESCRIPTION
Adds the phase 4 kit surfaces from todo #792.

What changed:
- kit push publishes kit YAML and upserts the registry manifest kits entry using the existing atomic GitHub push path.
- browse --kits lists remote kits in JSON/non-TTY mode and reuses the list TUI for interactive kit browsing/install.
- doctor now reports orphaned installed kits, forgotten kit registries, and locally-detectable broken kit refs.

Tests: go test ./...