### PR TITLE
Enforce Codex skill budget guardrail

### DIFF
--- a/cmd/budget_helpers_test.go
+++ b/cmd/budget_helpers_test.go
@@ -82,7 +82,7 @@ func TestBudgetSkillsForAgentUsesProjectProjectionOverGlobalPin(t *testing.T) {
 	}
 }
 
-func TestProjectLocalBudgetUsesShortCodexDescriptions(t *testing.T) {
+func TestProjectLocalBudgetUsesRawCodexDescriptions(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	wd := t.TempDir()
@@ -128,8 +128,8 @@ func TestProjectLocalBudgetUsesShortCodexDescriptions(t *testing.T) {
 		t.Fatalf("raw Status = %s, want %s", raw.Status, budget.StatusRefuse)
 	}
 	projected := budget.CheckProjectionBudget(budgetSkillsForAgent(set, st, "codex"), "codex")
-	if projected.Status == budget.StatusRefuse {
-		t.Fatalf("projected Status = %s, want non-refuse; used %d", projected.Status, projected.Used)
+	if projected.Status != budget.StatusRefuse {
+		t.Fatalf("projected Status = %s, want %s; used %d", projected.Status, budget.StatusRefuse, projected.Used)
 	}
 }
 

--- a/cmd/kit.go
+++ b/cmd/kit.go
@@ -46,6 +46,7 @@ type kitListOptions struct {
 
 type kitInstallOptions struct {
 	alias         string
+	forceBudget   bool
 	noDeps        bool
 	noInteraction bool
 	json          bool
@@ -236,6 +237,7 @@ func newKitInstallCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&opts.alias, "alias", "", "Install incoming kit under this local name")
+	cmd.Flags().BoolVar(&opts.forceBudget, "force", false, "Project skills even when an agent budget is exceeded")
 	cmd.Flags().BoolVar(&opts.noDeps, "no-deps", false, "Install kit body without installing referenced skills")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output machine-readable JSON")
 	addNoInteractionFlag(cmd, "Disable interactive prompts", false)
@@ -254,6 +256,7 @@ func newKitSyncCommand() *cobra.Command {
 			return runKitSync(cmd, opts)
 		},
 	}
+	cmd.Flags().BoolVar(&opts.forceBudget, "force", false, "Project skills even when an agent budget is exceeded")
 	cmd.Flags().BoolVar(&opts.noDeps, "no-deps", false, "Refresh kit bodies without installing referenced skills")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output machine-readable JSON")
 	addNoInteractionFlag(cmd, "Disable interactive prompts", false)
@@ -501,7 +504,7 @@ func runKitInstall(cmd *cobra.Command, ref string, opts *kitInstallOptions) erro
 	}
 	installedSkills := flattenKitDeps(depsByRegistry)
 	if !opts.noDeps {
-		if err := runKitInstallDepsFn(cmd, factory, depsByRegistry); err != nil {
+		if err := runKitInstallDepsFn(cmd, factory, depsByRegistry, opts.forceBudget); err != nil {
 			return err
 		}
 	}
@@ -616,7 +619,7 @@ func installableKitRefs(k *kit.Kit, registryRepo string, cfg *config.Config) (ma
 	return deps, missing, missingRegistries, nil
 }
 
-func runKitInstallDeps(cmd *cobra.Command, factory *app.Factory, depsByRegistry map[string][]kitInstallDep) error {
+func runKitInstallDeps(cmd *cobra.Command, factory *app.Factory, depsByRegistry map[string][]kitInstallDep, forceBudget bool) error {
 	registries := make([]string, 0, len(depsByRegistry))
 	for registryRepo := range depsByRegistry {
 		registries = append(registries, registryRepo)
@@ -642,6 +645,7 @@ func runKitInstallDeps(cmd *cobra.Command, factory *app.Factory, depsByRegistry 
 		bag := &workflow.Bag{
 			Args:               skillNames,
 			RepoFlag:           registryRepo,
+			ForceBudget:        forceBudget,
 			Factory:            factory,
 			FilterRegistries:   filterRegistries,
 			SkillAliases:       aliases,
@@ -754,7 +758,7 @@ func runKitSync(cmd *cobra.Command, opts *kitInstallOptions) error {
 		}
 		installedSkills := flattenKitDeps(depsByRegistry)
 		if !opts.noDeps {
-			if err := runKitInstallDepsFn(cmd, factory, depsByRegistry); err != nil {
+			if err := runKitInstallDepsFn(cmd, factory, depsByRegistry, opts.forceBudget); err != nil {
 				return err
 			}
 		}

--- a/cmd/kit_install_test.go
+++ b/cmd/kit_install_test.go
@@ -71,13 +71,15 @@ func TestKitInstallWritesKitStateAndInstallsSameRegistryDeps(t *testing.T) {
 		return "abc123", nil
 	}
 	var gotDeps map[string][]kitInstallDep
-	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep) error {
+	var gotForceBudget bool
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, forceBudget bool) error {
 		gotDeps = depsByRegistry
+		gotForceBudget = forceBudget
 		return nil
 	}
 
 	cmd := newKitInstallCommand()
-	cmd.SetArgs([]string{"acme/skills:baseline", "--json"})
+	cmd.SetArgs([]string{"acme/skills:baseline", "--json", "--force"})
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&bytes.Buffer{})
@@ -90,6 +92,9 @@ func TestKitInstallWritesKitStateAndInstallsSameRegistryDeps(t *testing.T) {
 	}
 	if !reflect.DeepEqual(gotDeps, wantDeps) {
 		t.Fatalf("deps = %#v, want %#v", gotDeps, wantDeps)
+	}
+	if !gotForceBudget {
+		t.Fatal("expected kit install --force to pass through to dependency budget checks")
 	}
 	if _, err := os.Stat(filepath.Join(home, ".scribe", "kits", "baseline.yaml")); err != nil {
 		t.Fatalf("installed kit missing: %v", err)
@@ -284,7 +289,7 @@ func TestKitInstallConnectPromptInstallsCrossRegistryRefs(t *testing.T) {
 		return nil
 	}
 	var gotDeps map[string][]kitInstallDep
-	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep) error {
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, _ bool) error {
 		gotDeps = depsByRegistry
 		return nil
 	}
@@ -343,7 +348,7 @@ func TestKitInstallAliasMappingPassesSkillAlias(t *testing.T) {
 	}
 	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "abc123", nil }
 	var gotDeps map[string][]kitInstallDep
-	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep) error {
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, _ bool) error {
 		gotDeps = depsByRegistry
 		return nil
 	}
@@ -397,7 +402,7 @@ func TestKitInstallPinnedGitHubRefPassesPinnedSource(t *testing.T) {
 	}
 	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "abc123", nil }
 	var gotDeps map[string][]kitInstallDep
-	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep) error {
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, _ bool) error {
 		gotDeps = depsByRegistry
 		return nil
 	}
@@ -449,7 +454,7 @@ func TestKitSyncRefreshesInstalledRegistryKit(t *testing.T) {
 	}
 	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "new", nil }
 	var gotDeps map[string][]kitInstallDep
-	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep) error {
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, _ bool) error {
 		gotDeps = depsByRegistry
 		return nil
 	}
