### PR TITLE
test: cover kit resolution and projection cleanup

### DIFF
--- a/internal/kit/resolver_test.go
+++ b/internal/kit/resolver_test.go
@@ -54,6 +54,18 @@ func TestResolve(t *testing.T) {
 			want:            []string{"init-go", "init-react"},
 		},
 		{
+			name: "multiple kits union expands globs against installed skills",
+			projectFile: &projectfile.ProjectFile{
+				Kits: []string{"frontend", "backend"},
+			},
+			availableKits: map[string]*Kit{
+				"frontend": {Name: "frontend", Skills: []string{"init-*", "shared"}},
+				"backend":  {Name: "backend", Skills: []string{"deploy-*", "shared"}},
+			},
+			installedSkills: []string{"deploy-api", "init-react", "init-tailwind", "unmatched"},
+			want:            []string{"deploy-api", "init-react", "init-tailwind", "shared"},
+		},
+		{
 			name: "add applies after kits",
 			projectFile: &projectfile.ProjectFile{
 				Kits: []string{"frontend"},
@@ -75,6 +87,18 @@ func TestResolve(t *testing.T) {
 				"frontend": {Name: "frontend", Skills: []string{"init-react", "init-tailwind"}},
 			},
 			want: []string{"init-tailwind"},
+		},
+		{
+			name: "remove subtracts skill also provided by kit and add",
+			projectFile: &projectfile.ProjectFile{
+				Kits:   []string{"frontend"},
+				Add:    []string{"init-react", "audit-tests"},
+				Remove: []string{"init-react"},
+			},
+			availableKits: map[string]*Kit{
+				"frontend": {Name: "frontend", Skills: []string{"init-react", "init-tailwind"}},
+			},
+			want: []string{"audit-tests", "init-tailwind"},
 		},
 		{
 			name: "missing kit returns error with name",

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -125,6 +125,13 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 		}
 
 		if !kitAllowed(name) {
+			removed, removedActions, err := e.removeCurrentProjectProjections(name, &skill, storeDir, byName)
+			if err != nil {
+				return summary, actions, err
+			}
+			summary.Removed += removed
+			actions = append(actions, removedActions...)
+			st.Installed[name] = skill
 			continue
 		}
 
@@ -267,6 +274,63 @@ func (e *Engine) Run(st *state.State) (Summary, []Action, error) {
 	}
 
 	return summary, actions, nil
+}
+
+func (e *Engine) removeCurrentProjectProjections(name string, skill *state.InstalledSkill, storeDir string, byName map[string]tools.Tool) (int, []Action, error) {
+	if e.ProjectRoot == "" {
+		return 0, nil, nil
+	}
+
+	currentPaths := map[string]string{}
+	for _, projection := range skill.Projections {
+		if projection.Project != e.ProjectRoot {
+			continue
+		}
+		for _, toolName := range projection.Tools {
+			tool, ok := supportedToolByName(toolName, byName)
+			if !ok {
+				continue
+			}
+			path, err := tool.SkillPath(name, e.ProjectRoot)
+			if err == nil {
+				currentPaths[path] = toolName
+			}
+		}
+	}
+	if len(currentPaths) == 0 {
+		return 0, nil, nil
+	}
+
+	canonicalDir := e.canonicalDirForSkill(storeDir, name, *skill)
+	var removed int
+	var actions []Action
+	for path, toolName := range currentPaths {
+		skill.Paths = removePath(skill.Paths, path)
+		skill.ManagedPaths = removePath(skill.ManagedPaths, path)
+		if _, err := os.Lstat(path); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return removed, actions, err
+		}
+		if !isManagedProjection(path, canonicalDir) {
+			continue
+		}
+		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return removed, actions, err
+		}
+		removed++
+		actions = append(actions, Action{Kind: ActionRemoved, Name: name, Tool: toolName, Path: path})
+	}
+
+	projections := skill.Projections[:0]
+	for _, projection := range skill.Projections {
+		if projection.Project != e.ProjectRoot {
+			projections = append(projections, projection)
+		}
+	}
+	skill.Projections = projections
+	return removed, actions, nil
 }
 
 func (e *Engine) canonicalDirForSkill(storeDir, name string, skill state.InstalledSkill) string {

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -641,6 +641,93 @@ func TestRun_KitFilterEnabled_BlocksNonKitProjection(t *testing.T) {
 	}
 }
 
