### PR TITLE
feat: support GitHub SourceSpec browse internals

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
@@ -46,8 +47,10 @@ type installRunResults struct {
 
 // browseEntry pairs a SkillStatus with the registry it came from.
 type browseEntry struct {
-	Status   sync.SkillStatus
-	Registry string
+	Status    sync.SkillStatus
+	Registry  string
+	SourceKey string
+	Source    source.SourceSpec
 }
 
 func newAddCommand() *cobra.Command {
@@ -269,6 +272,27 @@ func runAddDirectInstallForCommand(
 	skipConfirm bool,
 	resync bool,
 ) error {
+	spec, ident, err := sourceSpecForRegistry(registryRepo)
+	if err != nil {
+		return err
+	}
+	return runAddDirectInstallSourceForCommand(cmd, ctx, registryRepo, ident.Key, spec, skillName, cfg, st, syncer, authenticated, useJSON, skipConfirm, resync)
+}
+
+func runAddDirectInstallSourceForCommand(
+	cmd *cobra.Command,
+	ctx context.Context,
+	registryDisplay, sourceKey string,
+	spec source.SourceSpec,
+	skillName string,
+	cfg *config.Config,
+	st *state.State,
+	syncer *sync.Syncer,
+	authenticated bool,
+	useJSON bool,
+	skipConfirm bool,
+	resync bool,
+) error {
 	if !authenticated {
 		return clierrors.Wrap(
 			fmt.Errorf("authentication required"),
@@ -278,9 +302,15 @@ func runAddDirectInstallForCommand(
 		)
 	}
 
-	statuses, _, err := syncer.Diff(ctx, registryRepo, st)
+	var statuses []sync.SkillStatus
+	var err error
+	if isLegacyGitHubSource(spec) {
+		statuses, _, err = syncer.Diff(ctx, spec.Repo, st)
+	} else {
+		statuses, _, err = syncer.DiffSource(ctx, sourceKey, spec, st)
+	}
 	if err != nil {
-		return fmt.Errorf("diff %s: %w", registryRepo, err)
+		return fmt.Errorf("diff %s: %w", registryDisplay, err)
 	}
 
 	var target *sync.SkillStatus
@@ -291,24 +321,24 @@ func runAddDirectInstallForCommand(
 		}
 	}
 	if target == nil {
-		return fmt.Errorf("skill %q not found in %s", skillName, registryRepo)
+		return fmt.Errorf("skill %q not found in %s", skillName, registryDisplay)
 	}
 
 	// Skill exists — safe to auto-connect the registry now.
-	if cfg.FindRegistry(registryRepo) == nil {
-		cfg.AddRegistry(config.RegistryConfig{Repo: registryRepo})
+	if cfg.FindRegistryByKeyOrRepo(sourceKey) == nil && cfg.FindRegistryByKeyOrRepo(registryDisplay) == nil {
+		cfg.AddRegistry(registryConfigForSource(spec))
 		if err := cfg.Save(); err != nil {
 			return fmt.Errorf("save config: %w", err)
 		}
 		if !useJSON {
-			fmt.Printf("connected %s\n", registryRepo)
+			fmt.Printf("connected %s\n", registryDisplay)
 		}
 	}
 
 	if target.Status == sync.StatusCurrent {
 		if useJSON {
 			return emitInstallJSON([]installResult{{
-				Name: target.Name, Registry: registryRepo, Status: "already-installed",
+				Name: target.Name, Registry: registryDisplay, Status: "already-installed",
 			}}, nil, cmd)
 		}
 		fmt.Printf("%s is already installed (current).\n", skillName)
@@ -317,7 +347,7 @@ func runAddDirectInstallForCommand(
 	if target.Status == sync.StatusModified && !resync {
 		if useJSON {
 			return emitInstallJSON([]installResult{{
-				Name: target.Name, Registry: registryRepo, Status: "modified",
+				Name: target.Name, Registry: registryDisplay, Status: "modified",
 			}}, nil, cmd)
 		}
 		fmt.Printf("%s has local edits. Run with --resync to overwrite them from upstream.\n", skillName)
@@ -327,12 +357,12 @@ func runAddDirectInstallForCommand(
 	// Confirmation.
 	if !skipConfirm && !useJSON {
 		var confirm bool
-		title := fmt.Sprintf("Install %s from %s?", skillName, registryRepo)
+		title := fmt.Sprintf("Install %s from %s?", skillName, registryDisplay)
 		if target.Status == sync.StatusOutdated {
-			title = fmt.Sprintf("Update %s from %s?", skillName, registryRepo)
+			title = fmt.Sprintf("Update %s from %s?", skillName, registryDisplay)
 		}
 		if target.Status == sync.StatusModified && resync {
-			title = fmt.Sprintf("Resync %s from %s and overwrite local edits?", skillName, registryRepo)
+			title = fmt.Sprintf("Resync %s from %s and overwrite local edits?", skillName, registryDisplay)
 		}
 		if err := huh.NewConfirm().Title(title).Value(&confirm).Run(); err != nil {
 			return err
@@ -342,8 +372,13 @@ func runAddDirectInstallForCommand(
 		}
 	}
 
-	results := wireInstallSyncer(syncer, registryRepo, useJSON)
-	if err := syncer.RunWithDiff(ctx, registryRepo, []sync.SkillStatus{*target}, st); err != nil {
+	results := wireInstallSyncer(syncer, registryDisplay, useJSON)
+	if isLegacyGitHubSource(spec) {
+		err = syncer.RunWithDiff(ctx, spec.Repo, []sync.SkillStatus{*target}, st)
+	} else {
+		err = syncer.RunWithDiffSource(ctx, sourceKey, spec, []sync.SkillStatus{*target}, st)
+	}
+	if err != nil {
 		return fmt.Errorf("install %s: %w", skillName, err)
 	}
 
@@ -351,6 +386,32 @@ func runAddDirectInstallForCommand(
 		return emitInstallJSON(results.Installed, results.Resolution, cmd)
 	}
 	return nil
+}
+
+func sourceSpecForRegistry(input string) (source.SourceSpec, source.SourceIdentity, error) {
+	spec, err := source.ParseSourceArg(input)
+	if err != nil {
+		return source.SourceSpec{}, source.SourceIdentity{}, err
+	}
+	spec, ident, err := source.Canonicalize(spec)
+	if err != nil {
+		return source.SourceSpec{}, source.SourceIdentity{}, err
+	}
+	if spec.Type == source.SourceGitHub && spec.Path == "" && spec.Ref == "" {
+		ident.Key = spec.Repo
+	}
+	return spec, ident, nil
+}
+
+func registryConfigForSource(spec source.SourceSpec) config.RegistryConfig {
+	if isLegacyGitHubSource(spec) {
+		return config.RegistryConfig{Repo: spec.Repo, Enabled: true, Type: config.RegistryTypeCommunity}
+	}
+	return config.RegistryConfig{ID: spec.ID, Enabled: true, Type: config.RegistryTypeCommunity, Source: &spec}
+}
+
+func isLegacyGitHubSource(spec source.SourceSpec) bool {
+	return spec.Type == source.SourceGitHub && spec.Path == "" && spec.Ref == ""
 }
 
 // installSelected installs the user-selected entries from the browser. Each
@@ -369,12 +430,18 @@ func installSelected(
 ) error {
 	// Group by registry.
 	byRegistry := map[string][]sync.SkillStatus{}
+	sourceByRegistry := map[string]source.SourceSpec{}
+	sourceKeyByRegistry := map[string]string{}
 	order := []string{}
 	for _, e := range selected {
 		if _, seen := byRegistry[e.Registry]; !seen {
 			order = append(order, e.Registry)
 		}
 		byRegistry[e.Registry] = append(byRegistry[e.Registry], e.Status)
+		if e.SourceKey != "" {
+			sourceByRegistry[e.Registry] = e.Source
+			sourceKeyByRegistry[e.Registry] = e.SourceKey
+		}
 	}
 
 	// Confirmation summary.
@@ -407,8 +474,12 @@ func installSelected(
 	var installErr error
 	for _, registryRepo := range order {
 		// Auto-connect if needed.
-		if cfg.FindRegistry(registryRepo) == nil {
-			cfg.AddRegistry(config.RegistryConfig{Repo: registryRepo})
+		if cfg.FindRegistryByKeyOrRepo(registryRepo) == nil {
+			if spec, ok := sourceByRegistry[registryRepo]; ok {
+				cfg.AddRegistry(registryConfigForSource(spec))
+			} else {
+				cfg.AddRegistry(config.RegistryConfig{Repo: registryRepo, Enabled: true, Type: config.RegistryTypeCommunity})
+			}
 			if err := cfg.Save(); err != nil {
 				return fmt.Errorf("save config: %w", err)
 			}
@@ -430,7 +501,13 @@ func installSelected(
 
 		fmt.Printf("\ninstalling from %s...\n\n", registryRepo)
 		_ = wireInstallSyncer(syncer, registryRepo, false)
-		if err := syncer.RunWithDiff(ctx, registryRepo, toInstall, st); err != nil {
+		var err error
+		if spec, ok := sourceByRegistry[registryRepo]; ok {
+			err = syncer.RunWithDiffSource(ctx, sourceKeyByRegistry[registryRepo], spec, toInstall, st)
+		} else {
+			err = syncer.RunWithDiff(ctx, registryRepo, toInstall, st)
+		}
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "  error: %v\n", err)
 			installErr = err
 		}
@@ -553,6 +630,43 @@ func discoverEntries(
 	return entries, errs
 }
 
+func discoverSourceEntries(
+	ctx context.Context,
+	sources []config.RegistrySource,
+	client *gh.Client,
+	targets []tools.Tool,
+	st *state.State,
+) ([]browseEntry, []error) {
+	syncer := &sync.Syncer{
+		Client:   sync.WrapGitHubClient(client),
+		Provider: provider.NewGitHubProvider(provider.WrapGitHubClient(client)),
+		Tools:    targets,
+	}
+
+	var entries []browseEntry
+	var errs []error
+	for _, src := range sources {
+		statuses, _, err := syncer.DiffSource(ctx, src.Identity.Key, src.Source, st)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", src.ID, err))
+			continue
+		}
+		for _, s := range statuses {
+			// Skip extras (local-only) — `add` is for installing FROM registries.
+			if s.Status == sync.StatusExtra {
+				continue
+			}
+			entries = append(entries, browseEntry{
+				Status:    s,
+				Registry:  registryDisplay(src),
+				SourceKey: src.Identity.Key,
+				Source:    src.Source,
+			})
+		}
+	}
+	return entries, errs
+}
+
 // filterEntries returns entries whose name or description contains the query
 // (case-insensitive).
 func filterEntries(entries []browseEntry, query string) []browseEntry {
@@ -590,6 +704,8 @@ func emitBrowseJSONForCommand(cmd *cobra.Command, entries []browseEntry) error {
 	type row struct {
 		Name        string `json:"name"`
 		Registry    string `json:"registry"`
+		SourceKey   string `json:"source_key,omitempty"`
+		Source      any    `json:"source,omitempty"`
 		Status      string `json:"status"`
 		Version     string `json:"version,omitempty"`
 		Description string `json:"description,omitempty"`
@@ -604,6 +720,8 @@ func emitBrowseJSONForCommand(cmd *cobra.Command, entries []browseEntry) error {
 		rows = append(rows, row{
 			Name:        e.Status.Name,
 			Registry:    e.Registry,
+			SourceKey:   e.SourceKey,
+			Source:      jsonSource(e.Source),
 			Status:      e.Status.Status.String(),
 			Version:     e.Status.DisplayVersion(),
 			Description: desc,
@@ -615,6 +733,23 @@ func emitBrowseJSONForCommand(cmd *cobra.Command, entries []browseEntry) error {
 		return json.NewEncoder(os.Stdout).Encode(payload)
 	}
 	return renderMutatorEnvelope(cmd, payload, envelope.StatusOK)
+}
+
+func registryDisplay(src config.RegistrySource) string {
+	if src.Config.Repo != "" {
+		return src.Config.Repo
+	}
+	if src.ID != "" {
+		return src.ID
+	}
+	return src.Identity.Key
+}
+
+func jsonSource(spec source.SourceSpec) any {
+	if spec.Type == "" {
+		return nil
+	}
+	return spec
 }
 
 // emitInstallJSON emits per-skill install results as JSON.

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -646,7 +646,8 @@ func discoverSourceEntries(
 	var entries []browseEntry
 	var errs []error
 	for _, src := range sources {
-		statuses, _, err := syncer.DiffSource(ctx, src.Identity.Key, src.Source, st)
+		sourceKey := registryStateKey(src)
+		statuses, _, err := syncer.DiffSource(ctx, sourceKey, src.Source, st)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", src.ID, err))
 			continue
@@ -659,7 +660,7 @@ func discoverSourceEntries(
 			entries = append(entries, browseEntry{
 				Status:    s,
 				Registry:  registryDisplay(src),
-				SourceKey: src.Identity.Key,
+				SourceKey: sourceKey,
 				Source:    src.Source,
 			})
 		}
@@ -741,6 +742,13 @@ func registryDisplay(src config.RegistrySource) string {
 	}
 	if src.ID != "" {
 		return src.ID
+	}
+	return src.Identity.Key
+}
+
+func registryStateKey(src config.RegistrySource) string {
+	if src.Config.Source == nil && src.Config.Repo != "" && isLegacyGitHubSource(src.Source) {
+		return src.Config.Repo
 	}
 	return src.Identity.Key
 }

--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/registry"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
@@ -24,6 +25,7 @@ import (
 )
 
 var discoverEntriesFn = discoverEntries
+var discoverSourceEntriesFn = discoverSourceEntries
 var discoverKitEntriesFn = discoverKitEntries
 
 func newBrowseCommand() *cobra.Command {
@@ -71,16 +73,17 @@ func runBrowse(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("resolve active tools: %w", err)
 	}
 
-	repos, err := browseRepos(registryFilter, cfg.TeamRepos())
+	sources, err := browseSources(registryFilter, cfg)
 	if err != nil {
 		return err
 	}
+	repos := legacyReposFromSources(sources)
 
 	if kits {
 		return runBrowseKitsWithDeps(cmd.Context(), repos, query, installRef, cfg, st, client, useJSON, yes)
 	}
 
-	return runBrowseWithDeps(cmd.Context(), repos, query, installRef, cfg, st, client, targets, useJSON, yes, resync)
+	return runBrowseWithDeps(cmd.Context(), sources, query, installRef, cfg, st, client, targets, useJSON, yes, resync)
 }
 
 type kitBrowseEntry struct {
@@ -220,9 +223,43 @@ func browseRepos(registryFilter string, connected []string) ([]string, error) {
 	return []string{repo}, nil
 }
 
+func browseSources(registryFilter string, cfg *config.Config) ([]config.RegistrySource, error) {
+	connected := cfg.EnabledSources()
+	if registryFilter == "" {
+		if len(connected) == 0 {
+			return nil, fmt.Errorf("no registries connected — run: scribe connect <owner/repo>")
+		}
+		return connected, nil
+	}
+	if rc := cfg.FindRegistryByKeyOrRepo(registryFilter); rc != nil {
+		spec, ident, err := source.Canonicalize(rc.SourceSpec())
+		if err != nil {
+			return nil, err
+		}
+		rs := config.RegistrySource{Config: *rc, Source: spec, Identity: ident}
+		rs.ID = registryDisplay(rs)
+		return []config.RegistrySource{rs}, nil
+	}
+	spec, ident, err := sourceSpecForRegistry(registryFilter)
+	if err != nil {
+		return nil, err
+	}
+	return []config.RegistrySource{{ID: registryFilter, Source: spec, Identity: ident}}, nil
+}
+
+func legacyReposFromSources(sources []config.RegistrySource) []string {
+	repos := make([]string, 0, len(sources))
+	for _, src := range sources {
+		if src.Source.Type == source.SourceGitHub && src.Source.Repo != "" {
+			repos = append(repos, src.Source.Repo)
+		}
+	}
+	return repos
+}
+
 func runBrowseWithDeps(
 	ctx context.Context,
-	repos []string,
+	sources []config.RegistrySource,
 	query string,
 	installRef string,
 	cfg *config.Config,
@@ -235,7 +272,7 @@ func runBrowseWithDeps(
 ) error {
 	if installRef == "" && !useJSON {
 		if cfg != nil {
-			for _, repo := range repos {
+			for _, repo := range legacyReposFromSources(sources) {
 				if cfg.FindRegistry(repo) == nil {
 					cfg.AddRegistry(config.RegistryConfig{Repo: repo, Enabled: true, Type: config.RegistryTypeCommunity})
 				}
@@ -255,6 +292,7 @@ func runBrowseWithDeps(
 			FilterRegistries: filterRegistries,
 		}
 		bag.Provider = provider.NewGitHubProvider(provider.WrapGitHubClient(client))
+		repos := legacyReposFromSources(sources)
 		if len(repos) == 1 {
 			bag.RepoFlag = repos[0]
 		}
@@ -270,7 +308,7 @@ func runBrowseWithDeps(
 		return nil
 	}
 
-	entries, errs := discoverEntriesFn(ctx, repos, client, targets, st)
+	entries, errs := discoverSourceEntriesFn(ctx, sources, client, targets, st)
 	for _, e := range errs {
 		fmt.Fprintf(os.Stderr, "warning: %v\n", e)
 	}
@@ -323,12 +361,19 @@ func browseInstall(
 	if len(matches) > 1 {
 		var options []string
 		for _, match := range matches {
-			options = append(options, fmt.Sprintf("%s:%s", match.Registry, match.Status.Name))
+			sourceID := match.Registry
+			if match.SourceKey != "" {
+				sourceID = match.SourceKey
+			}
+			options = append(options, fmt.Sprintf("%s:%s", sourceID, match.Status.Name))
 		}
 		return fmt.Errorf("skill %q is ambiguous — use one of: %s", installRef, strings.Join(options, ", "))
 	}
 
 	match := matches[0]
+	if match.SourceKey != "" {
+		return runAddDirectInstallSourceForCommand(nil, ctx, match.Registry, match.SourceKey, match.Source, match.Status.Name, cfg, st, newInstallSyncer(client, targets), client.IsAuthenticated(), useJSON, skipConfirm, resync)
+	}
 	return runAddDirectInstall(ctx, match.Registry, match.Status.Name, cfg, st, newInstallSyncer(client, targets), client.IsAuthenticated(), useJSON, skipConfirm, resync)
 }
 

--- a/cmd/browse_test.go
+++ b/cmd/browse_test.go
@@ -10,12 +10,34 @@ import (
 
 	"github.com/Naoray/scribe/internal/config"
 	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/registry"
 	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
 )
+
+type browseSourceProvider struct {
+	entries []manifest.Entry
+}
+
+func (p browseSourceProvider) Discover(ctx context.Context, repo string) (*provider.DiscoverResult, error) {
+	return &provider.DiscoverResult{Entries: p.entries, IsTeam: true}, nil
+}
+
+func (p browseSourceProvider) DiscoverSource(ctx context.Context, spec source.SourceSpec) (*provider.DiscoverResult, error) {
+	return p.Discover(ctx, spec.Repo)
+}
+
+func (p browseSourceProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]provider.File, error) {
+	return nil, nil
+}
+
+func (p browseSourceProvider) FetchSource(ctx context.Context, spec source.SourceSpec, entry manifest.Entry) ([]provider.File, error) {
+	return nil, nil
+}
 
 func TestRunBrowseWithDeps_JSONQueryFiltersResults(t *testing.T) {
 	old := discoverSourceEntriesFn
@@ -108,6 +130,48 @@ func TestRunBrowseKitsWithDeps_JSONQueryFiltersResults(t *testing.T) {
 	}
 	if len(out.Results) != 1 || out.Results[0].Name != "baseline" || !out.Results[0].InstalledLocally {
 		t.Fatalf("results = %+v, want installed baseline only", out.Results)
+	}
+}
+
+func TestLegacyRegistrySourceUsesRepoStateKey(t *testing.T) {
+	cfg := &config.Config{Registries: []config.RegistryConfig{{
+		Repo:    "acme/skills",
+		Enabled: true,
+	}}}
+	sources := cfg.EnabledSources()
+	if len(sources) != 1 {
+		t.Fatalf("EnabledSources len = %d, want 1", len(sources))
+	}
+	sourceKey := registryStateKey(sources[0])
+	if sourceKey != "acme/skills" {
+		t.Fatalf("registryStateKey = %q, want acme/skills", sourceKey)
+	}
+
+	syncer := &sync.Syncer{
+		Client: &sync.NoopFetcher{},
+		Provider: browseSourceProvider{entries: []manifest.Entry{{
+			Name:   "cleanup",
+			Source: "github:acme/skills@v1.0.0",
+		}}},
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"cleanup": {
+			Sources: []state.SkillSource{{
+				Registry: "acme/skills",
+				Ref:      "v1.0.0",
+			}},
+		},
+	}}
+
+	statuses, _, err := syncer.DiffSource(context.Background(), sourceKey, sources[0].Source, st)
+	if err != nil {
+		t.Fatalf("DiffSource: %v", err)
+	}
+	if len(statuses) != 1 {
+		t.Fatalf("statuses = %d, want 1", len(statuses))
+	}
+	if statuses[0].Status != sync.StatusCurrent {
+		t.Fatalf("status = %s, want %s", statuses[0].Status, sync.StatusCurrent)
 	}
 }
 

--- a/cmd/browse_test.go
+++ b/cmd/browse_test.go
@@ -8,20 +8,22 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Naoray/scribe/internal/config"
 	gh "github.com/Naoray/scribe/internal/github"
 	"github.com/Naoray/scribe/internal/registry"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
 )
 
 func TestRunBrowseWithDeps_JSONQueryFiltersResults(t *testing.T) {
-	old := discoverEntriesFn
-	defer func() { discoverEntriesFn = old }()
-	discoverEntriesFn = func(context.Context, []string, *gh.Client, []tools.Tool, *state.State) ([]browseEntry, []error) {
+	old := discoverSourceEntriesFn
+	defer func() { discoverSourceEntriesFn = old }()
+	discoverSourceEntriesFn = func(context.Context, []config.RegistrySource, *gh.Client, []tools.Tool, *state.State) ([]browseEntry, []error) {
 		return []browseEntry{
-			{Registry: "acme/skills", Status: sync.SkillStatus{Name: "cleanup", Status: sync.StatusMissing}},
-			{Registry: "acme/skills", Status: sync.SkillStatus{Name: "deploy", Status: sync.StatusMissing}},
+			{Registry: "scoped", SourceKey: "github:acme/skills:skills", Source: source.SourceSpec{Type: source.SourceGitHub, Repo: "acme/skills", Path: "skills"}, Status: sync.SkillStatus{Name: "cleanup", Status: sync.StatusMissing}},
+			{Registry: "scoped", SourceKey: "github:acme/skills:skills", Source: source.SourceSpec{Type: source.SourceGitHub, Repo: "acme/skills", Path: "skills"}, Status: sync.SkillStatus{Name: "deploy", Status: sync.StatusMissing}},
 		}, nil
 	}
 
@@ -33,7 +35,11 @@ func TestRunBrowseWithDeps_JSONQueryFiltersResults(t *testing.T) {
 	os.Stdout = w
 	defer func() { os.Stdout = oldStdout }()
 
-	err = runBrowseWithDeps(context.Background(), []string{"acme/skills"}, "clean", "", nil, &state.State{Installed: map[string]state.InstalledSkill{}}, nil, nil, true, true, false)
+	err = runBrowseWithDeps(context.Background(), []config.RegistrySource{{
+		ID:       "acme/skills",
+		Source:   source.SourceSpec{Type: source.SourceGitHub, Repo: "acme/skills"},
+		Identity: source.SourceIdentity{Key: "acme/skills"},
+	}}, "clean", "", nil, &state.State{Installed: map[string]state.InstalledSkill{}}, nil, nil, true, true, false)
 	w.Close()
 	if err != nil {
 		t.Fatalf("runBrowseWithDeps() error = %v", err)
@@ -46,7 +52,9 @@ func TestRunBrowseWithDeps_JSONQueryFiltersResults(t *testing.T) {
 
 	var out struct {
 		Results []struct {
-			Name string `json:"name"`
+			Name      string            `json:"name"`
+			SourceKey string            `json:"source_key"`
+			Source    source.SourceSpec `json:"source"`
 		} `json:"results"`
 	}
 	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
@@ -54,6 +62,9 @@ func TestRunBrowseWithDeps_JSONQueryFiltersResults(t *testing.T) {
 	}
 	if len(out.Results) != 1 || out.Results[0].Name != "cleanup" {
 		t.Fatalf("results = %+v, want only cleanup", out.Results)
+	}
+	if out.Results[0].SourceKey != "github:acme/skills:skills" || out.Results[0].Source.Path != "skills" {
+		t.Fatalf("source fields = %+v", out.Results[0])
 	}
 }
 

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -97,7 +97,7 @@ func (p *GitHubProvider) DiscoverSource(ctx context.Context, spec source.SourceS
 }
 
 func (p *GitHubProvider) discoverScribeYAML(ctx context.Context, owner, repo, scope, ref string) (*manifest.Manifest, error) {
-	raw, err := p.client.FetchFile(ctx, owner, repo, scopedPath(scope, manifest.ManifestFilename), ref)
+	raw, err := p.client.FetchFile(ctx, owner, repo, ScopedPath(scope, manifest.ManifestFilename), ref)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (p *GitHubProvider) discoverScribeYAML(ctx context.Context, owner, repo, sc
 }
 
 func (p *GitHubProvider) discoverScribeTOML(ctx context.Context, owner, repo, scope, ref string) (*manifest.Manifest, error) {
-	raw, err := p.client.FetchFile(ctx, owner, repo, scopedPath(scope, manifest.LegacyManifestFilename), ref)
+	raw, err := p.client.FetchFile(ctx, owner, repo, ScopedPath(scope, manifest.LegacyManifestFilename), ref)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (p *GitHubProvider) discoverScribeTOML(ctx context.Context, owner, repo, sc
 }
 
 func (p *GitHubProvider) discoverMarketplace(ctx context.Context, owner, repo, scope, ref string) ([]manifest.Entry, error) {
-	raw, err := p.client.FetchFile(ctx, owner, repo, scopedPath(scope, marketplacePath), ref)
+	raw, err := p.client.FetchFile(ctx, owner, repo, ScopedPath(scope, marketplacePath), ref)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (p *GitHubProvider) discoverMarketplace(ctx context.Context, owner, repo, s
 	}
 	if scope != "" {
 		for i := range entries {
-			entries[i].Path = scopedPath(scope, entries[i].Path)
+			entries[i].Path = ScopedPath(scope, entries[i].Path)
 		}
 	}
 	return entries, nil
@@ -244,7 +244,7 @@ func (p *GitHubProvider) FetchSource(ctx context.Context, spec source.SourceSpec
 	if skillPath == "" {
 		skillPath = entry.Name
 	}
-	skillPath = scopedPath(spec.Path, skillPath)
+	skillPath = ScopedPath(spec.Path, skillPath)
 
 	if path.Base(skillPath) == skillFileName {
 		data, err := p.client.FetchFile(ctx, owner, repoName, skillPath, ref)
@@ -284,7 +284,9 @@ func sourceRef(spec source.SourceSpec) string {
 	return "HEAD"
 }
 
-func scopedPath(scope, rel string) string {
+// ScopedPath resolves rel under scope without double-prefixing paths that
+// already include the scope.
+func ScopedPath(scope, rel string) string {
 	scope = strings.Trim(path.Clean(strings.TrimSpace(scope)), "/")
 	rel = strings.Trim(path.Clean(strings.TrimSpace(rel)), "/")
 	if scope == "." {

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 
 	gh "github.com/Naoray/scribe/internal/github"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/migrate"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/tools"
 )
 
@@ -46,45 +48,56 @@ func (p *GitHubProvider) warn(msg string) {
 
 // Discover probes the repo using a fallback chain and returns all discovered entries.
 func (p *GitHubProvider) Discover(ctx context.Context, repo string) (*DiscoverResult, error) {
-	normalized, err := manifest.NormalizeGitHubRepo(repo)
+	spec, err := source.ParseSourceArg(repo)
 	if err != nil {
 		return nil, err
 	}
-	owner, repoName, err := manifest.ParseOwnerRepo(normalized)
+	return p.DiscoverSource(ctx, spec)
+}
+
+// DiscoverSource probes a GitHub source using the same fallback chain as
+// Discover, scoped to SourceSpec.Path when configured.
+func (p *GitHubProvider) DiscoverSource(ctx context.Context, spec source.SourceSpec) (*DiscoverResult, error) {
+	spec, err := canonicalGitHubSource(spec)
 	if err != nil {
 		return nil, err
 	}
+	owner, repoName, err := manifest.ParseOwnerRepo(spec.Repo)
+	if err != nil {
+		return nil, err
+	}
+	ref := sourceRef(spec)
 
 	// Step 1: Try scribe.yaml.
-	m, err := p.discoverScribeYAML(ctx, owner, repoName)
+	m, err := p.discoverScribeYAML(ctx, owner, repoName, spec.Path, ref)
 	if err == nil {
 		return &DiscoverResult{Entries: m.Catalog, IsTeam: true, Manifest: m}, nil
 	}
 
 	// Step 2: Try scribe.toml (legacy).
-	m, err = p.discoverScribeTOML(ctx, owner, repoName)
+	m, err = p.discoverScribeTOML(ctx, owner, repoName, spec.Path, ref)
 	if err == nil {
-		p.warn(fmt.Sprintf("%s uses legacy scribe.toml format — consider migrating to scribe.yaml", repo))
+		p.warn(fmt.Sprintf("%s uses legacy scribe.toml format — consider migrating to scribe.yaml", spec.Repo))
 		return &DiscoverResult{Entries: m.Catalog, IsTeam: true, Manifest: m}, nil
 	}
 
 	// Step 3: Try .claude-plugin/marketplace.json.
-	entries, err := p.discoverMarketplace(ctx, owner, repoName)
+	entries, err := p.discoverMarketplace(ctx, owner, repoName, spec.Path, ref)
 	if err == nil {
 		return &DiscoverResult{Entries: entries, IsTeam: false}, nil
 	}
 
 	// Step 4: Tree scan for SKILL.md files.
-	entries, err = p.discoverTreeScan(ctx, owner, repoName)
+	entries, err = p.discoverTreeScan(ctx, owner, repoName, spec.Path, ref)
 	if err == nil && len(entries) > 0 {
 		return &DiscoverResult{Entries: entries, IsTeam: false}, nil
 	}
 
-	return nil, fmt.Errorf("%s: no skills found (looked for scribe.yaml, scribe.toml, marketplace.json, and SKILL.md files)", repo)
+	return nil, fmt.Errorf("%s: no skills found (looked for scribe.yaml, scribe.toml, marketplace.json, and SKILL.md files)", spec.Repo)
 }
 
-func (p *GitHubProvider) discoverScribeYAML(ctx context.Context, owner, repo string) (*manifest.Manifest, error) {
-	raw, err := p.client.FetchFile(ctx, owner, repo, manifest.ManifestFilename, "HEAD")
+func (p *GitHubProvider) discoverScribeYAML(ctx context.Context, owner, repo, scope, ref string) (*manifest.Manifest, error) {
+	raw, err := p.client.FetchFile(ctx, owner, repo, scopedPath(scope, manifest.ManifestFilename), ref)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +108,8 @@ func (p *GitHubProvider) discoverScribeYAML(ctx context.Context, owner, repo str
 	return m, nil
 }
 
-func (p *GitHubProvider) discoverScribeTOML(ctx context.Context, owner, repo string) (*manifest.Manifest, error) {
-	raw, err := p.client.FetchFile(ctx, owner, repo, manifest.LegacyManifestFilename, "HEAD")
+func (p *GitHubProvider) discoverScribeTOML(ctx context.Context, owner, repo, scope, ref string) (*manifest.Manifest, error) {
+	raw, err := p.client.FetchFile(ctx, owner, repo, scopedPath(scope, manifest.LegacyManifestFilename), ref)
 	if err != nil {
 		return nil, err
 	}
@@ -107,8 +120,8 @@ func (p *GitHubProvider) discoverScribeTOML(ctx context.Context, owner, repo str
 	return m, nil
 }
 
-func (p *GitHubProvider) discoverMarketplace(ctx context.Context, owner, repo string) ([]manifest.Entry, error) {
-	raw, err := p.client.FetchFile(ctx, owner, repo, marketplacePath, "HEAD")
+func (p *GitHubProvider) discoverMarketplace(ctx context.Context, owner, repo, scope, ref string) ([]manifest.Entry, error) {
+	raw, err := p.client.FetchFile(ctx, owner, repo, scopedPath(scope, marketplacePath), ref)
 	if err != nil {
 		return nil, err
 	}
@@ -119,14 +132,20 @@ func (p *GitHubProvider) discoverMarketplace(ctx context.Context, owner, repo st
 	if len(entries) == 0 {
 		return nil, fmt.Errorf("marketplace.json has no skills")
 	}
+	if scope != "" {
+		for i := range entries {
+			entries[i].Path = scopedPath(scope, entries[i].Path)
+		}
+	}
 	return entries, nil
 }
 
-func (p *GitHubProvider) discoverTreeScan(ctx context.Context, owner, repo string) ([]manifest.Entry, error) {
-	tree, err := p.client.GetTree(ctx, owner, repo, "HEAD")
+func (p *GitHubProvider) discoverTreeScan(ctx context.Context, owner, repo, scope, ref string) ([]manifest.Entry, error) {
+	tree, err := p.client.GetTree(ctx, owner, repo, ref)
 	if err != nil {
 		return nil, err
 	}
+	tree = filterTreeToScope(tree, scope)
 	entries := ScanTreeForSkills(tree, owner, repo)
 	if len(entries) == 0 {
 		return nil, fmt.Errorf("no SKILL.md files found in %s/%s", owner, repo)
@@ -137,7 +156,7 @@ func (p *GitHubProvider) discoverTreeScan(ctx context.Context, owner, repo strin
 		if path.Base(skillPath) != skillFileName {
 			skillPath = path.Join(skillPath, skillFileName)
 		}
-		data, err := p.client.FetchFile(ctx, owner, repo, skillPath, "HEAD")
+		data, err := p.client.FetchFile(ctx, owner, repo, skillPath, ref)
 		if err != nil {
 			p.warn(fmt.Sprintf("%s/%s: could not read %s frontmatter: %v", owner, repo, skillPath, err))
 			continue
@@ -204,21 +223,38 @@ func (p *GitHubProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]Fil
 	if err != nil {
 		return nil, fmt.Errorf("parse source for %s: %w", entry.Name, err)
 	}
+	spec := source.SourceSpec{Type: source.SourceGitHub, Repo: src.Owner + "/" + src.Repo, Ref: src.Ref}
+	return p.FetchSource(ctx, spec, entry)
+}
+
+// FetchSource downloads an entry from a GitHub source, resolving paths relative
+// to the source scope unless the entry already includes that scope.
+func (p *GitHubProvider) FetchSource(ctx context.Context, spec source.SourceSpec, entry manifest.Entry) ([]File, error) {
+	spec, err := canonicalGitHubSource(spec)
+	if err != nil {
+		return nil, err
+	}
+	owner, repoName, err := manifest.ParseOwnerRepo(spec.Repo)
+	if err != nil {
+		return nil, err
+	}
+	ref := sourceRef(spec)
 
 	skillPath := entry.Path
 	if skillPath == "" {
 		skillPath = entry.Name
 	}
+	skillPath = scopedPath(spec.Path, skillPath)
 
 	if path.Base(skillPath) == skillFileName {
-		data, err := p.client.FetchFile(ctx, src.Owner, src.Repo, skillPath, src.Ref)
+		data, err := p.client.FetchFile(ctx, owner, repoName, skillPath, ref)
 		if err != nil {
 			return nil, err
 		}
 		return []File{{Path: skillFileName, Content: data}}, nil
 	}
 
-	ghFiles, err := p.client.FetchDirectory(ctx, src.Owner, src.Repo, skillPath, src.Ref)
+	ghFiles, err := p.client.FetchDirectory(ctx, owner, repoName, skillPath, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -228,4 +264,54 @@ func (p *GitHubProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]Fil
 		files[i] = File{Path: f.Path, Content: f.Content}
 	}
 	return files, nil
+}
+
+func canonicalGitHubSource(spec source.SourceSpec) (source.SourceSpec, error) {
+	spec, err := source.CanonicalSpec(spec)
+	if err != nil {
+		return source.SourceSpec{}, err
+	}
+	if spec.Type != source.SourceGitHub {
+		return source.SourceSpec{}, fmt.Errorf("unsupported source type %q for GitHub provider", spec.Type)
+	}
+	return spec, nil
+}
+
+func sourceRef(spec source.SourceSpec) string {
+	if spec.Ref != "" {
+		return spec.Ref
+	}
+	return "HEAD"
+}
+
+func scopedPath(scope, rel string) string {
+	scope = strings.Trim(path.Clean(strings.TrimSpace(scope)), "/")
+	rel = strings.Trim(path.Clean(strings.TrimSpace(rel)), "/")
+	if scope == "." {
+		scope = ""
+	}
+	if rel == "." {
+		rel = ""
+	}
+	if scope == "" {
+		return rel
+	}
+	if rel == "" || rel == scope || strings.HasPrefix(rel, scope+"/") {
+		return rel
+	}
+	return path.Join(scope, rel)
+}
+
+func filterTreeToScope(tree []TreeEntry, scope string) []TreeEntry {
+	scope = strings.Trim(path.Clean(strings.TrimSpace(scope)), "/")
+	if scope == "" || scope == "." {
+		return tree
+	}
+	filtered := make([]TreeEntry, 0, len(tree))
+	for _, entry := range tree {
+		if entry.Path == scope || strings.HasPrefix(entry.Path, scope+"/") {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
 }

--- a/internal/provider/github_test.go
+++ b/internal/provider/github_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/tools"
 )
 
@@ -266,6 +267,94 @@ func TestDiscoverTreeScanAsLastResort(t *testing.T) {
 	}
 	if !names["deploy"] || !names["lint"] {
 		t.Errorf("expected deploy and lint, got %v", names)
+	}
+}
+
+func TestDiscoverSourceTreeScopeFiltersAndUsesScopedFetch(t *testing.T) {
+	client := &stubClient{
+		treeFiles: []provider.TreeEntry{
+			{Path: "skills/nextjs/SKILL.md", Type: "blob"},
+			{Path: "skills/react/SKILL.md", Type: "blob"},
+			{Path: "templates/ignored/SKILL.md", Type: "blob"},
+		},
+		files: map[string][]byte{
+			"vercel-labs/agent-skills/skills/nextjs/SKILL.md": []byte("---\ndescription: Next.js work\n---\n# Next\n"),
+			"vercel-labs/agent-skills/skills/react/SKILL.md":  []byte("# React\n"),
+		},
+	}
+	p := provider.NewGitHubProvider(client)
+
+	result, err := p.DiscoverSource(context.Background(), source.SourceSpec{
+		Type: source.SourceGitHub,
+		Repo: "vercel-labs/agent-skills",
+		Ref:  "main",
+		Path: "skills",
+	})
+	if err != nil {
+		t.Fatalf("DiscoverSource: %v", err)
+	}
+	if result.IsTeam {
+		t.Fatal("scoped tree scan should not be team registry")
+	}
+	if len(result.Entries) != 2 {
+		t.Fatalf("entries: got %d, want 2", len(result.Entries))
+	}
+	names := map[string]bool{}
+	for _, entry := range result.Entries {
+		names[entry.Name] = true
+		if entry.Source != "github:vercel-labs/agent-skills@HEAD" {
+			t.Fatalf("Source = %q", entry.Source)
+		}
+		if entry.Path == "templates/ignored" {
+			t.Fatal("unscoped tree entry leaked into results")
+		}
+	}
+	if !names["nextjs"] || !names["react"] {
+		t.Fatalf("names = %v", names)
+	}
+}
+
+func TestFetchSourceDoesNotDoublePrefixScopedPath(t *testing.T) {
+	client := &stubClient{
+		dirs: map[string][]tools.SkillFile{
+			"vercel-labs/agent-skills/skills/nextjs": {
+				{Path: "SKILL.md", Content: []byte("# Next")},
+			},
+		},
+	}
+	p := provider.NewGitHubProvider(client)
+
+	files, err := p.FetchSource(context.Background(),
+		source.SourceSpec{Type: source.SourceGitHub, Repo: "vercel-labs/agent-skills", Ref: "main", Path: "skills"},
+		manifest.Entry{Name: "nextjs", Source: "github:vercel-labs/agent-skills@HEAD", Path: "skills/nextjs"},
+	)
+	if err != nil {
+		t.Fatalf("FetchSource: %v", err)
+	}
+	if len(files) != 1 || files[0].Path != "SKILL.md" {
+		t.Fatalf("files = %#v", files)
+	}
+}
+
+func TestFetchSourceResolvesPathRelativeToScope(t *testing.T) {
+	client := &stubClient{
+		dirs: map[string][]tools.SkillFile{
+			"vercel-labs/agent-skills/skills/nextjs": {
+				{Path: "SKILL.md", Content: []byte("# Next")},
+			},
+		},
+	}
+	p := provider.NewGitHubProvider(client)
+
+	files, err := p.FetchSource(context.Background(),
+		source.SourceSpec{Type: source.SourceGitHub, Repo: "vercel-labs/agent-skills", Ref: "main", Path: "skills"},
+		manifest.Entry{Name: "nextjs", Source: "github:vercel-labs/agent-skills@HEAD", Path: "nextjs"},
+	)
+	if err != nil {
+		t.Fatalf("FetchSource: %v", err)
+	}
+	if len(files) != 1 || files[0].Path != "SKILL.md" {
+		t.Fatalf("files = %#v", files)
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/tools"
 )
 
@@ -29,4 +30,11 @@ type Provider interface {
 	// Fetch downloads all files for a single catalog entry.
 	// Returns skill files ready to be written to the canonical store.
 	Fetch(ctx context.Context, entry manifest.Entry) ([]File, error)
+}
+
+// SourceProvider is the transitional SourceSpec-aware provider API.
+// Provider remains stable so existing tests and callers can keep using repo strings.
+type SourceProvider interface {
+	DiscoverSource(ctx context.Context, spec source.SourceSpec) (*DiscoverResult, error)
+	FetchSource(ctx context.Context, spec source.SourceSpec, entry manifest.Entry) ([]File, error)
 }

--- a/internal/sync/blobsha.go
+++ b/internal/sync/blobsha.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/source"
 )
 
 // missingSkillBlobSHA marks a successful tree lookup where the referenced
@@ -33,6 +34,15 @@ func resolveSkillBlobSHAs(tree []provider.TreeEntry, entry manifest.Entry) map[s
 		blobs[e.Path] = e.SHA
 	}
 	return blobs
+}
+
+func sourceScopedSkillEntry(spec source.SourceSpec, entry manifest.Entry) manifest.Entry {
+	if spec.Type != source.SourceGitHub || spec.Path == "" {
+		return entry
+	}
+	scoped := entry
+	scoped.Path = provider.ScopedPath(spec.Path, skillTreeBase(entry))
+	return scoped
 }
 
 func skillBlobTarget(entry manifest.Entry) string {

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/tools"
 )
@@ -41,7 +42,15 @@ func (p *diffTestProvider) Discover(ctx context.Context, repo string) (*provider
 	}, nil
 }
 
+func (p *diffTestProvider) DiscoverSource(ctx context.Context, spec source.SourceSpec) (*provider.DiscoverResult, error) {
+	return p.Discover(ctx, spec.Repo)
+}
+
 func (p *diffTestProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]tools.SkillFile, error) {
+	return nil, nil
+}
+
+func (p *diffTestProvider) FetchSource(ctx context.Context, spec source.SourceSpec, entry manifest.Entry) ([]provider.File, error) {
 	return nil, nil
 }
 
@@ -86,6 +95,56 @@ func TestDiffMarksBranchSkillOutdatedWhenSkillFileMissingFromTree(t *testing.T) 
 	}
 	if statuses[0].LatestSHA != missingSkillBlobSHA {
 		t.Fatalf("latest SHA = %q, want %q", statuses[0].LatestSHA, missingSkillBlobSHA)
+	}
+}
+
+func TestDiffSourceResolvesScopedManifestEntryBlobSHA(t *testing.T) {
+	syncer := &Syncer{
+		Client: &diffTestFetcher{
+			tree: []provider.TreeEntry{
+				{Path: "skills/nextjs/SKILL.md", Type: "blob", SHA: "nextjs-blob"},
+			},
+		},
+		Provider: &diffTestProvider{
+			entry: manifest.Entry{
+				Name:   "nextjs",
+				Path:   "nextjs",
+				Source: "github:vercel-labs/agent-skills@HEAD",
+			},
+		},
+	}
+	st := &state.State{
+		Installed: map[string]state.InstalledSkill{
+			"nextjs": {
+				Sources: []state.SkillSource{{
+					Registry: "github:vercel-labs/agent-skills:skills",
+					Ref:      "main",
+					LastSHA:  "nextjs-blob",
+				}},
+			},
+		},
+	}
+
+	statuses, _, err := syncer.DiffSource(
+		context.Background(),
+		"github:vercel-labs/agent-skills:skills",
+		source.SourceSpec{Type: source.SourceGitHub, Repo: "vercel-labs/agent-skills", Ref: "main", Path: "skills"},
+		st,
+	)
+	if err != nil {
+		t.Fatalf("DiffSource: %v", err)
+	}
+	if len(statuses) != 1 {
+		t.Fatalf("statuses = %d, want 1", len(statuses))
+	}
+	if statuses[0].LatestSHA != "nextjs-blob" {
+		t.Fatalf("LatestSHA = %q, want nextjs-blob", statuses[0].LatestSHA)
+	}
+	if statuses[0].LatestSHA == missingSkillBlobSHA {
+		t.Fatalf("LatestSHA used missing sentinel")
+	}
+	if statuses[0].Status != StatusCurrent {
+		t.Fatalf("Status = %s, want %s", statuses[0].Status, StatusCurrent)
 	}
 }
 

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/projectstore"
 	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/tools"
 )
@@ -141,8 +142,24 @@ const (
 // FetchManifest tries Provider.Discover first (if set), then falls back to
 // direct file fetch with scribe.yaml → scribe.toml fallback.
 func (s *Syncer) FetchManifest(ctx context.Context, owner, repo string) (*manifest.Manifest, error) {
+	return s.FetchManifestSource(ctx, source.SourceSpec{Type: source.SourceGitHub, Repo: owner + "/" + repo})
+}
+
+// FetchManifestSource fetches a manifest through SourceSpec-aware providers.
+// It falls back to legacy GitHub file fetch only for unscoped GitHub sources.
+func (s *Syncer) FetchManifestSource(ctx context.Context, spec source.SourceSpec) (*manifest.Manifest, error) {
+	spec, err := source.CanonicalSpec(spec)
+	if err != nil {
+		return nil, err
+	}
 	if s.Provider != nil {
-		result, err := s.Provider.Discover(ctx, owner+"/"+repo)
+		var result *provider.DiscoverResult
+		var err error
+		if sp, ok := s.Provider.(provider.SourceProvider); ok {
+			result, err = sp.DiscoverSource(ctx, spec)
+		} else {
+			result, err = s.Provider.Discover(ctx, spec.Repo)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -152,9 +169,17 @@ func (s *Syncer) FetchManifest(ctx context.Context, owner, repo string) (*manife
 			Catalog:    result.Entries,
 		}
 		if result.IsTeam {
-			m.Team = &manifest.Team{Name: owner + "/" + repo}
+			m.Team = &manifest.Team{Name: spec.Repo}
 		}
 		return m, nil
+	}
+
+	if spec.Type != source.SourceGitHub || spec.Path != "" || spec.Ref != "" {
+		return nil, fmt.Errorf("source %q requires a SourceSpec-aware provider", spec.Repo)
+	}
+	owner, repo, err := manifest.ParseOwnerRepo(spec.Repo)
+	if err != nil {
+		return nil, err
 	}
 
 	// Legacy path: direct file fetch.
@@ -172,17 +197,26 @@ func (s *Syncer) FetchManifest(ctx context.Context, owner, repo string) (*manife
 // without making any changes. Used by `scribe list`.
 // Returns the parsed manifest alongside statuses so callers can reuse it.
 func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]SkillStatus, *manifest.Manifest, error) {
-	owner, repo, err := manifest.ParseOwnerRepo(teamRepo)
+	spec, err := source.ParseSourceArg(teamRepo)
 	if err != nil {
 		return nil, nil, err
 	}
+	return s.DiffSource(ctx, teamRepo, spec, st)
+}
 
-	m, err := s.FetchManifest(ctx, owner, repo)
+// DiffSource fetches a SourceSpec-backed registry and computes status for each skill.
+// registryKey is the legacy/display identity used in state and JSON during phase 2.
+func (s *Syncer) DiffSource(ctx context.Context, registryKey string, spec source.SourceSpec, st *state.State) ([]SkillStatus, *manifest.Manifest, error) {
+	spec, err := source.CanonicalSpec(spec)
+	if err != nil {
+		return nil, nil, err
+	}
+	m, err := s.FetchManifestSource(ctx, spec)
 	if err != nil {
 		return nil, nil, fmt.Errorf("parse loadout: %w", err)
 	}
 	if len(m.Catalog) == 0 {
-		return nil, nil, fmt.Errorf("%s has no skills", teamRepo)
+		return nil, nil, fmt.Errorf("%s has no skills", registryKey)
 	}
 
 	var statuses []SkillStatus
@@ -216,6 +250,8 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 		// compareEntry handles that gracefully.
 		var blobSHAs map[string]string
 		if err == nil {
+			src = sourceScopedManifestSource(spec, src)
+			entry.Source = src.String()
 			switch {
 			case entry.IsPackage():
 				key := src.Owner + "/" + src.Repo + "/" + src.Ref
@@ -253,7 +289,7 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 			}
 		}
 
-		status := compareEntry(entry, installedPtr, latestSHA, teamRepo, locallyModified)
+		status := compareEntry(entry, installedPtr, latestSHA, registryKey, locallyModified)
 		statuses = append(statuses, SkillStatus{
 			Name:       entry.Name,
 			Status:     status,
@@ -280,7 +316,7 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 		}
 		// Check if any source matches this registry.
 		for _, src := range skill.Sources {
-			if src.Registry == teamRepo {
+			if src.Registry == registryKey {
 				extraNames = append(extraNames, name)
 				break
 			}
@@ -303,6 +339,15 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 // Emits events throughout. Updates state incrementally — a failed skill
 // does not prevent successful skills from being recorded.
 func (s *Syncer) Run(ctx context.Context, teamRepo string, st *state.State) error {
+	spec, err := source.ParseSourceArg(teamRepo)
+	if err != nil {
+		return err
+	}
+	return s.RunSource(ctx, teamRepo, spec, st)
+}
+
+// RunSource executes a sync against a SourceSpec-backed registry.
+func (s *Syncer) RunSource(ctx context.Context, teamRepo string, spec source.SourceSpec, st *state.State) error {
 	if err := s.ensureProjectRoot(); err != nil {
 		return err
 	}
@@ -313,7 +358,7 @@ func (s *Syncer) Run(ctx context.Context, teamRepo string, st *state.State) erro
 		s.emit(SkillErrorMsg{Name: "<migration>", Err: fmt.Errorf("reclassify legacy packages: %w", err)})
 	}
 
-	statuses, m, err := s.Diff(ctx, teamRepo, st)
+	statuses, m, err := s.DiffSource(ctx, teamRepo, spec, st)
 	if err != nil {
 		return fmt.Errorf("sync %s: %w", teamRepo, err)
 	}
@@ -353,7 +398,7 @@ func (s *Syncer) Run(ctx context.Context, teamRepo string, st *state.State) erro
 		}
 		applyLockPins(statuses, lf)
 	}
-	if err := s.apply(ctx, teamRepo, statuses, st); err != nil {
+	if err := s.applySource(ctx, teamRepo, &spec, statuses, st); err != nil {
 		return err
 	}
 	if s.OnRegistryFetched != nil {
@@ -683,6 +728,10 @@ func applyLockPins(statuses []SkillStatus, lf *lockfile.Lockfile) {
 }
 
 func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillStatus, st *state.State) error {
+	return s.applySource(ctx, teamRepo, nil, statuses, st)
+}
+
+func (s *Syncer) applySource(ctx context.Context, teamRepo string, spec *source.SourceSpec, statuses []SkillStatus, st *state.State) error {
 	// Emit resolved status for each skill (populates list view before downloads start).
 	for _, sk := range statuses {
 		s.emit(SkillResolvedMsg{sk})
@@ -734,7 +783,17 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 
 			if s.Provider != nil {
 				// Use Provider.Fetch — returns []tools.SkillFile directly.
-				files, err := s.Provider.Fetch(ctx, *sk.Entry)
+				var files []tools.SkillFile
+				var err error
+				if spec != nil {
+					if sp, ok := s.Provider.(provider.SourceProvider); ok {
+						files, err = sp.FetchSource(ctx, *spec, *sk.Entry)
+					} else {
+						err = fmt.Errorf("source %q requires a SourceSpec-aware provider", teamRepo)
+					}
+				} else {
+					files, err = s.Provider.Fetch(ctx, *sk.Entry)
+				}
 				if err != nil {
 					s.emit(SkillErrorMsg{Name: sk.Name, Err: err})
 					summary.Failed++
@@ -1230,6 +1289,14 @@ func (s *Syncer) RunWithDiff(ctx context.Context, teamRepo string, statuses []Sk
 	return s.apply(ctx, teamRepo, statuses, st)
 }
 
+// RunWithDiffSource applies a pre-computed diff using SourceSpec-aware fetch.
+func (s *Syncer) RunWithDiffSource(ctx context.Context, teamRepo string, spec source.SourceSpec, statuses []SkillStatus, st *state.State) error {
+	if err := s.ensureProjectRoot(); err != nil {
+		return err
+	}
+	return s.applySource(ctx, teamRepo, &spec, statuses, st)
+}
+
 func (s *Syncer) ensureProjectRoot() error {
 	if s.ProjectRoot != "" {
 		return nil
@@ -1695,6 +1762,20 @@ func loadoutRef(entry manifest.Entry) string {
 		return "?"
 	}
 	return src.Ref
+}
+
+func sourceScopedManifestSource(spec source.SourceSpec, src manifest.Source) manifest.Source {
+	if spec.Type != source.SourceGitHub || spec.Ref == "" || src.Ref != "HEAD" {
+		return src
+	}
+	owner, repo, err := manifest.ParseOwnerRepo(spec.Repo)
+	if err != nil {
+		return src
+	}
+	if src.Owner == owner && src.Repo == repo {
+		src.Ref = spec.Ref
+	}
+	return src
 }
 
 // lookupInstalled returns a pointer to the installed skill, or nil if not found.

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -339,15 +339,15 @@ func (s *Syncer) DiffSource(ctx context.Context, registryKey string, spec source
 // Emits events throughout. Updates state incrementally — a failed skill
 // does not prevent successful skills from being recorded.
 func (s *Syncer) Run(ctx context.Context, teamRepo string, st *state.State) error {
-	spec, err := source.ParseSourceArg(teamRepo)
-	if err != nil {
-		return err
-	}
-	return s.RunSource(ctx, teamRepo, spec, st)
+	return s.run(ctx, teamRepo, nil, st)
 }
 
 // RunSource executes a sync against a SourceSpec-backed registry.
 func (s *Syncer) RunSource(ctx context.Context, teamRepo string, spec source.SourceSpec, st *state.State) error {
+	return s.run(ctx, teamRepo, &spec, st)
+}
+
+func (s *Syncer) run(ctx context.Context, teamRepo string, spec *source.SourceSpec, st *state.State) error {
 	if err := s.ensureProjectRoot(); err != nil {
 		return err
 	}
@@ -358,7 +358,14 @@ func (s *Syncer) RunSource(ctx context.Context, teamRepo string, spec source.Sou
 		s.emit(SkillErrorMsg{Name: "<migration>", Err: fmt.Errorf("reclassify legacy packages: %w", err)})
 	}
 
-	statuses, m, err := s.DiffSource(ctx, teamRepo, spec, st)
+	var statuses []SkillStatus
+	var m *manifest.Manifest
+	var err error
+	if spec != nil {
+		statuses, m, err = s.DiffSource(ctx, teamRepo, *spec, st)
+	} else {
+		statuses, m, err = s.Diff(ctx, teamRepo, st)
+	}
 	if err != nil {
 		return fmt.Errorf("sync %s: %w", teamRepo, err)
 	}
@@ -398,7 +405,7 @@ func (s *Syncer) RunSource(ctx context.Context, teamRepo string, spec source.Sou
 		}
 		applyLockPins(statuses, lf)
 	}
-	if err := s.applySource(ctx, teamRepo, &spec, statuses, st); err != nil {
+	if err := s.applySource(ctx, teamRepo, spec, statuses, st); err != nil {
 		return err
 	}
 	if s.OnRegistryFetched != nil {

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -278,8 +278,9 @@ func (s *Syncer) DiffSource(ctx context.Context, registryKey string, spec source
 						}
 					}
 					if len(tree) > 0 {
-						blobSHAs = resolveSkillBlobSHAs(tree, entry)
-						if resolvedSHA, found := blobSHAs[skillBlobTarget(entry)]; found {
+						blobEntry := sourceScopedSkillEntry(spec, entry)
+						blobSHAs = resolveSkillBlobSHAs(tree, blobEntry)
+						if resolvedSHA, found := blobSHAs[skillBlobTarget(blobEntry)]; found {
 							latestSHA = resolvedSHA
 						} else {
 							latestSHA = missingSkillBlobSHA

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/projectstore"
 	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
@@ -58,6 +59,7 @@ type mockProvider struct {
 	entries        []manifest.Entry
 	files          []tools.SkillFile
 	fetchedSources []string
+	fetchedSpecs   []source.SourceSpec
 }
 
 func (m *mockProvider) Discover(_ context.Context, repo string) (*provider.DiscoverResult, error) {
@@ -71,6 +73,15 @@ func (m *mockProvider) Fetch(_ context.Context, entry manifest.Entry) ([]provide
 		out[i] = provider.File{Path: f.Path, Content: f.Content}
 	}
 	return out, nil
+}
+
+func (m *mockProvider) DiscoverSource(_ context.Context, spec source.SourceSpec) (*provider.DiscoverResult, error) {
+	return &provider.DiscoverResult{Entries: m.entries, IsTeam: true}, nil
+}
+
+func (m *mockProvider) FetchSource(_ context.Context, spec source.SourceSpec, entry manifest.Entry) ([]provider.File, error) {
+	m.fetchedSpecs = append(m.fetchedSpecs, spec)
+	return m.Fetch(context.Background(), entry)
 }
 
 func TestRunPinnedSkillSourceOverridesManifestSource(t *testing.T) {
@@ -104,6 +115,43 @@ func TestRunPinnedSkillSourceOverridesManifestSource(t *testing.T) {
 	source := installed.Sources[0]
 	if source.Registry != "other/skills" || source.SourceRepo != "other/skills" || source.Ref != commit || source.LastSHA != commit {
 		t.Fatalf("source = %#v", source)
+	}
+}
+
+func TestRunWithDiffSourceUsesSourceProviderFetch(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	entry := manifest.Entry{Name: "nextjs", Source: "github:vercel-labs/agent-skills@main", Path: "nextjs"}
+	provider := &mockProvider{
+		files: []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# nextjs\n")}},
+	}
+	syncer := &sync.Syncer{
+		Client:   &sync.NoopFetcher{},
+		Provider: provider,
+		Tools:    []tools.Tool{testProjectionTool{root: filepath.Join(home, ".test-tool")}},
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{}}
+	statuses := []sync.SkillStatus{{
+		Name:      "nextjs",
+		Status:    sync.StatusMissing,
+		Entry:     &entry,
+		LatestSHA: "sha-next",
+	}}
+	spec := source.SourceSpec{Type: source.SourceGitHub, Repo: "vercel-labs/agent-skills", Ref: "main", Path: "skills"}
+
+	if err := syncer.RunWithDiffSource(context.Background(), "github:vercel-labs/agent-skills:skills", spec, statuses, st); err != nil {
+		t.Fatalf("RunWithDiffSource: %v", err)
+	}
+	if len(provider.fetchedSpecs) != 1 {
+		t.Fatalf("fetched specs = %#v", provider.fetchedSpecs)
+	}
+	if provider.fetchedSpecs[0].Path != "skills" {
+		t.Fatalf("fetched spec path = %q, want skills", provider.fetchedSpecs[0].Path)
+	}
+	installed := st.Installed["nextjs"]
+	if len(installed.Sources) != 1 || installed.Sources[0].Registry != "github:vercel-labs/agent-skills:skills" {
+		t.Fatalf("installed sources = %#v", installed.Sources)
 	}
 }
 


### PR DESCRIPTION
Adds phase 2 GitHub SourceSpec support for browse/install internals. GitHub repo URLs and tree-scoped sources now flow through provider discovery/fetch, sync diff/apply, and browse JSON output while legacy owner/repo registry behavior stays on the old shape.

What changed:
- add transitional SourceProvider methods for GitHub DiscoverSource/FetchSource
- scope GitHub manifest, marketplace, and tree-scan discovery to SourceSpec.Path
- centralize scoped entry path resolution so fetch avoids double-prefixing
- add sync DiffSource/RunWithDiffSource paths without expanding lock/state writes
- browse JSON includes legacy registry plus source_key/source for SourceSpec-backed rows

Tests:
- go test ./internal/provider ./internal/sync ./cmd
- go test ./...