@@ -524,7 +529,7 @@ func TestKitSyncRefusesToOverwriteLocallyEditedKit(t *testing.T) {
 		return &kit.Kit{Name: entry.Name, Skills: []string{"tdd", "upstream"}, Source: &kit.Source{Registry: registryRepo}}, nil
 	}
 	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "new", nil }
-	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, _ map[string][]kitInstallDep) error {
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, _ map[string][]kitInstallDep, _ bool) error {
 		t.Fatal("dependencies should not install after local kit conflict")
 		return nil
 	}

--- a/internal/budget/agents.go
+++ b/internal/budget/agents.go
@@ -2,6 +2,5 @@ package budget
 
 // AgentBudgets is the configurable per-agent description-byte budget table.
 var AgentBudgets = map[string]int{
-	"codex":  5440,
-	"claude": 8000, // TODO: replace with a probed Claude Code hard limit.
+	"codex": 5440,
 }

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -61,22 +61,7 @@ func CheckBudget(skills []Skill, agent string) Result {
 }
 
 func CheckProjectionBudget(skills []Skill, agent string) Result {
-	estimator := EstimateDescriptionBytes
-	if strings.EqualFold(agent, "codex") {
-		estimator = EstimateCodexProjectionDescriptionBytes
-	}
-	return checkBudget(skills, agent, estimator)
-}
-
-func EstimateCodexProjectionDescriptionBytes(skill Skill) int {
-	description, body := splitSkill(skill.Content)
-	description = shortenDescription(strings.TrimSpace(description))
-	firstParagraph := shortenDescription(extractFirstParagraph(body))
-	used := len([]byte(description)) + len([]byte(firstParagraph))
-	if description != "" && firstParagraph != "" {
-		used += len("\n\n")
-	}
-	return used
+	return checkBudget(skills, agent, EstimateDescriptionBytes)
 }
 
 func checkBudget(skills []Skill, agent string, estimate func(Skill) int) Result {
@@ -96,49 +81,31 @@ func checkBudget(skills []Skill, agent string, estimate func(Skill) int) Result 
 		return ordered[i].Name < ordered[j].Name
 	})
 
