### PR TITLE
Add typed source CLI UX

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -124,7 +124,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	}
 	configureInstallNameConflictResolver(syncer, conflictMode, aliasName)
 
-	if sourceFlags.hasTyped() {
+	if sourceFlags.hasTyped() && !sourceFlagsMatchConnectedSource(sourceFlags, cfg) {
 		if len(args) != 1 {
 			return fmt.Errorf("skill name required when using source flags")
 		}
@@ -222,6 +222,13 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return handleNameConflictError(cmd, err)
 	}
 	return nil
+}
+
+func sourceFlagsMatchConnectedSource(v sourceFlagValues, cfg *config.Config) bool {
+	if cfg == nil || v.source == "" || v.repo != "" || v.url != "" || v.ref != "" || v.path != "" || v.id != "" {
+		return false
+	}
+	return cfg.FindRegistryByKeyOrRepo(v.source) != nil
 }
 
 // parseSkillRef parses "owner/repo:skillname" into its parts.

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -28,9 +27,6 @@ import (
 	"github.com/Naoray/scribe/internal/tools"
 	"github.com/Naoray/scribe/internal/workflow"
 )
-
-// skillRefPattern matches "owner/repo:skillname" — direct install reference.
-var skillRefPattern = regexp.MustCompile(`^\w[\w.-]*/[\w.-]+:\S+$`)
 
 // installResult is the per-skill JSON output for `scribe add`.
 type installResult struct {
@@ -76,7 +72,7 @@ Examples:
 	}
 	addNoInteractionFlag(cmd, "Disable interactive prompts", false)
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
-	cmd.Flags().String("registry", "", "Limit search to a specific registry (owner/repo)")
+	addSourceFlags(cmd, true)
 	cmd.Flags().Bool("force", false, "Project skills even when an agent budget is exceeded")
 	cmd.Flags().Bool("resync", false, "Overwrite local edits with the upstream version for modified skills")
 	cmd.Flags().String("alias", "", "Install incoming skill under this name when a local directory conflicts")
@@ -86,7 +82,10 @@ Examples:
 func runAdd(cmd *cobra.Command, args []string) error {
 	skipConfirm := noInteractionFlagPassed(cmd)
 	jsonFlag := jsonFlagPassed(cmd)
-	registryFilter, _ := cmd.Flags().GetString("registry")
+	sourceFlags, err := readSourceFlags(cmd)
+	if err != nil {
+		return err
+	}
 	forceBudget, _ := cmd.Flags().GetBool("force")
 	resync, _ := cmd.Flags().GetBool("resync")
 	aliasName, _ := cmd.Flags().GetString("alias")
@@ -119,33 +118,40 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("resolve tools: %w", err)
 	}
 
