### PR TITLE
feat: add SourceSpec foundation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Naoray/scribe/internal/paths"
+	"github.com/Naoray/scribe/internal/source"
 )
 
 const (
@@ -26,12 +27,21 @@ const (
 
 // RegistryConfig describes a connected skill registry.
 type RegistryConfig struct {
-	Repo       string `yaml:"repo"`
-	Enabled    bool   `yaml:"enabled"`
-	Builtin    bool   `yaml:"builtin,omitempty"`
-	Type       string `yaml:"type,omitempty"`
-	Visibility string `yaml:"visibility,omitempty"`
-	Writable   bool   `yaml:"writable,omitempty"`
+	ID         string             `yaml:"id,omitempty"`
+	Repo       string             `yaml:"repo,omitempty"`
+	Enabled    bool               `yaml:"enabled"`
+	Builtin    bool               `yaml:"builtin,omitempty"`
+	Type       string             `yaml:"type,omitempty"`
+	Visibility string             `yaml:"visibility,omitempty"`
+	Writable   bool               `yaml:"writable,omitempty"`
+	Source     *source.SourceSpec `yaml:"source,omitempty"`
+}
+
+type RegistrySource struct {
+	ID       string
+	Config   RegistryConfig
+	Source   source.SourceSpec
+	Identity source.SourceIdentity
 }
 
 // ToolConfig describes an AI tool target for skill installation.
@@ -91,7 +101,9 @@ func (c *Config) TeamRepos() []string {
 	var repos []string
 	for _, r := range c.Registries {
 		if r.Enabled {
-			repos = append(repos, r.Repo)
+			if repo := r.SourceSpec().Repo; repo != "" {
+				repos = append(repos, repo)
+			}
 		}
 	}
 	return repos
@@ -101,7 +113,7 @@ func (c *Config) TeamRepos() []string {
 func (c *Config) AddRegistry(rc RegistryConfig) {
 	rc.Normalize()
 	for i := range c.Registries {
-		if strings.EqualFold(c.Registries[i].Repo, rc.Repo) {
+		if registriesMatch(c.Registries[i], rc) {
 			c.Registries[i] = rc
 			return
 		}
@@ -112,8 +124,31 @@ func (c *Config) AddRegistry(rc RegistryConfig) {
 // FindRegistry returns the RegistryConfig for a given repo, or nil if not found.
 func (c *Config) FindRegistry(repo string) *RegistryConfig {
 	for i := range c.Registries {
-		if strings.EqualFold(c.Registries[i].Repo, repo) {
+		if strings.EqualFold(c.Registries[i].SourceSpec().Repo, repo) {
 			return &c.Registries[i]
+		}
+	}
+	return nil
+}
+
+func (c *Config) FindRegistryByKeyOrRepo(input string) *RegistryConfig {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil
+	}
+	for i := range c.Registries {
+		rc := &c.Registries[i]
+		if strings.EqualFold(rc.ID, input) || strings.EqualFold(rc.Repo, input) {
+			return rc
+		}
+		spec := rc.SourceSpec()
+		if strings.EqualFold(spec.Repo, input) || strings.EqualFold(spec.URL, input) || strings.EqualFold(spec.ID, input) {
+			return rc
+		}
+		if canonical, ident, err := source.Canonicalize(spec); err == nil {
+			if strings.EqualFold(ident.Key, input) || strings.EqualFold(canonical.URL, input) {
+				return rc
+			}
 		}
 	}
 	return nil
@@ -126,6 +161,33 @@ func (c *Config) EnabledRegistries() []RegistryConfig {
 		if rc.Enabled {
 			enabled = append(enabled, rc)
 		}
+	}
+	return enabled
+}
+
+func (c *Config) EnabledSources() []RegistrySource {
+	var enabled []RegistrySource
+	ids := map[string]int{}
+	for _, rc := range c.Registries {
+		if !rc.Enabled {
+			continue
+		}
+		spec, ident, err := source.Canonicalize(rc.SourceSpec())
+		if err != nil {
+			continue
+		}
+		id := registrySourceID(rc, spec, ident)
+		key := strings.ToLower(id)
+		ids[key]++
+		if ids[key] > 1 {
+			id = fmt.Sprintf("%s-%d", id, ids[key])
+		}
+		enabled = append(enabled, RegistrySource{
+			ID:       id,
+			Config:   rc,
+			Source:   spec,
+			Identity: ident,
+		})
 	}
 	return enabled
 }
@@ -218,6 +280,31 @@ func (rc RegistryConfig) IsPublic() bool {
 	return rc.Visibility == RegistryVisibilityPublic
 }
 
+func (rc RegistryConfig) SourceSpec() source.SourceSpec {
+	var spec source.SourceSpec
+	if rc.Source != nil {
+		spec = *rc.Source
+	} else {
+		spec = source.SourceSpec{Type: source.SourceGitHub, Repo: rc.Repo}
+	}
+	if spec.ID == "" {
+		spec.ID = rc.ID
+	}
+	if spec.Writable == nil && rc.Writable {
+		writable := true
+		spec.Writable = &writable
+	}
+	return spec
+}
+
+func (rc RegistryConfig) Identity() source.SourceIdentity {
+	_, ident, err := source.Canonicalize(rc.SourceSpec())
+	if err != nil {
+		return source.SourceIdentity{}
+	}
+	return ident
+}
+
 // Normalize fills privacy-safe defaults for legacy or incomplete registry rows.
 func (rc *RegistryConfig) Normalize() {
 	if rc.Visibility == "" {
@@ -225,6 +312,42 @@ func (rc *RegistryConfig) Normalize() {
 		return
 	}
 	rc.Visibility = NormalizeRegistryVisibility(rc.Visibility)
+}
+
+func (c *Config) ValidateSources() error {
+	ids := map[string]struct{}{}
+	keys := map[string]struct{}{}
+	for _, rc := range c.Registries {
+		if rc.ID != "" {
+			id := strings.ToLower(rc.ID)
+			if _, ok := ids[id]; ok {
+				return fmt.Errorf("duplicate registry id %q", rc.ID)
+			}
+			ids[id] = struct{}{}
+		}
+		if rc.Source == nil && rc.Repo == "" {
+			continue
+		}
+		spec, ident, err := source.Canonicalize(rc.SourceSpec())
+		if err != nil {
+			return err
+		}
+		if spec.ID != "" {
+			id := strings.ToLower(spec.ID)
+			if _, ok := ids[id]; ok && !strings.EqualFold(spec.ID, rc.ID) {
+				return fmt.Errorf("duplicate registry id %q", spec.ID)
+			}
+			ids[id] = struct{}{}
+		}
+		if rc.Source != nil {
+			key := strings.ToLower(ident.Key)
+			if _, ok := keys[key]; ok {
+				return fmt.Errorf("duplicate registry source key %q", ident.Key)
+			}
+			keys[key] = struct{}{}
+		}
+	}
+	return nil
 }
 
 func NormalizeRegistryVisibility(visibility string) string {
@@ -270,6 +393,9 @@ func Load() (*Config, error) {
 			return nil, fmt.Errorf("parse config.yaml: %w", err)
 		}
 		cfg.applyDefaults()
+		if err := cfg.ValidateSources(); err != nil {
+			return nil, fmt.Errorf("validate config.yaml: %w", err)
+		}
 		if _, err := cfg.AdoptionPaths(); err != nil {
 			return nil, err
 		}
@@ -314,6 +440,48 @@ func (c *Config) applyDefaults() {
 	for i := range c.Registries {
 		c.Registries[i].Normalize()
 	}
+}
+
+func registriesMatch(a, b RegistryConfig) bool {
+	if a.ID != "" && b.ID != "" && strings.EqualFold(a.ID, b.ID) {
+		return true
+	}
+	if a.Repo != "" && b.Repo != "" && strings.EqualFold(a.Repo, b.Repo) {
+		return true
+	}
+	_, aIdent, aErr := source.Canonicalize(a.SourceSpec())
+	_, bIdent, bErr := source.Canonicalize(b.SourceSpec())
+	return aErr == nil && bErr == nil && strings.EqualFold(aIdent.Key, bIdent.Key)
+}
+
+func registrySourceID(rc RegistryConfig, spec source.SourceSpec, ident source.SourceIdentity) string {
+	if rc.ID != "" {
+		return rc.ID
+	}
+	if spec.ID != "" {
+		return spec.ID
+	}
+	if rc.Repo != "" {
+		return slug(rc.Repo)
+	}
+	if spec.Repo != "" {
+		return slug(spec.Repo)
+	}
+	if spec.URL != "" {
+		return slug(spec.URL)
+	}
+	return slug(ident.Key)
+}
+
+func slug(s string) string {
+	s = strings.TrimSpace(strings.ToLower(s))
+	replacer := strings.NewReplacer("://", "-", "/", "-", ":", "-", "@", "-", ".", "-", "_", "-")
+	s = replacer.Replace(s)
+	s = strings.Trim(s, "-")
+	if s == "" {
+		return "source"
+	}
+	return s
 }
 
 // migrateFromTOML converts legacy TOML fields to the new Config struct.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,13 +95,13 @@ type Config struct {
 	LazyGitHub      bool              `yaml:"-"`
 }
 
-// TeamRepos returns the list of enabled registry repos.
-// Backward-compatible helper for code that previously used Config.TeamRepos.
+// TeamRepos returns the list of enabled legacy registry repo strings.
+// Backward-compatible helper for GitHub-only code that previously used Config.TeamRepos.
 func (c *Config) TeamRepos() []string {
 	var repos []string
 	for _, r := range c.Registries {
 		if r.Enabled {
-			if repo := r.SourceSpec().Repo; repo != "" {
+			if repo := strings.TrimSpace(r.Repo); repo != "" {
 				repos = append(repos, repo)
 			}
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -297,6 +297,14 @@ func (rc RegistryConfig) SourceSpec() source.SourceSpec {
 	return spec
 }
 
+func ParseConfigSource(rc RegistryConfig) (source.SourceSpec, error) {
+	spec, _, err := source.Canonicalize(rc.SourceSpec())
+	if err != nil {
+		return source.SourceSpec{}, err
+	}
+	return spec, nil
+}
+
 func (rc RegistryConfig) Identity() source.SourceIdentity {
 	_, ident, err := source.Canonicalize(rc.SourceSpec())
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -606,7 +606,7 @@ func TestConfigLoadSupportsNestedSourceWithoutLegacyChurn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if got := cfg.TeamRepos(); len(got) != 2 || got[0] != "acme/legacy-skills" || got[1] != "vercel-labs/agent-skills" {
+	if got := cfg.TeamRepos(); len(got) != 1 || got[0] != "acme/legacy-skills" {
 		t.Fatalf("TeamRepos = %#v", got)
 	}
 	legacy := cfg.FindRegistry("acme/legacy-skills")
@@ -740,11 +740,46 @@ func TestEnabledRegistries(t *testing.T) {
 
 // TeamRepos returns the list of registry repo strings for backward compatibility.
 func TestTeamReposCompat(t *testing.T) {
+	gitWritable := true
 	cfg := &config.Config{
 		Registries: []config.RegistryConfig{
 			{Repo: "ArtistfyHQ/team-skills", Enabled: true},
 			{Repo: "disabled/repo", Enabled: false},
 			{Repo: "vercel/skills", Enabled: true},
+			{
+				ID:      "github-tree",
+				Enabled: true,
+				Source: &source.SourceSpec{
+					Type: source.SourceGitHub,
+					Repo: "nested/github-skills",
+					Path: "packs/team",
+				},
+			},
+			{
+				ID:      "gitlab",
+				Enabled: true,
+				Source: &source.SourceSpec{
+					Type: source.SourceGitLab,
+					Repo: "group/project",
+				},
+			},
+			{
+				ID:      "git",
+				Enabled: true,
+				Source: &source.SourceSpec{
+					Type:     source.SourceGit,
+					URL:      "https://example.com/team/skills.git",
+					Writable: &gitWritable,
+				},
+			},
+			{
+				ID:      "local",
+				Enabled: true,
+				Source: &source.SourceSpec{
+					Type: source.SourceLocal,
+					Path: "/opt/scribe/skills",
+				},
+			},
 		},
 	}
 	repos := cfg.TeamRepos()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -572,6 +572,13 @@ func TestRegistryConfigSourceSpecLegacyRepo(t *testing.T) {
 	if spec.Type != source.SourceGitHub || spec.Repo != "Owner/Repo" {
 		t.Fatalf("SourceSpec = %#v", spec)
 	}
+	parsed, err := config.ParseConfigSource(rc)
+	if err != nil {
+		t.Fatalf("ParseConfigSource: %v", err)
+	}
+	if parsed.URL != "https://github.com/Owner/Repo" {
+		t.Fatalf("parsed URL = %q", parsed.URL)
+	}
 	ident := rc.Identity()
 	if ident.Key != "github:owner/repo" {
 		t.Fatalf("identity key = %q", ident.Key)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/source"
 	"gopkg.in/yaml.v3"
 )
 
@@ -557,6 +558,132 @@ func TestFindRegistry(t *testing.T) {
 	// Not found.
 	if cfg.FindRegistry("nonexistent/repo") != nil {
 		t.Error("expected nil for nonexistent repo")
+	}
+}
+
+func TestRegistryConfigSourceSpecLegacyRepo(t *testing.T) {
+	rc := config.RegistryConfig{
+		Repo:    "Owner/Repo",
+		Enabled: true,
+		Type:    config.RegistryTypeCommunity,
+	}
+
+	spec := rc.SourceSpec()
+	if spec.Type != source.SourceGitHub || spec.Repo != "Owner/Repo" {
+		t.Fatalf("SourceSpec = %#v", spec)
+	}
+	ident := rc.Identity()
+	if ident.Key != "github:owner/repo" {
+		t.Fatalf("identity key = %q", ident.Key)
+	}
+}
+
+func TestConfigLoadSupportsNestedSourceWithoutLegacyChurn(t *testing.T) {
+	home := setupHome(t)
+	content := `registries:
+  - repo: acme/legacy-skills
+    enabled: true
+    type: team
+  - id: scoped
+    enabled: true
+    type: community
+    source:
+      type: github
+      repo: vercel-labs/agent-skills
+      ref: main
+      path: skills
+`
+	writeYAMLConfig(t, home, content)
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.TeamRepos(); len(got) != 2 || got[0] != "acme/legacy-skills" || got[1] != "vercel-labs/agent-skills" {
+		t.Fatalf("TeamRepos = %#v", got)
+	}
+	legacy := cfg.FindRegistry("acme/legacy-skills")
+	if legacy == nil || legacy.Source != nil {
+		t.Fatalf("legacy registry changed: %#v", legacy)
+	}
+	if got := cfg.FindRegistryByKeyOrRepo("scoped"); got == nil || got.ID != "scoped" {
+		t.Fatalf("FindRegistryByKeyOrRepo(id) = %#v", got)
+	}
+	if got := cfg.FindRegistryByKeyOrRepo("github:vercel-labs/agent-skills:skills"); got == nil || got.ID != "scoped" {
+		t.Fatalf("FindRegistryByKeyOrRepo(key) = %#v", got)
+	}
+	if got := cfg.FindRegistryByKeyOrRepo("https://github.com/vercel-labs/agent-skills"); got == nil || got.ID != "scoped" {
+		t.Fatalf("FindRegistryByKeyOrRepo(url) = %#v", got)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".scribe", "config.yaml"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(data) != content {
+		t.Fatalf("config file was churned\n got:\n%s\nwant:\n%s", data, content)
+	}
+}
+
+func TestEnabledSourcesGeneratesUniqueIDs(t *testing.T) {
+	cfg := &config.Config{Registries: []config.RegistryConfig{
+		{Repo: "org/skills", Enabled: true},
+		{Enabled: true, Source: &source.SourceSpec{Type: source.SourceGitHub, Repo: "other/skills"}, ID: "org-skills"},
+	}}
+
+	sources := cfg.EnabledSources()
+	if len(sources) != 2 {
+		t.Fatalf("EnabledSources len = %d", len(sources))
+	}
+	if sources[0].ID != "org-skills" || sources[1].ID != "org-skills-2" {
+		t.Fatalf("IDs = %q, %q", sources[0].ID, sources[1].ID)
+	}
+}
+
+func TestLoadRejectsDuplicateIDsAndSourceKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "duplicate ids",
+			content: `registries:
+  - id: team
+    enabled: true
+    source:
+      type: github
+      repo: org/one
+  - id: TEAM
+    enabled: true
+    source:
+      type: github
+      repo: org/two
+`,
+		},
+		{
+			name: "duplicate source keys",
+			content: `registries:
+  - id: one
+    enabled: true
+    source:
+      type: github
+      repo: org/skills
+  - id: two
+    enabled: true
+    source:
+      type: github
+      repo: ORG/Skills
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := setupHome(t)
+			writeYAMLConfig(t, home, tt.content)
+			if _, err := config.Load(); err == nil {
+				t.Fatal("expected load error")
+			}
+		})
 	}
 }
 

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -1,0 +1,394 @@
+package source
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type SourceType string
+
+const (
+	SourceGitHub SourceType = "github"
+	SourceGitLab SourceType = "gitlab"
+	SourceGit    SourceType = "git"
+	SourceLocal  SourceType = "local"
+)
+
+type SourceSpec struct {
+	ID       string     `yaml:"id,omitempty" json:"id,omitempty"`
+	Type     SourceType `yaml:"type" json:"type"`
+	Repo     string     `yaml:"repo,omitempty" json:"repo,omitempty"`
+	URL      string     `yaml:"url,omitempty" json:"url,omitempty"`
+	Ref      string     `yaml:"ref,omitempty" json:"ref,omitempty"`
+	Path     string     `yaml:"path,omitempty" json:"path,omitempty"`
+	Host     string     `yaml:"host,omitempty" json:"host,omitempty"`
+	Writable *bool      `yaml:"writable,omitempty" json:"writable,omitempty"`
+}
+
+type SourceIdentity struct {
+	Key          string `json:"key"`
+	Type         string `json:"type"`
+	Locator      string `json:"locator"`
+	Ref          string `json:"ref,omitempty"`
+	Path         string `json:"path,omitempty"`
+	ResolvedRev  string `json:"resolved_rev,omitempty"`
+	ContentScope string `json:"content_scope,omitempty"`
+}
+
+type InstallRef struct {
+	Source SourceSpec
+	Skill  string
+}
+
+var ownerRepoPattern = regexp.MustCompile(`^[^/\s]+/[^/\s]+$`)
+
+func ParseSourceArg(arg string) (SourceSpec, error) {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return SourceSpec{}, fmt.Errorf("source is empty")
+	}
+	if ownerRepoPattern.MatchString(arg) && !looksLikePath(arg) {
+		return CanonicalSpec(SourceSpec{Type: SourceGitHub, Repo: strings.TrimSuffix(arg, ".git")})
+	}
+	if strings.HasPrefix(arg, "file://") {
+		u, err := url.Parse(arg)
+		if err != nil {
+			return SourceSpec{}, fmt.Errorf("invalid file URL %q: %w", arg, err)
+		}
+		return CanonicalSpec(SourceSpec{Type: SourceLocal, Path: u.Path})
+	}
+	if looksLikeLocal(arg) {
+		return CanonicalSpec(SourceSpec{Type: SourceLocal, Path: arg})
+	}
+	if isGitURL(arg) {
+		return parseGitURL(arg)
+	}
+	if strings.Contains(arg, "://") {
+		return SourceSpec{}, fmt.Errorf("unsupported source URL %q", arg)
+	}
+	return SourceSpec{}, fmt.Errorf("invalid source %q", arg)
+}
+
+func ParseInstallRef(ref string) (InstallRef, error) {
+	ref = strings.TrimSpace(ref)
+	if strings.HasPrefix(ref, "[") {
+		end := strings.LastIndex(ref, "]:")
+		if end < 0 {
+			return InstallRef{}, fmt.Errorf("invalid install ref %q: expected [source]:skill", ref)
+		}
+		spec, err := ParseSourceArg(ref[1:end])
+		if err != nil {
+			return InstallRef{}, err
+		}
+		skill := strings.TrimSpace(ref[end+2:])
+		if skill == "" {
+			return InstallRef{}, fmt.Errorf("invalid install ref %q: skill name is empty", ref)
+		}
+		return InstallRef{Source: spec, Skill: skill}, nil
+	}
+	if strings.Contains(ref, "://") {
+		return InstallRef{}, fmt.Errorf("invalid install ref %q: URL sources must use [source]:skill or --source", ref)
+	}
+	idx := strings.LastIndex(ref, ":")
+	if idx < 0 {
+		return InstallRef{}, fmt.Errorf("invalid install ref %q: expected owner/repo:skill or [source]:skill", ref)
+	}
+	spec, err := ParseSourceArg(ref[:idx])
+	if err != nil {
+		return InstallRef{}, err
+	}
+	if spec.Type != SourceGitHub || spec.Path != "" {
+		return InstallRef{}, fmt.Errorf("invalid install ref %q: unbracketed refs must use owner/repo:skill", ref)
+	}
+	skill := strings.TrimSpace(ref[idx+1:])
+	if skill == "" {
+		return InstallRef{}, fmt.Errorf("invalid install ref %q: skill name is empty", ref)
+	}
+	return InstallRef{Source: spec, Skill: skill}, nil
+}
+
+func Canonicalize(spec SourceSpec) (SourceSpec, SourceIdentity, error) {
+	canonical, err := CanonicalSpec(spec)
+	if err != nil {
+		return SourceSpec{}, SourceIdentity{}, err
+	}
+	key := ""
+	locator := ""
+	switch canonical.Type {
+	case SourceGitHub:
+		host := canonical.Host
+		if host == "" {
+			host = "github.com"
+		}
+		locator = canonical.Repo
+		key = "github:" + strings.ToLower(canonical.Repo)
+		if canonical.Path != "" {
+			key += ":" + canonical.Path
+		}
+		_ = host
+	case SourceGitLab:
+		host := canonical.Host
+		if host == "" {
+			host = "gitlab.com"
+		}
+		locator = host + "/" + canonical.Repo
+		key = "gitlab:" + strings.ToLower(locator)
+		if canonical.Path != "" {
+			key += ":" + canonical.Path
+		}
+	case SourceGit:
+		locator = canonical.URL
+		key = "git:" + canonical.URL
+		if canonical.Path != "" {
+			key += ":" + canonical.Path
+		}
+	case SourceLocal:
+		locator = canonical.Path
+		key = "local:" + canonical.Path
+	default:
+		return SourceSpec{}, SourceIdentity{}, fmt.Errorf("invalid source type %q", spec.Type)
+	}
+	return canonical, SourceIdentity{
+		Key:          key,
+		Type:         string(canonical.Type),
+		Locator:      locator,
+		Ref:          canonical.Ref,
+		Path:         canonical.Path,
+		ContentScope: canonical.Path,
+	}, nil
+}
+
+func CanonicalSpec(spec SourceSpec) (SourceSpec, error) {
+	spec.ID = strings.TrimSpace(spec.ID)
+	spec.Type = SourceType(strings.ToLower(strings.TrimSpace(string(spec.Type))))
+	spec.Repo = strings.Trim(strings.TrimSpace(spec.Repo), "/")
+	spec.URL = strings.TrimSpace(spec.URL)
+	spec.Ref = strings.TrimSpace(spec.Ref)
+	spec.Host = strings.ToLower(strings.TrimSpace(spec.Host))
+
+	var err error
+	switch spec.Type {
+	case SourceGitHub:
+		spec.Repo = strings.TrimSuffix(spec.Repo, ".git")
+		if spec.Host == "" {
+			spec.Host = "github.com"
+		}
+		if spec.Repo == "" {
+			return SourceSpec{}, fmt.Errorf("github source requires repo")
+		}
+		if !validRepo(spec.Repo, false) {
+			return SourceSpec{}, fmt.Errorf("invalid github repo %q: expected owner/repo", spec.Repo)
+		}
+		if spec.URL == "" {
+			spec.URL = "https://github.com/" + spec.Repo
+		}
+		spec.Path, err = cleanGitPath(spec.Path)
+	case SourceGitLab:
+		if spec.Host == "" {
+			spec.Host = "gitlab.com"
+		}
+		if spec.Repo == "" {
+			return SourceSpec{}, fmt.Errorf("gitlab source requires repo")
+		}
+		if !validRepo(spec.Repo, true) {
+			return SourceSpec{}, fmt.Errorf("invalid gitlab repo %q", spec.Repo)
+		}
+		if spec.URL == "" {
+			spec.URL = "https://" + spec.Host + "/" + spec.Repo
+		}
+		spec.Path, err = cleanGitPath(spec.Path)
+	case SourceGit:
+		if spec.URL == "" {
+			return SourceSpec{}, fmt.Errorf("git source requires url")
+		}
+		spec.URL = normalizeGitURL(spec.URL)
+		spec.Path, err = cleanGitPath(spec.Path)
+	case SourceLocal:
+		if spec.Path == "" {
+			return SourceSpec{}, fmt.Errorf("local source requires path")
+		}
+		if spec.Ref != "" {
+			return SourceSpec{}, fmt.Errorf("local source does not support ref")
+		}
+		if spec.Repo != "" || spec.URL != "" {
+			return SourceSpec{}, fmt.Errorf("local source uses path, not repo or url")
+		}
+		spec.Path, err = cleanLocalPath(spec.Path)
+	default:
+		return SourceSpec{}, fmt.Errorf("invalid source type %q", spec.Type)
+	}
+	if err != nil {
+		return SourceSpec{}, err
+	}
+	return spec, nil
+}
+
+func parseGitURL(raw string) (SourceSpec, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return SourceSpec{}, fmt.Errorf("invalid source URL %q: %w", raw, err)
+	}
+	host := strings.ToLower(u.Hostname())
+	switch {
+	case host == "github.com" && (u.Scheme == "http" || u.Scheme == "https"):
+		return parseGitHubURL(raw, u)
+	case host == "gitlab.com" && (u.Scheme == "http" || u.Scheme == "https"):
+		return parseGitLabURL(raw, u)
+	default:
+		return CanonicalSpec(SourceSpec{Type: SourceGit, URL: raw})
+	}
+}
+
+func parseGitHubURL(raw string, u *url.URL) (SourceSpec, error) {
+	parts := cleanURLParts(u.Path)
+	if len(parts) < 2 {
+		return SourceSpec{}, fmt.Errorf("invalid GitHub URL %q: expected github.com/owner/repo", raw)
+	}
+	spec := SourceSpec{
+		Type: SourceGitHub,
+		Repo: parts[0] + "/" + strings.TrimSuffix(parts[1], ".git"),
+		URL:  "https://github.com/" + parts[0] + "/" + strings.TrimSuffix(parts[1], ".git"),
+	}
+	if len(parts) > 2 {
+		if parts[2] != "tree" && parts[2] != "blob" {
+			return SourceSpec{}, fmt.Errorf("invalid GitHub URL %q: expected repo or tree URL", raw)
+		}
+		if len(parts) < 4 {
+			return SourceSpec{}, fmt.Errorf("invalid GitHub URL %q: missing ref", raw)
+		}
+		spec.Ref = parts[3]
+		if len(parts) > 4 {
+			spec.Path = strings.Join(parts[4:], "/")
+		}
+	}
+	return CanonicalSpec(spec)
+}
+
+func parseGitLabURL(raw string, u *url.URL) (SourceSpec, error) {
+	parts := cleanURLParts(u.Path)
+	if len(parts) < 2 {
+		return SourceSpec{}, fmt.Errorf("invalid GitLab URL %q: expected gitlab.com/group/project", raw)
+	}
+	spec := SourceSpec{Type: SourceGitLab, Host: "gitlab.com"}
+	treeIdx := -1
+	for i := 0; i+1 < len(parts); i++ {
+		if parts[i] == "-" && (parts[i+1] == "tree" || parts[i+1] == "blob") {
+			treeIdx = i
+			break
+		}
+	}
+	repoEnd := len(parts)
+	if treeIdx >= 0 {
+		repoEnd = treeIdx
+	}
+	spec.Repo = strings.Join(parts[:repoEnd], "/")
+	spec.URL = "https://gitlab.com/" + spec.Repo
+	if treeIdx >= 0 {
+		if len(parts) <= treeIdx+2 {
+			return SourceSpec{}, fmt.Errorf("invalid GitLab URL %q: missing ref", raw)
+		}
+		spec.Ref = parts[treeIdx+2]
+		if len(parts) > treeIdx+3 {
+			spec.Path = strings.Join(parts[treeIdx+3:], "/")
+		}
+	}
+	return CanonicalSpec(spec)
+}
+
+func cleanURLParts(rawPath string) []string {
+	cleaned := path.Clean("/" + rawPath)
+	trimmed := strings.Trim(cleaned, "/")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "/")
+}
+
+func cleanGitPath(p string) (string, error) {
+	p = strings.TrimSpace(p)
+	if p == "" || p == "." {
+		return "", nil
+	}
+	if path.IsAbs(p) {
+		return "", fmt.Errorf("source path %q must be relative", p)
+	}
+	if strings.Contains(p, "\\") {
+		return "", fmt.Errorf("source path %q must use slash separators", p)
+	}
+	cleaned := path.Clean(p)
+	if cleaned == "." {
+		return "", nil
+	}
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") || strings.Contains(cleaned, "/../") {
+		return "", fmt.Errorf("source path %q cannot traverse directories", p)
+	}
+	for _, part := range strings.Split(cleaned, "/") {
+		if part == "" || part == "." || part == ".." || part == ".git" {
+			return "", fmt.Errorf("invalid source path %q", p)
+		}
+	}
+	return cleaned, nil
+}
+
+func cleanLocalPath(p string) (string, error) {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "", fmt.Errorf("local source requires path")
+	}
+	if strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("get home dir: %w", err)
+		}
+		p = filepath.Join(home, p[2:])
+	}
+	if !filepath.IsAbs(p) {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return "", fmt.Errorf("resolve local path %q: %w", p, err)
+		}
+		p = abs
+	}
+	return filepath.Clean(p), nil
+}
+
+func validRepo(repo string, allowNested bool) bool {
+	parts := strings.Split(repo, "/")
+	if (!allowNested && len(parts) != 2) || (allowNested && len(parts) < 2) {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." || strings.ContainsAny(part, " \t\n\r") {
+			return false
+		}
+	}
+	return true
+}
+
+func isGitURL(s string) bool {
+	return strings.HasPrefix(s, "http://") ||
+		strings.HasPrefix(s, "https://") ||
+		strings.HasPrefix(s, "ssh://") ||
+		strings.HasPrefix(s, "git+ssh://") ||
+		strings.HasPrefix(s, "git://")
+}
+
+func normalizeGitURL(s string) string {
+	if strings.HasPrefix(s, "git+ssh://") {
+		return "ssh://" + strings.TrimPrefix(s, "git+ssh://")
+	}
+	return strings.TrimSuffix(s, "/")
+}
+
+func looksLikeLocal(s string) bool {
+	return strings.HasPrefix(s, "~/") || strings.HasPrefix(s, "./") || strings.HasPrefix(s, "../") || filepath.IsAbs(s)
+}
+
+func looksLikePath(s string) bool {
+	return strings.HasPrefix(s, ".") || strings.HasPrefix(s, "~") || filepath.IsAbs(s)
+}

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -1,0 +1,139 @@
+package source_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/source"
+)
+
+func TestParseSourceArg(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tests := []struct {
+		name string
+		raw  string
+		want source.SourceSpec
+		key  string
+	}{
+		{
+			name: "github shorthand",
+			raw:  "Owner/Repo",
+			want: source.SourceSpec{Type: source.SourceGitHub, Repo: "Owner/Repo", URL: "https://github.com/Owner/Repo", Host: "github.com"},
+			key:  "github:owner/repo",
+		},
+		{
+			name: "github repo url",
+			raw:  "https://github.com/owner/repo.git",
+			want: source.SourceSpec{Type: source.SourceGitHub, Repo: "owner/repo", URL: "https://github.com/owner/repo", Host: "github.com"},
+			key:  "github:owner/repo",
+		},
+		{
+			name: "github tree url",
+			raw:  "https://github.com/owner/repo/tree/main/skills",
+			want: source.SourceSpec{Type: source.SourceGitHub, Repo: "owner/repo", URL: "https://github.com/owner/repo", Ref: "main", Path: "skills", Host: "github.com"},
+			key:  "github:owner/repo:skills",
+		},
+		{
+			name: "gitlab repo url",
+			raw:  "https://gitlab.com/group/project",
+			want: source.SourceSpec{Type: source.SourceGitLab, Repo: "group/project", URL: "https://gitlab.com/group/project", Host: "gitlab.com"},
+			key:  "gitlab:gitlab.com/group/project",
+		},
+		{
+			name: "gitlab tree url",
+			raw:  "https://gitlab.com/group/subgroup/project/-/tree/main/skills",
+			want: source.SourceSpec{Type: source.SourceGitLab, Repo: "group/subgroup/project", URL: "https://gitlab.com/group/subgroup/project", Ref: "main", Path: "skills", Host: "gitlab.com"},
+			key:  "gitlab:gitlab.com/group/subgroup/project:skills",
+		},
+		{
+			name: "arbitrary git url",
+			raw:  "https://example.com/org/skills.git",
+			want: source.SourceSpec{Type: source.SourceGit, URL: "https://example.com/org/skills.git"},
+			key:  "git:https://example.com/org/skills.git",
+		},
+		{
+			name: "ssh git url",
+			raw:  "git+ssh://git@example.com/org/skills.git",
+			want: source.SourceSpec{Type: source.SourceGit, URL: "ssh://git@example.com/org/skills.git"},
+			key:  "git:ssh://git@example.com/org/skills.git",
+		},
+		{
+			name: "absolute local path",
+			raw:  filepath.Join(home, "skills"),
+			want: source.SourceSpec{Type: source.SourceLocal, Path: filepath.Join(home, "skills")},
+			key:  "local:" + filepath.Join(home, "skills"),
+		},
+		{
+			name: "tilde local path",
+			raw:  "~/skills",
+			want: source.SourceSpec{Type: source.SourceLocal, Path: filepath.Join(home, "skills")},
+			key:  "local:" + filepath.Join(home, "skills"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := source.ParseSourceArg(tt.raw)
+			if err != nil {
+				t.Fatalf("ParseSourceArg: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("spec = %#v, want %#v", got, tt.want)
+			}
+			_, ident, err := source.Canonicalize(got)
+			if err != nil {
+				t.Fatalf("Canonicalize: %v", err)
+			}
+			if ident.Key != tt.key {
+				t.Fatalf("key = %q, want %q", ident.Key, tt.key)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeRejectsInvalidSource(t *testing.T) {
+	tests := []struct {
+		name string
+		spec source.SourceSpec
+	}{
+		{name: "invalid type", spec: source.SourceSpec{Type: "svn", URL: "https://example.com/repo"}},
+		{name: "github traversal", spec: source.SourceSpec{Type: source.SourceGitHub, Repo: "owner/repo", Path: "../skills"}},
+		{name: "github absolute path", spec: source.SourceSpec{Type: source.SourceGitHub, Repo: "owner/repo", Path: "/skills"}},
+		{name: "local ref", spec: source.SourceSpec{Type: source.SourceLocal, Path: "/tmp/skills", Ref: "main"}},
+		{name: "missing git url", spec: source.SourceSpec{Type: source.SourceGit}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, _, err := source.Canonicalize(tt.spec); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestParseInstallRef(t *testing.T) {
+	tests := []struct {
+		raw       string
+		wantRepo  string
+		wantSkill string
+		wantPath  string
+	}{
+		{raw: "owner/repo:skill", wantRepo: "owner/repo", wantSkill: "skill"},
+		{raw: "[https://github.com/owner/repo/tree/main/skills]:skill", wantRepo: "owner/repo", wantSkill: "skill", wantPath: "skills"},
+	}
+	for _, tt := range tests {
+		got, err := source.ParseInstallRef(tt.raw)
+		if err != nil {
+			t.Fatalf("ParseInstallRef(%q): %v", tt.raw, err)
+		}
+		if got.Source.Repo != tt.wantRepo || got.Skill != tt.wantSkill || got.Source.Path != tt.wantPath {
+			t.Fatalf("ParseInstallRef(%q) = %#v", tt.raw, got)
+		}
+	}
+
+	if _, err := source.ParseInstallRef("https://github.com/owner/repo:skill"); err == nil {
+		t.Fatal("expected unbracketed URL ref to fail")
+	}
+}


### PR DESCRIPTION
Adds the phase 1 SourceSpec foundation without rewiring provider/browse/sync internals yet. Registry configs can now carry nested source metadata while legacy repo rows still load and save in the old shape.\n\nWhat changed:\n- add internal/source with SourceSpec, SourceIdentity, canonical keys, source arg parsing, and bracket install-ref parsing\n- add registries[].source plus config adapters: SourceSpec(), ParseConfigSource(), Identity(), EnabledSources(), and FindRegistryByKeyOrRepo()\n- validate explicit duplicate IDs/source keys and reject invalid source types/path traversal\n\nTests:\n- go test ./internal/source ./internal/config\n- go test ./...