+	contributions := make([]Overflow, 0, len(ordered))
 	for _, skill := range ordered {
 		size := estimate(skill)
-		before := result.Used
-		result.Used += size
-		if result.Used >= limit {
-			overflow := result.Used - limit
-			if before > limit {
-				overflow = size
-			}
-			result.Overflow = append(result.Overflow, Overflow{
-				Skill: skill.Name,
-				Bytes: overflow,
-			})
+		if size > 0 {
+			contributions = append(contributions, Overflow{Skill: skill.Name, Bytes: size})
 		}
+		result.Used += size
 	}
 
 	switch {
 	case result.Used >= limit:
 		result.Status = StatusRefuse
+		sort.SliceStable(contributions, func(i, j int) bool {
+			if contributions[i].Bytes == contributions[j].Bytes {
+				return contributions[i].Skill < contributions[j].Skill
+			}
+			return contributions[i].Bytes > contributions[j].Bytes
+		})
+		result.Overflow = contributions
 	case float64(result.Used) >= float64(limit)*warnRatio:
 		result.Status = StatusWarn
 	default:
 		result.Status = StatusSilent
 	}
 	return result
-}
-
-func shortenDescription(s string) string {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return ""
-	}
-	if idx := strings.IndexAny(s, ".!"); idx > 0 && idx < 80 {
-		return s[:idx+1]
-	}
-	if len(s) <= 80 {
-		return s
-	}
-	cut := strings.LastIndex(s[:80], " ")
-	if cut > 40 {
-		return s[:cut] + "..."
-	}
-	return s[:80] + "..."
 }
 
 func FormatResult(result Result) string {
@@ -153,9 +120,9 @@ func FormatOverflow(result Result) string {
 	fmt.Fprintf(&b, "%s skill budget exceeded\n", title(result.Agent))
 	fmt.Fprintf(&b, "estimated: %d / %d bytes (%d%%)\n", result.Used, result.Limit, result.Percent())
 	if len(result.Overflow) > 0 {
-		b.WriteString("overflow caused by:\n")
+		b.WriteString("biggest contributors:\n")
 		for _, item := range result.Overflow {
-			fmt.Fprintf(&b, "  %s adds %d bytes over budget\n", item.Skill, item.Bytes)
+			fmt.Fprintf(&b, "  %s: %d bytes\n", item.Skill, item.Bytes)
 		}
 	}
 	return strings.TrimRight(b.String(), "\n")

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -83,7 +83,7 @@ func TestCheckBudgetThresholdBoundaries(t *testing.T) {
 	}
 }
 
-func TestCheckBudgetOverflowBreakdown(t *testing.T) {
+func TestCheckBudgetOverflowBreakdownShowsBiggestContributors(t *testing.T) {
 	skills := []Skill{
 		skillWithDescription("a", 3000),
 		skillWithDescription("b", 2500),
@@ -98,7 +98,8 @@ func TestCheckBudgetOverflowBreakdown(t *testing.T) {
 		t.Fatalf("Used = %d, want 5600", result.Used)
 	}
 	want := []Overflow{
-		{Skill: "b", Bytes: 60},
+		{Skill: "a", Bytes: 3000},
+		{Skill: "b", Bytes: 2500},
 		{Skill: "c", Bytes: 100},
 	}
 	if len(result.Overflow) != len(want) {
@@ -111,35 +112,30 @@ func TestCheckBudgetOverflowBreakdown(t *testing.T) {
 	}
 }
 
-func TestCheckProjectionBudgetShortensCodexDescriptions(t *testing.T) {
+func TestCheckProjectionBudgetUsesRawCodexDescriptions(t *testing.T) {
 	skills := []Skill{
 		skillWithSentenceDescription("a", strings.Repeat("a", 3000)+". "+strings.Repeat("ignored", 100)),
 		skillWithSentenceDescription("b", strings.Repeat("b", 3000)+". "+strings.Repeat("ignored", 100)),
 	}
 
-	raw := CheckBudget(skills, "codex")
-	if raw.Status != StatusRefuse {
-		t.Fatalf("raw Status = %s, want %s", raw.Status, StatusRefuse)
-	}
-
 	projected := CheckProjectionBudget(skills, "codex")
-	if projected.Status == StatusRefuse {
-		t.Fatalf("projected Status = %s, want non-refuse; used %d", projected.Status, projected.Used)
-	}
-	if projected.Used >= raw.Used {
-		t.Fatalf("projected Used = %d, want less than raw %d", projected.Used, raw.Used)
+	if projected.Status != StatusRefuse {
+		t.Fatalf("Status = %s, want %s", projected.Status, StatusRefuse)
 	}
 }
 
-func TestCheckProjectionBudgetKeepsClaudeRawDescriptions(t *testing.T) {
+func TestCheckProjectionBudgetTreatsUnknownClaudeLimitAsUnlimited(t *testing.T) {
 	skills := []Skill{
 		skillWithSentenceDescription("a", strings.Repeat("a", 3000)+". "+strings.Repeat("ignored", 100)),
 		skillWithSentenceDescription("b", strings.Repeat("b", 5200)+". "+strings.Repeat("ignored", 100)),
 	}
 
 	result := CheckProjectionBudget(skills, "claude")
-	if result.Status != StatusRefuse {
-		t.Fatalf("Status = %s, want %s", result.Status, StatusRefuse)
+	if result.Status != StatusSilent {
+		t.Fatalf("Status = %s, want %s", result.Status, StatusSilent)
+	}
+	if result.Limit != 0 {
+		t.Fatalf("Limit = %d, want unknown/unlimited", result.Limit)
 	}
 }
 

--- a/internal/sync/budget_projection_internal_test.go
+++ b/internal/sync/budget_projection_internal_test.go
@@ -92,7 +92,7 @@ func TestBudgetSkillsForProjectionUsesCurrentProjectToolsOverGlobalPin(t *testin
 	}
 }
 
-func TestCheckBudgetBeforeProjectionUsesShortCodexDescriptionsForProjectScope(t *testing.T) {
+func TestCheckBudgetBeforeProjectionRefusesRawCodexDescriptionsForProjectScope(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -142,8 +142,11 @@ func TestCheckBudgetBeforeProjectionUsesShortCodexDescriptionsForProjectScope(t 
 
 	syncer := &Syncer{ProjectRoot: projectRoot}
 	err = syncer.checkBudgetBeforeProjection(st, "incoming", []tools.SkillFile{{Path: "SKILL.md", Content: incoming}}, []tools.Tool{tools.CodexTool{}})
-	if err != nil {
-		t.Fatalf("checkBudgetBeforeProjection: %v", err)
+	if err == nil {
+		t.Fatal("expected budget refusal")
+	}
+	if !strings.Contains(err.Error(), "Codex skill budget exceeded") {
+		t.Fatalf("error = %v, want Codex budget refusal", err)
 	}
 }
 

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -1231,23 +1231,23 @@ func TestRunWithDiff_EmitsBudgetWarningForPostChangeProjection(t *testing.T) {
 		t.Fatalf("store dir: %v", err)
 	}
 	projectRoot := t.TempDir()
-	writeStoredSkill(t, storeDir, "existing", strings.Repeat("x", 5600))
+	writeStoredSkill(t, storeDir, "existing", strings.Repeat("x", 3750))
 
 	var events []any
 	syncer := &sync.Syncer{
 		Client: &syncTestFetcher{
 			files: []tools.SkillFile{{Path: "SKILL.md", Content: skillContent("incoming", strings.Repeat("y", 100))}},
 		},
-		Tools:       []tools.Tool{tools.ClaudeTool{}},
+		Tools:       []tools.Tool{tools.CodexTool{}},
 		ProjectRoot: projectRoot,
 		Emit:        func(msg any) { events = append(events, msg) },
 	}
 	st := &state.State{Installed: map[string]state.InstalledSkill{
 		"existing": {
-			Tools: []string{"claude"},
+			Tools: []string{"codex"},
 			Projections: []state.ProjectionEntry{{
 				Project: projectRoot,
-				Tools:   []string{"claude"},
+				Tools:   []string{"codex"},
 			}},
 		},
 	}}
@@ -1263,11 +1263,11 @@ func TestRunWithDiff_EmitsBudgetWarningForPostChangeProjection(t *testing.T) {
 
 	for _, event := range events {
 		if msg, ok := event.(sync.BudgetWarningMsg); ok {
-			if msg.Agent != "claude" {
-				t.Fatalf("Agent = %q, want claude", msg.Agent)
+			if msg.Agent != "codex" {
+				t.Fatalf("Agent = %q, want codex", msg.Agent)
 			}
-			if !strings.Contains(msg.Message, "Claude budget") {
-				t.Fatalf("Message = %q, want Claude budget warning", msg.Message)
+			if !strings.Contains(msg.Message, "Codex budget") {
+				t.Fatalf("Message = %q, want Codex budget warning", msg.Message)
 			}
 			return
 		}


### PR DESCRIPTION
## Summary
- enforce Codex 5440-byte skill description budget using raw frontmatter description plus first body paragraph
- treat Claude budget as unknown/unlimited until probed
- show biggest byte contributors in overflow output
- add budget --force pass-through for kit install/sync dependency installs

## Tests
- go test ./...

Todo: #371
Issue: #114