-	// Direct install: owner/repo:skillname.
-	if len(args) == 1 && skillRefPattern.MatchString(args[0]) {
-		registryRepo, skillName, err := parseSkillRef(args[0])
+	syncer := newInstallSyncerWithOptions(client, targets, forceBudget, aliasName)
+	if resync {
+		syncer.ModifiedStrategy = sync.ModifiedStrategyPreferTheirs
+	}
+	configureInstallNameConflictResolver(syncer, conflictMode, aliasName)
+
+	if sourceFlags.hasTyped() {
+		if len(args) != 1 {
+			return fmt.Errorf("skill name required when using source flags")
+		}
+		spec, ident, display, err := sourceSpecFromFlags(sourceFlags)
 		if err != nil {
 			return err
 		}
-		if !client.IsAuthenticated() {
-			return clierrors.Wrap(
-				fmt.Errorf("authentication required"),
-				"GH_AUTH_FAILED",
-				clierrors.ExitPerm,
-				clierrors.WithRemediation("run `gh auth login` or set GITHUB_TOKEN"),
-			)
+		if err := runAddDirectInstallSourceForCommand(cmd, ctx, display, ident.Key, spec, args[0], cfg, st, syncer, client.IsAuthenticated(), useJSON, skipConfirm, resync); err != nil {
+			return handleNameConflictError(cmd, err)
 		}
-		syncer := newInstallSyncerWithOptions(client, targets, forceBudget, aliasName)
-		if resync {
-			syncer.ModifiedStrategy = sync.ModifiedStrategyPreferTheirs
+		return nil
+	}
+
+	// Direct install: owner/repo:skillname or [source]:skillname.
+	if len(args) == 1 && looksLikeInstallRef(args[0]) {
+		spec, ident, display, skillName, err := parseInstallRefForCommand(args[0])
+		if err != nil {
+			return err
 		}
-		configureInstallNameConflictResolver(syncer, conflictMode, aliasName)
-		if err := runAddDirectInstallForCommand(cmd, ctx, registryRepo, skillName, cfg, st, syncer, true, useJSON, skipConfirm, resync); err != nil {
+		if err := runAddDirectInstallSourceForCommand(cmd, ctx, display, ident.Key, spec, skillName, cfg, st, syncer, client.IsAuthenticated(), useJSON, skipConfirm, resync); err != nil {
 			return handleNameConflictError(cmd, err)
 		}
 		return nil
 	}
 
 	// Need at least one connected registry to search/browse.
-	if len(cfg.TeamRepos()) == 0 {
+	if len(cfg.EnabledSources()) == 0 {
 		return fmt.Errorf("no registries connected — run: scribe connect <owner/repo>")
 	}
 	if !client.IsAuthenticated() {
@@ -158,13 +164,12 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Determine which registries to browse.
-	repos := cfg.TeamRepos()
-	if registryFilter != "" {
-		repo, err := resolveRegistry(registryFilter, repos)
+	sources := cfg.EnabledSources()
+	if sourceFlags.source != "" {
+		sources, err = browseSources(sourceFlags.source, cfg)
 		if err != nil {
 			return err
 		}
-		repos = []string{repo}
 	}
 
 	// Build query from arg.
@@ -179,7 +184,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Discover all skills across the selected registries.
-	entries, errs := discoverEntries(ctx, repos, client, targets, st)
+	entries, errs := discoverSourceEntries(ctx, sources, client, targets, st)
 	for _, e := range errs {
 		fmt.Fprintf(os.Stderr, "warning: %v\n", e)
 	}
@@ -237,6 +242,15 @@ func parseSkillRef(ref string) (registryRepo, skillName string, err error) {
 		return "", "", clierrors.Wrap(err, "USAGE_INVALID_SKILL_REF", clierrors.ExitUsage)
 	}
 	return registryRepo, skillName, nil
+}
+
+func looksLikeInstallRef(ref string) bool {
+	ref = strings.TrimSpace(ref)
+	if strings.HasPrefix(ref, "[") || strings.Contains(ref, "://") {
+		return true
+	}
+	parsed, err := source.ParseInstallRef(ref)
+	return err == nil && parsed.Source.Type == source.SourceGitHub && parsed.Source.Path == "" && parsed.Source.Ref == ""
 }
 
 // runAddDirectInstall installs a single skill from owner/repo:skillname.

--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -241,7 +241,11 @@ func browseSources(registryFilter string, cfg *config.Config) ([]config.Registry
 			return nil, err
 		}
 		rs := config.RegistrySource{Config: *rc, Source: spec, Identity: ident}
-		rs.ID = registryDisplay(rs)
+		if rc.ID != "" {
+			rs.ID = rc.ID
+		} else {
+			rs.ID = registryDisplay(rs)
+		}
 		return []config.RegistrySource{rs}, nil
 	}
 	spec, ident, err := sourceSpecForRegistry(registryFilter)

--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -38,7 +38,7 @@ func newBrowseCommand() *cobra.Command {
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	cmd.Flags().String("query", "", "Filter remote skills by query")
 	cmd.Flags().String("install", "", "Install a skill by exact name or owner/repo:skill")
-	cmd.Flags().String("registry", "", "Limit browse/install to one connected registry or GitHub owner/repo")
+	addSourceFlags(cmd, true)
 	cmd.Flags().Bool("kits", false, "Browse registry kits instead of skills")
 	cmd.Flags().Bool("resync", false, "Overwrite local edits with the upstream version for modified skills")
 	addNoInteractionFlag(cmd, "Disable interactive prompts", false)
@@ -48,7 +48,10 @@ func newBrowseCommand() *cobra.Command {
 func runBrowse(cmd *cobra.Command, _ []string) error {
 	query, _ := cmd.Flags().GetString("query")
 	installRef, _ := cmd.Flags().GetString("install")
-	registryFilter, _ := cmd.Flags().GetString("registry")
+	sourceFlags, err := readSourceFlags(cmd)
+	if err != nil {
+		return err
+	}
 	resync, _ := cmd.Flags().GetBool("resync")
 	kits, _ := cmd.Flags().GetBool("kits")
 	yes := noInteractionFlagPassed(cmd)
@@ -73,7 +76,8 @@ func runBrowse(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("resolve active tools: %w", err)
 	}
 
-	sources, err := browseSources(registryFilter, cfg)
+	sourceFilter := sourceFlags.source
+	sources, err := browseSources(sourceFilter, cfg)
 	if err != nil {
 		return err
 	}
@@ -342,11 +346,11 @@ func browseInstall(
 	resync bool,
 ) error {
 	if strings.Contains(installRef, ":") {
-		registryRepo, skillName, err := parseSkillRef(installRef)
+		spec, ident, display, skillName, err := parseInstallRefForCommand(installRef)
 		if err != nil {
 			return err
 		}
-		return runAddDirectInstall(ctx, registryRepo, skillName, cfg, st, newInstallSyncer(client, targets), client.IsAuthenticated(), useJSON, skipConfirm, resync)
+		return runAddDirectInstallSourceForCommand(nil, ctx, display, ident.Key, spec, skillName, cfg, st, newInstallSyncer(client, targets), client.IsAuthenticated(), useJSON, skipConfirm, resync)
 	}
 
 	var matches []browseEntry

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -10,6 +10,7 @@ import (
 
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/workflow"
 )
 
@@ -30,22 +31,44 @@ Examples:
 		RunE: runConnect,
 	}
 	cmd.Flags().Bool("install-all", false, "Install every discovered skill from the connected registry")
+	addSourceFlags(cmd, false)
 	return markJSONSupported(cmd)
 }
 
 func runConnect(cmd *cobra.Command, args []string) error {
-	repo, err := resolveRepo(args)
+	sourceFlags, err := readSourceFlags(cmd)
+	if err != nil {
+		return err
+	}
+	repo, err := resolveRepoWithFlags(args, sourceFlags)
 	if err != nil {
 		return err
 	}
 	installAll, _ := cmd.Flags().GetBool("install-all")
 	jsonFlag := jsonFlagPassed(cmd)
+	spec, ident, display, err := sourceSpecFromFlags(sourceFlags)
+	if err != nil {
+		return err
+	}
+	if sourceFlags.hasTyped() && installAll && (spec.Type != source.SourceGitHub || spec.Path != "" || spec.Ref != "") {
+		return fmt.Errorf("--install-all currently supports legacy GitHub owner/repo sources only")
+	}
 
 	bag := &workflow.Bag{
 		RepoArg:        repo,
 		JSONFlag:       jsonFlag,
 		InstallAllFlag: installAll,
 		Factory:        commandFactory(),
+	}
+	if sourceFlags.hasTyped() {
+		bag.SourceArg = spec
+		bag.SourceKey = ident.Key
+		bag.SourceID = spec.ID
+		if spec.Type == source.SourceGitHub {
+			bag.RepoArg = spec.Repo
+		} else {
+			bag.RepoArg = display
+		}
 	}
 	steps := workflow.ConnectSteps()
 	if installAll {
@@ -65,6 +88,29 @@ func runConnect(cmd *cobra.Command, args []string) error {
 
 // resolveRepo returns the owner/repo string from args or an interactive prompt.
 func resolveRepo(args []string) (string, error) {
+	return resolveRepoWithFlags(args, sourceFlagValues{})
+}
+
+func resolveRepoWithFlags(args []string, sourceFlags sourceFlagValues) (string, error) {
+	if sourceFlags.hasTyped() {
+		if len(args) > 0 {
+			return "", fmt.Errorf("repo argument cannot be combined with source flags")
+		}
+		spec, _, _, err := sourceSpecFromFlags(sourceFlags)
+		if err != nil {
+			return "", err
+		}
+		if spec.Type == source.SourceGitHub {
+			return spec.Repo, nil
+		}
+		if spec.Repo != "" {
+			return spec.Repo, nil
+		}
+		if spec.URL != "" {
+			return spec.URL, nil
+		}
+		return spec.Path, nil
+	}
 	if len(args) > 0 {
 		return manifest.NormalizeGitHubRepo(args[0])
 	}

--- a/cmd/connect_test.go
+++ b/cmd/connect_test.go
@@ -69,6 +69,23 @@ func TestResolveRepoWithGitHubURL(t *testing.T) {
 	}
 }
 
+func TestResolveRepoWithTypedSourceFlags(t *testing.T) {
+	repo, err := resolveRepoWithFlags(nil, sourceFlagValues{repo: "acme/skills", ref: "v1.2.3", path: "packs"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo != "acme/skills" {
+		t.Errorf("got %q", repo)
+	}
+}
+
+func TestResolveRepoRejectsArgWithTypedSourceFlags(t *testing.T) {
+	_, err := resolveRepoWithFlags([]string{"acme/skills"}, sourceFlagValues{repo: "other/skills"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestResolveRepoNoArgNonTTY(t *testing.T) {
 	// When stdin is not a TTY (like in tests), resolveRepo with no args should error.
 	_, err := resolveRepo([]string{})

--- a/cmd/source_flags.go
+++ b/cmd/source_flags.go
@@ -74,9 +74,30 @@ func sourceSpecFromFlags(v sourceFlagValues) (source.SourceSpec, source.SourceId
 	switch {
 	case v.source != "":
 		if v.repo != "" || v.url != "" {
-			return source.SourceSpec{}, source.SourceIdentity{}, "", fmt.Errorf("--source cannot be combined with --repo or --url")
+			sourceType := source.SourceType(strings.ToLower(strings.TrimSpace(v.source)))
+			switch sourceType {
+			case source.SourceGitHub, source.SourceGitLab:
+				if v.url != "" {
+					return source.SourceSpec{}, source.SourceIdentity{}, "", fmt.Errorf("--source %s requires --repo, not --url", sourceType)
+				}
+				spec = source.SourceSpec{Type: sourceType, Repo: v.repo}
+			case source.SourceGit:
+				if v.repo != "" {
+					return source.SourceSpec{}, source.SourceIdentity{}, "", fmt.Errorf("--source git requires --url, not --repo")
+				}
+				spec = source.SourceSpec{Type: sourceType, URL: v.url}
+			case source.SourceLocal:
+				return source.SourceSpec{}, source.SourceIdentity{}, "", fmt.Errorf("--source local requires --path, not --repo or --url")
+			default:
+				return source.SourceSpec{}, source.SourceIdentity{}, "", fmt.Errorf("--source cannot be combined with --repo or --url")
+			}
+		} else if strings.EqualFold(strings.TrimSpace(v.source), string(source.SourceLocal)) {
+			spec = source.SourceSpec{Type: source.SourceLocal, Path: v.path}
+		} else if sourceType := source.SourceType(strings.ToLower(strings.TrimSpace(v.source))); sourceType == source.SourceGitHub || sourceType == source.SourceGitLab || sourceType == source.SourceGit {
+			return source.SourceSpec{}, source.SourceIdentity{}, "", fmt.Errorf("--source %s requires --repo or --url", sourceType)
+		} else {
+			spec, err = source.ParseSourceArg(v.source)
 		}
-		spec, err = source.ParseSourceArg(v.source)
 	case v.repo != "":
 		if v.url != "" {
 			return source.SourceSpec{}, source.SourceIdentity{}, "", fmt.Errorf("--repo and --url cannot be used together")

--- a/cmd/source_flags.go
+++ b/cmd/source_flags.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/source"
+)
+
+type sourceFlagValues struct {
+	source         string
+	repo           string
+	url            string
+	ref            string
+	path           string
+	id             string
+	registryAlias  string
+	usedRegistryAs bool
+}
+
+func addSourceFlags(cmd *cobra.Command, includeRegistryAlias bool) {
+	cmd.Flags().String("source", "", "Source shorthand, URL, or local path")
+	cmd.Flags().String("repo", "", "GitHub owner/repo source")
+	cmd.Flags().String("url", "", "Git or file source URL")
+	cmd.Flags().String("ref", "", "Git ref for the source")
+	cmd.Flags().String("path", "", "Subdirectory path within the source")
+	cmd.Flags().String("id", "", "Stable source ID")
+	if includeRegistryAlias {
+		cmd.Flags().String("registry", "", "Legacy alias for --source")
+	}
+}
+
+func readSourceFlags(cmd *cobra.Command) (sourceFlagValues, error) {
+	values := sourceFlagValues{}
+	values.source, _ = cmd.Flags().GetString("source")
+	values.repo, _ = cmd.Flags().GetString("repo")
+	values.url, _ = cmd.Flags().GetString("url")
+	values.ref, _ = cmd.Flags().GetString("ref")
+	values.path, _ = cmd.Flags().GetString("path")
+	values.id, _ = cmd.Flags().GetString("id")
+
+	if f := cmd.Flags().Lookup("registry"); f != nil {
+		registry, _ := cmd.Flags().GetString("registry")
+		if values.source != "" && registry != "" {
+			return values, fmt.Errorf("--source and --registry cannot be used together")
+		}
+		if values.source == "" {
+			values.source = registry
+			values.registryAlias = registry
+			values.usedRegistryAs = true
+		}
+	}
+
+	return values, nil
+}
+
+func (v sourceFlagValues) hasAny() bool {
+	return v.source != "" || v.repo != "" || v.url != "" || v.ref != "" || v.path != "" || v.id != ""
+}
+
+func (v sourceFlagValues) hasTyped() bool {
+	return v.hasAny() && !v.usedRegistryAs
+}
+
+func sourceSpecFromFlags(v sourceFlagValues) (source.SourceSpec, source.SourceIdentity, string, error) {
+	if !v.hasAny() {
+		return source.SourceSpec{}, source.SourceIdentity{}, "", nil
+	}
+
+	var spec source.SourceSpec
+	var err error
+	switch {
+	case v.source != "":
+		if v.repo != "" || v.url != "" {
+			return source.SourceSpec{}, source.SourceIdentity{}, "", fmt.Errorf("--source cannot be combined with --repo or --url")
+		}
+		spec, err = source.ParseSourceArg(v.source)
+	case v.repo != "":
+		if v.url != "" {
+			return source.SourceSpec{}, source.SourceIdentity{}, "", fmt.Errorf("--repo and --url cannot be used together")
+		}
+		spec = source.SourceSpec{Type: source.SourceGitHub, Repo: v.repo}
+	case v.url != "":
+		spec, err = source.ParseSourceArg(v.url)
+	case v.path != "":
+		spec = source.SourceSpec{Type: source.SourceLocal, Path: v.path}
+	default:
+		return source.SourceSpec{}, source.SourceIdentity{}, "", fmt.Errorf("--ref, --path, and --id require --source, --repo, or --url")
+	}
+	if err != nil {
+		return source.SourceSpec{}, source.SourceIdentity{}, "", err
+	}
+
+	if v.ref != "" {
+		spec.Ref = v.ref
+	}
+	if v.path != "" && spec.Type != source.SourceLocal {
+		spec.Path = v.path
+	}
+	if v.id != "" {
+		spec.ID = v.id
+	}
+
+	spec, ident, err := source.Canonicalize(spec)
+	if err != nil {
+		return source.SourceSpec{}, source.SourceIdentity{}, "", err
+	}
+	display := sourceDisplay(spec, ident)
+	return spec, ident, display, nil
+}
+
+func sourceDisplay(spec source.SourceSpec, ident source.SourceIdentity) string {
+	if spec.ID != "" {
+		return spec.ID
+	}
+	if spec.Type == source.SourceGitHub && spec.Path == "" && spec.Ref == "" {
+		return spec.Repo
+	}
+	if ident.Key != "" {
+		return ident.Key
+	}
+	if spec.Repo != "" {
+		return spec.Repo
+	}
+	if spec.URL != "" {
+		return spec.URL
+	}
+	return spec.Path
+}
+
+func parseInstallRefForCommand(ref string) (source.SourceSpec, source.SourceIdentity, string, string, error) {
+	parsed, err := source.ParseInstallRef(ref)
+	if err != nil {
+		return source.SourceSpec{}, source.SourceIdentity{}, "", "", err
+	}
+	spec, ident, err := source.Canonicalize(parsed.Source)
+	if err != nil {
+		return source.SourceSpec{}, source.SourceIdentity{}, "", "", err
+	}
+	if spec.Type == source.SourceGitHub && spec.Path == "" && spec.Ref == "" {
+		ident.Key = spec.Repo
+	}
+	return spec, ident, sourceDisplay(spec, ident), strings.TrimSpace(parsed.Skill), nil
+}

--- a/cmd/source_flags_test.go
+++ b/cmd/source_flags_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/source"
+)
+
+func TestNewCommandsExposeTypedSourceFlags(t *testing.T) {
+	for _, cmd := range []*cobraCommandLike{
+		{name: "add", cmd: newAddCommand(), wantsRegistry: true},
+		{name: "browse", cmd: newBrowseCommand(), wantsRegistry: true},
+		{name: "connect", cmd: newConnectCommand(), wantsRegistry: false},
+	} {
+		t.Run(cmd.name, func(t *testing.T) {
+			for _, flag := range []string{"source", "repo", "url", "ref", "path", "id"} {
+				if cmd.cmd.Flags().Lookup(flag) == nil {
+					t.Fatalf("missing --%s", flag)
+				}
+			}
+			if got := cmd.cmd.Flags().Lookup("registry") != nil; got != cmd.wantsRegistry {
+				t.Fatalf("--registry present = %v, want %v", got, cmd.wantsRegistry)
+			}
+		})
+	}
+}
+
+type cobraCommandLike struct {
+	name          string
+	cmd           *cobra.Command
+	wantsRegistry bool
+}
+
+func TestSourceSpecFromFlagsBuildsTypedGitHubSource(t *testing.T) {
+	spec, ident, display, err := sourceSpecFromFlags(sourceFlagValues{
+		repo: "owner/repo",
+		ref:  "v1.2.3",
+		path: "skills",
+		id:   "team-skills",
+	})
+	if err != nil {
+		t.Fatalf("sourceSpecFromFlags: %v", err)
+	}
+	if spec.Type != source.SourceGitHub || spec.Repo != "owner/repo" || spec.Ref != "v1.2.3" || spec.Path != "skills" || spec.ID != "team-skills" {
+		t.Fatalf("spec = %#v", spec)
+	}
+	if ident.Key != "github:owner/repo:skills" {
+		t.Fatalf("key = %q", ident.Key)
+	}
+	if display != "team-skills" {
+		t.Fatalf("display = %q", display)
+	}
+}
+
+func TestParseInstallRefForCommandKeepsLegacyAndBracketSyntax(t *testing.T) {
+	spec, ident, display, skill, err := parseInstallRefForCommand("owner/repo:deploy")
+	if err != nil {
+		t.Fatalf("legacy parse: %v", err)
+	}
+	if spec.Repo != "owner/repo" || ident.Key != "owner/repo" || display != "owner/repo" || skill != "deploy" {
+		t.Fatalf("legacy parse = spec:%#v ident:%#v display:%q skill:%q", spec, ident, display, skill)
+	}
+
+	spec, ident, display, skill, err = parseInstallRefForCommand("[https://github.com/owner/repo/tree/main/skills]:deploy")
+	if err != nil {
+		t.Fatalf("bracket parse: %v", err)
+	}
+	if spec.Repo != "owner/repo" || spec.Ref != "main" || spec.Path != "skills" || ident.Key != "github:owner/repo:skills" || display != "github:owner/repo:skills" || skill != "deploy" {
+		t.Fatalf("bracket parse = spec:%#v ident:%#v display:%q skill:%q", spec, ident, display, skill)
+	}
+}
+
+func TestParseInstallRefForCommandRejectsAmbiguousURLRef(t *testing.T) {
+	_, _, _, _, err := parseInstallRefForCommand("https://github.com/owner/repo:deploy")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "[source]:skill or --source") {
+		t.Fatalf("error = %q", err.Error())
+	}
+}
+
+func TestBrowseSourcesAcceptsTypedSourceURL(t *testing.T) {
+	sources, err := browseSources("https://github.com/owner/repo/tree/main/skills", &config.Config{})
+	if err != nil {
+		t.Fatalf("browseSources: %v", err)
+	}
+	if len(sources) != 1 || sources[0].Source.Repo != "owner/repo" || sources[0].Source.Ref != "main" || sources[0].Source.Path != "skills" {
+		t.Fatalf("sources = %#v", sources)
+	}
+}

--- a/cmd/source_flags_test.go
+++ b/cmd/source_flags_test.go
@@ -56,6 +56,53 @@ func TestSourceSpecFromFlagsBuildsTypedGitHubSource(t *testing.T) {
 	}
 }
 
+func TestSourceSpecFromFlagsBuildsProviderTypedGitHubSource(t *testing.T) {
+	spec, ident, display, err := sourceSpecFromFlags(sourceFlagValues{
+		source: "github",
+		repo:   "vercel-labs/agent-skills",
+		ref:    "main",
+		path:   "skills",
+		id:     "vercel",
+	})
+	if err != nil {
+		t.Fatalf("sourceSpecFromFlags: %v", err)
+	}
+	if spec.Type != source.SourceGitHub || spec.Repo != "vercel-labs/agent-skills" || spec.Ref != "main" || spec.Path != "skills" || spec.ID != "vercel" {
+		t.Fatalf("spec = %#v", spec)
+	}
+	if ident.Key != "github:vercel-labs/agent-skills:skills" {
+		t.Fatalf("key = %q", ident.Key)
+	}
+	if display != "vercel" {
+		t.Fatalf("display = %q", display)
+	}
+}
+
+func TestAddSourceFlagConnectedIDIsFilterNotRawLocator(t *testing.T) {
+	cfg := &config.Config{Registries: []config.RegistryConfig{{
+		ID:      "vercel",
+		Enabled: true,
+		Source: &source.SourceSpec{
+			Type: source.SourceGitHub,
+			Repo: "vercel-labs/agent-skills",
+			Ref:  "main",
+			Path: "skills",
+		},
+	}}}
+	flags := sourceFlagValues{source: "vercel"}
+
+	if !sourceFlagsMatchConnectedSource(flags, cfg) {
+		t.Fatal("--source vercel should resolve as a connected source filter")
+	}
+	sources, err := browseSources(flags.source, cfg)
+	if err != nil {
+		t.Fatalf("browseSources: %v", err)
+	}
+	if len(sources) != 1 || sources[0].ID != "vercel" || sources[0].Source.Repo != "vercel-labs/agent-skills" || sources[0].Source.Path != "skills" {
+		t.Fatalf("sources = %#v", sources)
+	}
+}
+
 func TestParseInstallRefForCommandKeepsLegacyAndBracketSyntax(t *testing.T) {
 	spec, ident, display, skill, err := parseInstallRefForCommand("owner/repo:deploy")
 	if err != nil {

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/registryindex"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
@@ -75,7 +76,10 @@ type Bag struct {
 	Provider provider.Provider
 
 	// Connect-specific
-	RepoArg string // resolved owner/repo from args or prompt
+	RepoArg   string // resolved owner/repo from args or prompt
+	SourceArg source.SourceSpec
+	SourceKey string
+	SourceID  string
 
 	// FilterRegistries is injected by cmd/ to bridge flag resolution.
 	// If nil, defaults to returning all repos.

--- a/internal/workflow/connect.go
+++ b/internal/workflow/connect.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/registryindex"
+	"github.com/Naoray/scribe/internal/source"
 )
 
 // ConnectSteps returns the step list for the connect command.
@@ -64,8 +66,24 @@ func connectInstallAllTail() []Step {
 }
 
 func StepDedupCheck(_ context.Context, b *Bag) error {
-	for _, existing := range b.Config.TeamRepos() {
-		if strings.EqualFold(existing, b.RepoArg) {
+	targets := []string{b.RepoArg, b.SourceKey, b.SourceID}
+	for _, src := range b.Config.EnabledSources() {
+		existing := registryDisplayForWorkflow(src)
+		for _, target := range targets {
+			if target != "" && strings.EqualFold(existing, target) {
+				b.Formatter.OnConnectDuplicate(existing)
+				return errSkip
+			}
+			if target != "" && strings.EqualFold(src.Identity.Key, target) {
+				b.Formatter.OnConnectDuplicate(existing)
+				return errSkip
+			}
+			if target != "" && strings.EqualFold(src.ID, target) {
+				b.Formatter.OnConnectDuplicate(existing)
+				return errSkip
+			}
+		}
+		if b.SourceKey != "" && strings.EqualFold(src.Identity.Key, b.SourceKey) {
 			b.Formatter.OnConnectDuplicate(existing)
 			return errSkip
 		}
@@ -78,9 +96,19 @@ func StepFetchManifest(ctx context.Context, b *Bag) error {
 		return fmt.Errorf("internal: Provider not set in workflow bag")
 	}
 
-	result, err := b.Provider.Discover(ctx, b.RepoArg)
+	var result *provider.DiscoverResult
+	var err error
+	if b.SourceArg.Type != "" {
+		sourceProvider, ok := b.Provider.(provider.SourceProvider)
+		if !ok {
+			return fmt.Errorf("internal: Provider does not support sources")
+		}
+		result, err = sourceProvider.DiscoverSource(ctx, b.SourceArg)
+	} else {
+		result, err = b.Provider.Discover(ctx, b.RepoArg)
+	}
 	if err != nil {
-		return fmt.Errorf("could not discover skills in %s: %w", b.RepoArg, err)
+		return fmt.Errorf("could not discover skills in %s: %w", workflowSourceDisplay(b), err)
 	}
 
 	if result.Manifest != nil {
@@ -115,26 +143,44 @@ func StepInferRegistryType(ctx context.Context, b *Bag) error {
 	visibility := registryVisibility(ctx, b)
 
 	writable := false
-	if b.Client != nil {
+	if b.Client != nil && b.RepoArg != "" {
 		owner, repo, err := manifest.ParseOwnerRepo(b.RepoArg)
 		if err == nil {
 			writable, _ = b.Client.HasPushAccess(ctx, owner, repo)
 		}
 	}
 
-	b.Config.AddRegistry(config.RegistryConfig{
-		Repo:       b.RepoArg,
-		Enabled:    true,
-		Type:       regType,
-		Visibility: visibility,
-		Writable:   writable,
-	})
+	if b.SourceArg.Type != "" {
+		spec := b.SourceArg
+		if b.SourceID != "" {
+			spec.ID = b.SourceID
+		}
+		b.Config.AddRegistry(config.RegistryConfig{
+			ID:         b.SourceID,
+			Enabled:    true,
+			Type:       regType,
+			Visibility: visibility,
+			Writable:   writable,
+			Source:     &spec,
+		})
+	} else {
+		b.Config.AddRegistry(config.RegistryConfig{
+			Repo:       b.RepoArg,
+			Enabled:    true,
+			Type:       regType,
+			Visibility: visibility,
+			Writable:   writable,
+		})
+	}
 
 	return nil
 }
 
 func registryVisibility(ctx context.Context, b *Bag) string {
 	if b.Visibility == nil {
+		return config.RegistryVisibilityUnknown
+	}
+	if b.SourceArg.Type != "" && b.SourceArg.Type != source.SourceGitHub {
 		return config.RegistryVisibilityUnknown
 	}
 	owner, repo, err := manifest.ParseOwnerRepo(b.RepoArg)
@@ -155,11 +201,14 @@ func StepSaveConfig(_ context.Context, b *Bag) error {
 	if err := b.Config.Save(); err != nil {
 		return fmt.Errorf("save config: %w", err)
 	}
-	b.Formatter.OnConnectSaved(b.RepoArg)
+	b.Formatter.OnConnectSaved(workflowSourceDisplay(b))
 	return nil
 }
 
 func StepIndexPublicRegistry(ctx context.Context, b *Bag) error {
+	if b.SourceArg.Type != "" && (b.SourceArg.Type != source.SourceGitHub || b.SourceArg.Path != "" || b.SourceArg.Ref != "") {
+		return nil
+	}
 	return updateRegistryIndex(ctx, b, b.RepoArg, b.manifest)
 }
 
@@ -204,7 +253,7 @@ func StepShowAvailableSkills(_ context.Context, b *Bag) error {
 	if b.manifest != nil {
 		count = len(b.manifest.Catalog)
 	}
-	b.Formatter.OnConnectAvailable(b.RepoArg, count)
+	b.Formatter.OnConnectAvailable(workflowSourceDisplay(b), count)
 	return nil
 }
 
@@ -214,7 +263,7 @@ func StepConnectSyncError(ctx context.Context, b *Bag) error {
 	// This step wraps SyncSkills with error recovery for connect.
 	err := StepSyncSkills(ctx, b)
 	if err != nil {
-		b.Formatter.OnConnectSyncWarning(b.RepoArg, err)
+		b.Formatter.OnConnectSyncWarning(workflowSourceDisplay(b), err)
 		if !isatty.IsTerminal(os.Stdout.Fd()) {
 			return fmt.Errorf("sync failed: %w", err)
 		}
@@ -224,4 +273,36 @@ func StepConnectSyncError(ctx context.Context, b *Bag) error {
 		return nil
 	}
 	return nil
+}
+
+func workflowSourceDisplay(b *Bag) string {
+	if b.SourceID != "" {
+		return b.SourceID
+	}
+	if b.SourceArg.Type != "" {
+		if b.SourceKey != "" {
+			return b.SourceKey
+		}
+		if b.SourceArg.Repo != "" {
+			return b.SourceArg.Repo
+		}
+		if b.SourceArg.URL != "" {
+			return b.SourceArg.URL
+		}
+		return b.SourceArg.Path
+	}
+	return b.RepoArg
+}
+
+func registryDisplayForWorkflow(src config.RegistrySource) string {
+	if src.ID != "" {
+		return src.ID
+	}
+	if src.Config.Repo != "" {
+		return src.Config.Repo
+	}
+	if src.Identity.Key != "" {
+		return src.Identity.Key
+	}
+	return src.Source.Repo
 }

--- a/internal/workflow/connect_test.go
+++ b/internal/workflow/connect_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/tools"
 	"github.com/Naoray/scribe/internal/workflow"
 )
@@ -37,6 +38,20 @@ func (p connectTestProvider) Discover(context.Context, string) (*provider.Discov
 }
 
 func (p connectTestProvider) Fetch(context.Context, manifest.Entry) ([]tools.SkillFile, error) {
+	return nil, errors.New("unused")
+}
+
+type connectTestSourceProvider struct {
+	connectTestProvider
+	got source.SourceSpec
+}
+
+func (p *connectTestSourceProvider) DiscoverSource(ctx context.Context, spec source.SourceSpec) (*provider.DiscoverResult, error) {
+	p.got = spec
+	return p.connectTestProvider.Discover(ctx, spec.Repo)
+}
+
+func (p *connectTestSourceProvider) FetchSource(context.Context, source.SourceSpec, manifest.Entry) ([]tools.SkillFile, error) {
 	return nil, errors.New("unused")
 }
 
@@ -143,6 +158,55 @@ func TestStepIndexPublicRegistrySkipsPrivateAndUnknown(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(home, ".scribe", "index", "registries.json")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("index stat error = %v, want not exist", err)
+	}
+}
+
+func TestConnectSourceSpecPersistsTypedRegistry(t *testing.T) {
+	provider := &connectTestSourceProvider{
+		connectTestProvider: connectTestProvider{
+			isTeam: true,
+			manifest: &manifest.Manifest{
+				APIVersion: "scribe/v1",
+				Kind:       "Registry",
+				Team:       &manifest.Team{Name: "Acme"},
+				Catalog:    []manifest.Entry{{Name: "deploy"}},
+			},
+		},
+	}
+	bag := &workflow.Bag{
+		Config:   &config.Config{},
+		Provider: provider,
+		RepoArg:  "acme/skills",
+		SourceArg: source.SourceSpec{
+			ID:   "team-skills",
+			Type: source.SourceGitHub,
+			Repo: "acme/skills",
+			Ref:  "v1.2.3",
+			Path: "packs",
+		},
+		SourceKey: "github:acme/skills:packs",
+		SourceID:  "team-skills",
+	}
+
+	for _, step := range []func(context.Context, *workflow.Bag) error{
+		workflow.StepFetchManifest,
+		workflow.StepValidateManifest,
+		workflow.StepInferRegistryType,
+	} {
+		if err := step(context.Background(), bag); err != nil {
+			t.Fatalf("step failed: %v", err)
+		}
+	}
+
+	if provider.got.Path != "packs" || provider.got.Ref != "v1.2.3" {
+		t.Fatalf("DiscoverSource spec = %#v", provider.got)
+	}
+	if len(bag.Config.Registries) != 1 {
+		t.Fatalf("registries len = %d", len(bag.Config.Registries))
+	}
+	got := bag.Config.Registries[0]
+	if got.ID != "team-skills" || got.Source == nil || got.Source.Path != "packs" || got.Source.Ref != "v1.2.3" {
+		t.Fatalf("registry = %#v", got)
 	}
 }
 


### PR DESCRIPTION
Implements SourceSpec phase 3 CLI UX for #818.

What changed:
- added typed source flags to `add`, `browse`, and `connect`: `--source`, `--repo`, `--url`, `--ref`, `--path`, `--id`
- kept `--registry` on `add`/`browse` as a legacy alias/filter
- kept `owner/repo:skill` direct installs working
- added `[source]:skill` direct install refs for URL/path-style sources
- made unbracketed URL install refs fail with remediation to use `[source]:skill` or `--source`
- connected typed sources persist as `RegistryConfig.Source` instead of legacy `repo` rows

Tests:
- `go test ./cmd ./internal/workflow ./internal/source`
- `go test ./...`