+func TestRun_KitFilterEnabled_RemovesCurrentProjectProjectionOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	storeDir := filepath.Join(home, ".scribe", "skills")
+	for _, name := range []string{"recap", "debugger"} {
+		dir := filepath.Join(storeDir, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# "+name), 0o644); err != nil {
+			t.Fatalf("write skill: %v", err)
+		}
+	}
+
+	projectOne := t.TempDir()
+	projectTwo := t.TempDir()
+	debuggerOne := filepath.Join(projectOne, ".claude", "skills", "debugger")
+	debuggerTwo := filepath.Join(projectTwo, ".claude", "skills", "debugger")
+	recapOne := filepath.Join(projectOne, ".claude", "skills", "recap")
+	for path, target := range map[string]string{
+		debuggerOne: filepath.Join(storeDir, "debugger"),
+		debuggerTwo: filepath.Join(storeDir, "debugger"),
+		recapOne:    filepath.Join(storeDir, "recap"),
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir projection dir: %v", err)
+		}
+		if err := os.Symlink(target, path); err != nil {
+			t.Fatalf("symlink %s: %v", path, err)
+		}
+	}
+
+	st := &state.State{Installed: map[string]state.InstalledSkill{
+		"recap": {
+			Projections:  []state.ProjectionEntry{{Project: projectOne, Tools: []string{"claude"}}},
+			ManagedPaths: []string{recapOne},
+			Paths:        []string{recapOne},
+		},
+		"debugger": {
+			Projections: []state.ProjectionEntry{
+				{Project: projectOne, Tools: []string{"claude"}},
+				{Project: projectTwo, Tools: []string{"claude"}},
+			},
+			ManagedPaths: []string{debuggerOne, debuggerTwo},
+			Paths:        []string{debuggerOne, debuggerTwo},
+		},
+	}}
+
+	engine := &reconcile.Engine{
+		Tools:            []tools.Tool{tools.ClaudeTool{}},
+		ProjectRoot:      projectOne,
+		KitFilter:        []string{"recap"},
+		KitFilterEnabled: true,
+	}
+	summary, actions, err := engine.Run(st)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Removed != 1 {
+		t.Fatalf("Removed = %d, want 1; actions=%+v", summary.Removed, actions)
+	}
+	if _, err := os.Lstat(debuggerOne); !os.IsNotExist(err) {
+		t.Fatalf("project one debugger projection still exists or stat failed: %v", err)
+	}
+	if _, err := os.Lstat(debuggerTwo); err != nil {
+		t.Fatalf("project two debugger projection affected: %v", err)
+	}
+	if _, err := os.Lstat(recapOne); err != nil {
+		t.Fatalf("project one recap projection missing: %v", err)
+	}
+
+	debugger := st.Installed["debugger"]
+	if hasProjectionForProject(debugger.Projections, projectOne) {
+		t.Fatalf("debugger projections retained project one: %#v", debugger.Projections)
+	}
+	if !hasProjectionForProject(debugger.Projections, projectTwo) {
+		t.Fatalf("debugger projections lost project two: %#v", debugger.Projections)
+	}
+	if containsPath(debugger.ManagedPaths, debuggerOne) || containsPath(debugger.Paths, debuggerOne) {
+		t.Fatalf("debugger retained removed project one path: managed=%v paths=%v", debugger.ManagedPaths, debugger.Paths)
+	}
+	if !containsPath(debugger.ManagedPaths, debuggerTwo) || !containsPath(debugger.Paths, debuggerTwo) {
+		t.Fatalf("debugger lost project two path: managed=%v paths=%v", debugger.ManagedPaths, debugger.Paths)
+	}
+}
+
 func TestReconcileProjectRootPreservesUntrackedGlobalCodexSymlink(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -839,4 +926,22 @@ func TestReconcileRemovesStalePackageProjection(t *testing.T) {
 	if _, err := os.Lstat(stale); !os.IsNotExist(err) {
 		t.Errorf("stale package projection still exists: %v", err)
 	}
+}
+
+func hasProjectionForProject(projections []state.ProjectionEntry, project string) bool {
+	for _, projection := range projections {
+		if projection.Project == project {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPath(paths []string, want string) bool {
+	for _, path := range paths {
+		if path == want {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- add resolver coverage for multi-kit glob union and remove-over-kit/add semantics
- add project projection regression covering removed kit cleanup for current project while preserving other projects
- fix reconcile cleanup for skills no longer allowed by the current project kit filter

## Tests
- go test ./internal/kit
- go test ./internal/reconcile
- go test ./...
