### PR TITLE
feat: add snippet managed block projection

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -229,10 +229,9 @@ func inspectProjectSnippetDrift(cfg *config.Config) []Issue {
 		}}
 	}
 	projectRoot := filepath.Dir(projectPath)
-	active := availableToolNames(cfg)
 	var issues []Issue
 	for _, sn := range snippets {
-		for _, target := range expectedSnippetTargets(sn.Targets, active) {
+		for _, target := range expectedSnippetTargets(projectRoot, sn.Targets) {
 			path := snippet.TargetPath(projectRoot, sn.Name, target)
 			if path == "" || snippet.HasProjection(path, sn, target) {
 				continue
@@ -338,11 +337,7 @@ func topBudgetSkills(sizes map[string]int, limit int) []budget.Overflow {
 	return largest
 }
 
-func expectedSnippetTargets(targets, activeTools []string) []string {
-	active := map[string]bool{}
-	for _, tool := range activeTools {
-		active[strings.ToLower(tool)] = true
-	}
+func expectedSnippetTargets(projectRoot string, targets []string) []string {
 	seen := map[string]bool{}
 	var out []string
 	add := func(target string) {
@@ -358,8 +353,10 @@ func expectedSnippetTargets(targets, activeTools []string) []string {
 	}
 	for _, target := range targets {
 		if strings.EqualFold(target, "all") {
-			for tool := range active {
-				add(tool)
+			for _, tool := range []string{"claude", "codex", "cursor"} {
+				if snippetTargetExists(projectRoot, tool) {
+					add(tool)
+				}
 			}
 			continue
 		}
@@ -367,6 +364,15 @@ func expectedSnippetTargets(targets, activeTools []string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func snippetTargetExists(projectRoot, target string) bool {
+	path := snippet.TargetPath(projectRoot, "", target)
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func inspectMigrationBudgetOverflow(st *state.State, name string) []Issue {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Naoray/scribe/internal/budget"
 	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/snippet"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/tools"
 )
@@ -88,6 +89,58 @@ func TestInspectManagedSkillsReportsMissingSnippetProjection(t *testing.T) {
 	}
 	if !strings.Contains(issue.Message, "scribe sync") {
 		t.Fatalf("Message = %q, want sync remediation", issue.Message)
+	}
+}
+
+func TestInspectManagedSkillsHonorsExistingOnlyAllSnippetTargets(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	project := t.TempDir()
+	if err := os.WriteFile(filepath.Join(project, ".scribe.yaml"), []byte("snippets:\n  - all-rules\n"), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "AGENTS.md"), []byte("# Agents\n"), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+	snippetDir := filepath.Join(home, ".scribe", "snippets")
+	if err := os.MkdirAll(snippetDir, 0o755); err != nil {
+		t.Fatalf("mkdir snippets: %v", err)
+	}
+	snippetContent := "---\nname: all-rules\ndescription: All rules\ntargets: all\n---\n# Rules\n"
+	if err := os.WriteFile(filepath.Join(snippetDir, "all-rules.md"), []byte(snippetContent), 0o644); err != nil {
+		t.Fatalf("write snippet: %v", err)
+	}
+	snippets, err := snippet.LoadProject(snippetDir, []string{"all-rules"})
+	if err != nil {
+		t.Fatalf("LoadProject: %v", err)
+	}
+	if _, err := snippet.Project(project, snippets, []string{"claude", "codex", "cursor"}); err != nil {
+		t.Fatalf("Project: %v", err)
+	}
+	t.Chdir(project)
+
+	cfg := &config.Config{Tools: []config.ToolConfig{
+		{Name: "claude", Enabled: true},
+		{Name: "codex", Enabled: true},
+		{Name: "cursor", Enabled: true},
+	}}
+	st := &state.State{Installed: map[string]state.InstalledSkill{}}
+	report, err := InspectManagedSkills(cfg, st, "")
+	if err != nil {
+		t.Fatalf("InspectManagedSkills: %v", err)
+	}
+
+	for _, issue := range report.Issues {
+		if issue.Kind == IssueSnippetProjectionDrift {
+			t.Fatalf("unexpected snippet drift issue: %+v", issue)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(project, "CLAUDE.md")); !os.IsNotExist(err) {
+		t.Fatalf("CLAUDE.md should not be created by existing-only all target projection: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(project, ".cursorrules")); !os.IsNotExist(err) {
+		t.Fatalf(".cursorrules should not be created by existing-only all target projection: %v", err)
 	}
 }
 

--- a/internal/snippet/snippet.go
+++ b/internal/snippet/snippet.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -19,19 +18,16 @@ type Snippet struct {
 	Name        string
 	Description string
 	Targets     []string
+	Source      string
 	Body        []byte
 	Path        string
 }
 
 type frontmatter struct {
-	Name        string   `yaml:"name,omitempty"`
-	Description string   `yaml:"description,omitempty"`
-	Targets     []string `yaml:"targets,omitempty"`
-}
-
-type cursorFrontmatter struct {
-	Description string `yaml:"description,omitempty"`
-	AlwaysApply bool   `yaml:"alwaysApply"`
+	Name        string  `yaml:"name,omitempty"`
+	Description string  `yaml:"description,omitempty"`
+	Targets     targets `yaml:"targets,omitempty"`
+	Source      string  `yaml:"source,omitempty"`
 }
 
 func Dir(home string) string {
@@ -88,6 +84,7 @@ func Parse(path string, data []byte) (Snippet, error) {
 		Name:        fm.Name,
 		Description: strings.TrimSpace(fm.Description),
 		Targets:     targets,
+		Source:      strings.TrimSpace(fm.Source),
 		Body:        bytes.TrimLeft(body, "\n"),
 		Path:        path,
 	}, nil
@@ -101,16 +98,24 @@ func ContentForBudget(sn Snippet) []byte {
 	return bytes.Join([][]byte{[]byte("---\n"), data, []byte("---\n"), sn.Body}, nil)
 }
 
+type ProjectOptions struct {
+	CreateTargets bool
+}
+
 func Project(projectRoot string, snippets []Snippet, activeTools []string) ([]string, error) {
+	return ProjectWithOptions(projectRoot, snippets, activeTools, ProjectOptions{})
+}
+
+func ProjectWithOptions(projectRoot string, snippets []Snippet, activeTools []string, opts ProjectOptions) ([]string, error) {
 	byTarget := map[string][]Snippet{}
 	for _, sn := range snippets {
-		for _, target := range expandTargets(sn.Targets, activeTools) {
+		for _, target := range expandTargets(projectRoot, sn.Targets, activeTools, opts) {
 			byTarget[target] = append(byTarget[target], sn)
 		}
 	}
 
 	var paths []string
-	for _, target := range concreteTargets(activeTools) {
+	for _, target := range projectTargets(projectRoot, byTarget) {
 		written, err := projectTarget(projectRoot, target, byTarget[target])
 		if err != nil {
 			return paths, err
@@ -137,10 +142,8 @@ func TargetPath(projectRoot, name, target string) string {
 		return filepath.Join(projectRoot, "CLAUDE.md")
 	case "codex":
 		return filepath.Join(projectRoot, "AGENTS.md")
-	case "gemini":
-		return filepath.Join(projectRoot, "GEMINI.md")
 	case "cursor":
-		return filepath.Join(projectRoot, ".cursor", "rules", slug(name)+".mdc")
+		return filepath.Join(projectRoot, ".cursorrules")
 	default:
 		return ""
 	}
@@ -151,34 +154,9 @@ func HasProjection(path string, sn Snippet, target string) bool {
 	if err != nil {
 		return false
 	}
-	if strings.EqualFold(target, "cursor") {
-		return bytes.Contains(data, []byte("<!-- scribe-snippet:cursor -->")) && bytes.Contains(data, sn.Body)
-	}
-	start := "<!-- scribe-snippet:" + sn.Name + ":start "
-	end := "<!-- scribe-snippet:" + sn.Name + ":end -->"
+	start := "<!-- scribe:start name=" + sn.Name + " "
+	end := "<!-- scribe:end name=" + sn.Name + " -->"
 	return strings.Contains(string(data), start) && strings.Contains(string(data), end)
-}
-
-func concreteTargets(activeTools []string) []string {
-	seen := map[string]bool{
-		"claude": true,
-		"codex":  true,
-		"cursor": true,
-		"gemini": true,
-	}
-	for _, tool := range activeTools {
-		tool = strings.ToLower(strings.TrimSpace(tool))
-		switch tool {
-		case "claude", "codex", "cursor", "gemini":
-			seen[tool] = true
-		}
-	}
-	out := make([]string, 0, len(seen))
-	for target := range seen {
-		out = append(out, target)
-	}
-	sort.Strings(out)
-	return out
 }
 
 func split(data []byte) (frontmatter, []byte, error) {
@@ -200,6 +178,27 @@ func split(data []byte) (frontmatter, []byte, error) {
 	return fm, body, nil
 }
 
+type targets []string
+
+func (t *targets) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		*t = targets{value.Value}
+	case yaml.SequenceNode:
+		out := make([]string, 0, len(value.Content))
+		for _, node := range value.Content {
+			if node.Kind != yaml.ScalarNode {
+				return fmt.Errorf("targets entries must be strings")
+			}
+			out = append(out, node.Value)
+		}
+		*t = out
+	default:
+		return fmt.Errorf("targets must be a string or list")
+	}
+	return nil
+}
+
 func normalizeTargets(targets []string) []string {
 	seen := map[string]bool{}
 	var out []string
@@ -208,113 +207,52 @@ func normalizeTargets(targets []string) []string {
 		if target == "" || seen[target] {
 			continue
 		}
-		seen[target] = true
-		out = append(out, target)
-	}
-	sort.Strings(out)
-	return out
-}
-
-func expandTargets(targets, activeTools []string) []string {
-	seen := map[string]bool{}
-	var out []string
-	add := func(target string) {
-		target = strings.ToLower(strings.TrimSpace(target))
-		if target == "" || seen[target] {
-			return
-		}
 		switch target {
-		case "claude", "codex", "cursor", "gemini":
+		case "claude", "codex", "cursor", "all":
 			seen[target] = true
 			out = append(out, target)
 		}
 	}
+	return out
+}
+
+func expandTargets(projectRoot string, targets, activeTools []string, opts ProjectOptions) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(target string) {
+		if seen[target] {
+			return
+		}
+		seen[target] = true
+		out = append(out, target)
+	}
 	for _, target := range targets {
 		if strings.EqualFold(target, "all") {
-			for _, tool := range activeTools {
-				add(tool)
+			for _, detected := range detectedTargets(projectRoot, activeTools, opts.CreateTargets) {
+				add(detected)
 			}
 			continue
 		}
 		add(target)
 	}
-	sort.Strings(out)
 	return out
 }
 
 func projectTarget(projectRoot string, target string, snippets []Snippet) ([]string, error) {
 	switch target {
-	case "claude", "codex", "gemini":
+	case "claude", "codex", "cursor":
 		written, err := writeManagedBlocks(TargetPath(projectRoot, "", target), snippets)
 		if err != nil || written == "" {
 			return nil, err
 		}
 		return []string{written}, nil
-	case "cursor":
-		return writeCursorRules(projectRoot, snippets)
 	default:
 		return nil, nil
 	}
 }
 
-func writeCursorRules(projectRoot string, snippets []Snippet) ([]string, error) {
-	rulesDir := filepath.Join(projectRoot, ".cursor", "rules")
-	current := map[string]bool{}
-	var paths []string
-	for _, sn := range snippets {
-		path := TargetPath(projectRoot, sn.Name, "cursor")
-		current[path] = true
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			return paths, fmt.Errorf("create cursor snippets dir: %w", err)
-		}
-		content, err := cursorRule(sn)
-		if err != nil {
-			return paths, err
-		}
-		existing, err := os.ReadFile(path)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return paths, fmt.Errorf("read cursor snippet %q: %w", sn.Name, err)
-		}
-		if bytes.Equal(existing, content) {
-			continue
-		}
-		if err := os.WriteFile(path, content, 0o644); err != nil {
-			return paths, fmt.Errorf("write cursor snippet %q: %w", sn.Name, err)
-		}
-		paths = append(paths, path)
-	}
-	entries, err := os.ReadDir(rulesDir)
-	if errors.Is(err, fs.ErrNotExist) {
-		return paths, nil
-	}
-	if err != nil {
-		return paths, fmt.Errorf("read cursor snippets dir: %w", err)
-	}
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".mdc" {
-			continue
-		}
-		path := filepath.Join(rulesDir, entry.Name())
-		if current[path] {
-			continue
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return paths, fmt.Errorf("read cursor snippet %s: %w", path, err)
-		}
-		if bytes.Contains(data, []byte("<!-- scribe-snippet:cursor -->")) {
-			if err := os.Remove(path); err != nil {
-				return paths, fmt.Errorf("remove stale cursor snippet %s: %w", path, err)
-			}
-			paths = append(paths, path)
-		}
-	}
-	sort.Strings(paths)
-	return paths, nil
-}
-
 func RemoveLegacyCursorRule(projectRoot string, sn Snippet) (string, bool, error) {
-	path := TargetPath(projectRoot, sn.Name, "cursor")
+	path := filepath.Join(projectRoot, ".cursor", "rules", slug(sn.Name)+".mdc")
 	if path == "" {
 		return "", false, nil
 	}
@@ -341,26 +279,6 @@ func RemoveLegacyCursorRule(projectRoot string, sn Snippet) (string, bool, error
 	return path, true, nil
 }
 
-func cursorRule(sn Snippet) ([]byte, error) {
-	fm, err := yaml.Marshal(cursorFrontmatter{
-		Description: sn.Description,
-		AlwaysApply: false,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("encode cursor snippet %q: %w", sn.Name, err)
-	}
-	var b bytes.Buffer
-	b.WriteString("---\n")
-	b.Write(fm)
-	b.WriteString("---\n")
-	b.WriteString("<!-- scribe-snippet:cursor -->\n\n")
-	b.Write(sn.Body)
-	if !bytes.HasSuffix(sn.Body, []byte("\n")) {
-		b.WriteString("\n")
-	}
-	return b.Bytes(), nil
-}
-
 func writeManagedBlocks(path string, snippets []Snippet) (string, error) {
 	if path == "" {
 		return "", nil
@@ -375,14 +293,14 @@ func writeManagedBlocks(path string, snippets []Snippet) (string, error) {
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return "", fmt.Errorf("read snippet target %s: %w", path, err)
 	}
-	next := renderManagedBlocks(string(existing), snippets)
-	if next == "" && len(existing) == 0 {
+	next := renderManagedBlocks(existing, snippets)
+	if len(next) == 0 && len(existing) == 0 {
 		return "", nil
 	}
-	if string(existing) == next {
+	if bytes.Equal(existing, next) {
 		return "", nil
 	}
-	if err := os.WriteFile(path, []byte(next), 0o644); err != nil {
+	if err := os.WriteFile(path, next, 0o644); err != nil {
 		return "", fmt.Errorf("write snippet target %s: %w", path, err)
 	}
 	return path, nil
@@ -393,39 +311,58 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
-func renderManagedBlocks(existing string, snippets []Snippet) string {
+func renderManagedBlocks(existing []byte, snippets []Snippet) []byte {
 	cleaned := stripManagedBlocks(existing)
-	var blocks strings.Builder
+	var blocks bytes.Buffer
 	for _, sn := range snippets {
-		blocks.WriteString(managedBlock(sn))
+		blocks.Write(managedBlock(sn))
 	}
 	if blocks.Len() == 0 {
 		return cleaned
 	}
-	if strings.TrimSpace(cleaned) == "" {
-		return blocks.String()
+	if len(bytes.TrimSpace(cleaned)) == 0 {
+		return blocks.Bytes()
 	}
-	if !strings.HasSuffix(cleaned, "\n") {
-		cleaned += "\n"
+	switch {
+	case bytes.HasSuffix(cleaned, []byte("\n\n")):
+	case bytes.HasSuffix(cleaned, []byte("\n")):
+		cleaned = append(cleaned, '\n')
+	default:
+		cleaned = append(cleaned, '\n')
+		cleaned = append(cleaned, '\n')
 	}
-	return cleaned + "\n" + blocks.String()
+	cleaned = append(cleaned, blocks.Bytes()...)
+	return cleaned
 }
 
-func stripManagedBlocks(existing string) string {
-	re := regexp.MustCompile(`(?s)<!-- scribe-snippet:[^:]+:start [^>]*-->.*?<!-- scribe-snippet:[^:]+:end -->\n?`)
-	return strings.TrimRight(re.ReplaceAllString(existing, ""), "\n")
+func stripManagedBlocks(existing []byte) []byte {
+	blocks := parseManagedBlocks(existing)
+	if len(blocks) == 0 {
+		return append([]byte(nil), existing...)
+	}
+	out := make([]byte, 0, len(existing))
+	pos := 0
+	for _, block := range blocks {
+		out = append(out, existing[pos:block.start]...)
+		pos = block.end
+		if pos < len(existing) && existing[pos] == '\n' {
+			pos++
+		}
+	}
+	out = append(out, existing[pos:]...)
+	return out
 }
 
-func managedBlock(sn Snippet) string {
+func managedBlock(sn Snippet) []byte {
 	sum := sha256.Sum256(sn.Body)
-	var b strings.Builder
-	fmt.Fprintf(&b, "<!-- scribe-snippet:%s:start sha256=%x -->\n", sn.Name, sum)
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "<!-- scribe:start name=%s hash=%x -->\n", sn.Name, sum)
 	b.Write(sn.Body)
 	if !bytes.HasSuffix(sn.Body, []byte("\n")) {
 		b.WriteString("\n")
 	}
-	fmt.Fprintf(&b, "<!-- scribe-snippet:%s:end -->\n", sn.Name)
-	return b.String()
+	fmt.Fprintf(&b, "<!-- scribe:end name=%s -->\n", sn.Name)
+	return b.Bytes()
 }
 
 func slug(name string) string {
@@ -442,4 +379,101 @@ func slug(name string) string {
 		}
 	}
 	return strings.Trim(b.String(), "-")
+}
+
+func projectTargets(projectRoot string, byTarget map[string][]Snippet) []string {
+	seen := map[string]bool{}
+	for _, target := range supportedTargets() {
+		if len(byTarget[target]) > 0 || fileExists(TargetPath(projectRoot, "", target)) {
+			seen[target] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for _, target := range supportedTargets() {
+		if seen[target] {
+			out = append(out, target)
+		}
+	}
+	return out
+}
+
+func detectedTargets(projectRoot string, activeTools []string, createTargets bool) []string {
+	if !createTargets {
+		var out []string
+		for _, target := range supportedTargets() {
+			if fileExists(TargetPath(projectRoot, "", target)) {
+				out = append(out, target)
+			}
+		}
+		return out
+	}
+	if len(activeTools) == 0 {
+		return supportedTargets()
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, tool := range activeTools {
+		tool = strings.ToLower(strings.TrimSpace(tool))
+		switch tool {
+		case "claude", "codex", "cursor":
+			if !seen[tool] {
+				seen[tool] = true
+				out = append(out, tool)
+			}
+		}
+	}
+	return out
+}
+
+func supportedTargets() []string {
+	return []string{"claude", "codex", "cursor"}
+}
+
+type managedBlockSpan struct {
+	start int
+	end   int
+}
+
+func parseManagedBlocks(data []byte) []managedBlockSpan {
+	var spans []managedBlockSpan
+	searchFrom := 0
+	for {
+		startRel := bytes.Index(data[searchFrom:], []byte("<!-- scribe:start "))
+		if startRel < 0 {
+			break
+		}
+		start := searchFrom + startRel
+		startCloseRel := bytes.Index(data[start:], []byte("-->"))
+		if startCloseRel < 0 {
+			break
+		}
+		startMarker := string(data[start : start+startCloseRel+len("-->")])
+		name, ok := markerField(startMarker, "name")
+		if !ok {
+			searchFrom = start + len("<!-- scribe:start ")
+			continue
+		}
+		endMarker := []byte("<!-- scribe:end name=" + name + " -->")
+		bodyStart := start + startCloseRel + len("-->")
+		endRel := bytes.Index(data[bodyStart:], endMarker)
+		if endRel < 0 {
+			break
+		}
+		end := bodyStart + endRel + len(endMarker)
+		spans = append(spans, managedBlockSpan{start: start, end: end})
+		searchFrom = end
+	}
+	return spans
+}
+
+func markerField(marker, key string) (string, bool) {
+	prefix := key + "="
+	for _, field := range strings.Fields(marker) {
+		field = strings.TrimSuffix(field, "-->")
+		if strings.HasPrefix(field, prefix) {
+			value := strings.TrimPrefix(field, prefix)
+			return strings.TrimSpace(value), value != ""
+		}
+	}
+	return "", false
 }

--- a/internal/snippet/snippet_test.go
+++ b/internal/snippet/snippet_test.go
@@ -7,6 +7,42 @@ import (
 	"testing"
 )
 
+func TestLoadParsesFrontmatterAndBody(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("---\nname: commit-discipline\ndescription: Commit rules\ntargets: [claude, codex]\nsource: local\n---\n\n# Body\n")
+	if err := os.WriteFile(filepath.Join(dir, "commit-discipline.md"), data, 0o644); err != nil {
+		t.Fatalf("write snippet: %v", err)
+	}
+	sn, err := Load(dir, "commit-discipline")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if sn.Name != "commit-discipline" || sn.Description != "Commit rules" || sn.Source != "local" {
+		t.Fatalf("snippet metadata = %#v", sn)
+	}
+	if string(sn.Body) != "# Body\n" {
+		t.Fatalf("Body = %q, want frontmatter stripped", sn.Body)
+	}
+	if len(sn.Targets) != 2 || sn.Targets[0] != "claude" || sn.Targets[1] != "codex" {
+		t.Fatalf("Targets = %v", sn.Targets)
+	}
+}
+
+func TestLoadParsesScalarAllTarget(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("---\nname: all-rules\ndescription: All rules\ntargets: all\nsource: local\n---\n# Body\n")
+	if err := os.WriteFile(filepath.Join(dir, "all-rules.md"), data, 0o644); err != nil {
+		t.Fatalf("write snippet: %v", err)
+	}
+	sn, err := Load(dir, "all-rules")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(sn.Targets) != 1 || sn.Targets[0] != "all" {
+		t.Fatalf("Targets = %v, want [all]", sn.Targets)
+	}
+}
+
 func TestProjectWritesManagedBlocksIdempotently(t *testing.T) {
 	project := t.TempDir()
 	sn := Snippet{
@@ -30,8 +66,11 @@ func TestProjectWritesManagedBlocksIdempotently(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read CLAUDE.md: %v", err)
 	}
-	if !strings.Contains(string(first), "user rule") || !strings.Contains(string(first), "Agent Commit Discipline") {
-		t.Fatalf("CLAUDE.md missing user content or snippet:\n%s", first)
+	if !strings.Contains(string(first), "user rule\n") || !strings.Contains(string(first), "<!-- scribe:start name=commit-discipline hash=") {
+		t.Fatalf("CLAUDE.md missing user content or marker:\n%s", first)
+	}
+	if !strings.Contains(string(first), "<!-- scribe:end name=commit-discipline -->") {
+		t.Fatalf("CLAUDE.md missing end marker:\n%s", first)
 	}
 
 	paths, err = Project(project, []Snippet{sn}, []string{"claude", "codex"})
@@ -47,6 +86,53 @@ func TestProjectWritesManagedBlocksIdempotently(t *testing.T) {
 	}
 	if string(first) != string(second) {
 		t.Fatalf("projection not idempotent\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func TestProjectUpdatesExistingBlockWhenHashChanges(t *testing.T) {
+	project := t.TempDir()
+	sn := Snippet{Name: "rules", Targets: []string{"claude"}, Body: []byte("old body\n")}
+	if _, err := Project(project, []Snippet{sn}, []string{"claude"}); err != nil {
+		t.Fatalf("Project initial: %v", err)
+	}
+	sn.Body = []byte("new body\n")
+	if _, err := Project(project, []Snippet{sn}, []string{"claude"}); err != nil {
+		t.Fatalf("Project update: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(project, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if strings.Contains(string(data), "old body") || !strings.Contains(string(data), "new body") {
+		t.Fatalf("block was not hash-updated:\n%s", data)
+	}
+	if strings.Count(string(data), "<!-- scribe:start name=rules hash=") != 1 {
+		t.Fatalf("expected one rules block:\n%s", data)
+	}
+}
+
+func TestProjectPreservesUserContentAroundManagedBlocks(t *testing.T) {
+	project := t.TempDir()
+	existing := "top\n<!-- scribe:start name=old hash=abc -->\nold\n<!-- scribe:end name=old -->\nbetween\n<!-- scribe:start name=keep hash=abc -->\nstale\n<!-- scribe:end name=keep -->\nbottom\n"
+	if err := os.WriteFile(filepath.Join(project, "AGENTS.md"), []byte(existing), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+	sn := Snippet{Name: "keep", Targets: []string{"codex"}, Body: []byte("fresh\n")}
+	if _, err := Project(project, []Snippet{sn}, []string{"codex"}); err != nil {
+		t.Fatalf("Project: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(project, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{"top\n", "\nbetween\n", "\nbottom\n"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("user content %q not preserved byte-for-byte:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "old\n") || strings.Contains(got, "stale\n") || !strings.Contains(got, "fresh\n") {
+		t.Fatalf("managed block content mismatch:\n%s", got)
 	}
 }
 
@@ -84,54 +170,10 @@ func TestProjectRemovesStaleBlocksAndAppliesOrder(t *testing.T) {
 	}
 }
 
-func TestProjectRemovesCursorRuleWhenSnippetRemoved(t *testing.T) {
-	project := t.TempDir()
-	sn := Snippet{Name: "commit-discipline", Targets: []string{"cursor"}, Body: []byte("# Body\n")}
-	if _, err := Project(project, []Snippet{sn}, []string{"cursor"}); err != nil {
-		t.Fatalf("Project initial: %v", err)
-	}
-	path := filepath.Join(project, ".cursor", "rules", "commit-discipline.mdc")
-	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("stat cursor rule: %v", err)
-	}
-	if _, err := Project(project, nil, []string{"cursor"}); err != nil {
-		t.Fatalf("Project removed: %v", err)
-	}
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Fatalf("cursor rule still exists or stat failed: %v", err)
-	}
-}
-
-func TestContentForBudgetAndCursorRuleQuoteYAMLDescriptions(t *testing.T) {
-	sn := Snippet{
-		Name:        "quotes",
-		Description: "Commit: \"carefully\"\nwith newline",
-		Targets:     []string{"cursor"},
-		Body:        []byte("# Body\n"),
-	}
-	if !strings.Contains(string(ContentForBudget(sn)), "description:") {
-		t.Fatalf("budget content missing description:\n%s", ContentForBudget(sn))
-	}
-	if strings.Contains(string(ContentForBudget(sn)), "name:") || strings.Contains(string(ContentForBudget(sn)), "targets:") {
-		t.Fatalf("budget content includes empty metadata:\n%s", ContentForBudget(sn))
-	}
-	project := t.TempDir()
-	if _, err := Project(project, []Snippet{sn}, []string{"cursor"}); err != nil {
-		t.Fatalf("Project: %v", err)
-	}
-	data, err := os.ReadFile(filepath.Join(project, ".cursor", "rules", "quotes.mdc"))
-	if err != nil {
-		t.Fatalf("read cursor rule: %v", err)
-	}
-	if !strings.Contains(string(data), "Commit:") || !strings.Contains(string(data), "with newline") {
-		t.Fatalf("cursor YAML lost description:\n%s", data)
-	}
-}
-
-func TestProjectWritesCursorRule(t *testing.T) {
+func TestProjectWritesCursorRulesFile(t *testing.T) {
 	project := t.TempDir()
 	sn := Snippet{
-		Name:        "commit discipline",
+		Name:        "commit-discipline",
 		Description: "Commit rules",
 		Targets:     []string{"cursor"},
 		Body:        []byte("# Agent Commit Discipline\n"),
@@ -144,12 +186,12 @@ func TestProjectWritesCursorRule(t *testing.T) {
 	if len(paths) != 1 {
 		t.Fatalf("paths = %v, want one changed target", paths)
 	}
-	data, err := os.ReadFile(filepath.Join(project, ".cursor", "rules", "commit-discipline.mdc"))
+	data, err := os.ReadFile(filepath.Join(project, ".cursorrules"))
 	if err != nil {
-		t.Fatalf("read cursor rule: %v", err)
+		t.Fatalf("read .cursorrules: %v", err)
 	}
-	if !strings.Contains(string(data), "alwaysApply: false") || !strings.Contains(string(data), "Agent Commit Discipline") {
-		t.Fatalf("cursor rule missing expected content:\n%s", data)
+	if !strings.Contains(string(data), "<!-- scribe:start name=commit-discipline hash=") || !strings.Contains(string(data), "Agent Commit Discipline") {
+		t.Fatalf(".cursorrules missing expected content:\n%s", data)
 	}
 	paths, err = Project(project, []Snippet{sn}, []string{"cursor"})
 	if err != nil {
@@ -160,20 +202,54 @@ func TestProjectWritesCursorRule(t *testing.T) {
 	}
 }
 
-func TestLoadStripsFrontmatter(t *testing.T) {
-	dir := t.TempDir()
-	data := []byte("---\nname: commit-discipline\ndescription: Commit rules\ntargets: [claude, codex]\n---\n\n# Body\n")
-	if err := os.WriteFile(filepath.Join(dir, "commit-discipline.md"), data, 0o644); err != nil {
-		t.Fatalf("write snippet: %v", err)
+func TestProjectAllTargetsExistingOnlyUnlessCreateTargets(t *testing.T) {
+	project := t.TempDir()
+	if err := os.WriteFile(filepath.Join(project, "AGENTS.md"), []byte("codex user\n"), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
 	}
-	sn, err := Load(dir, "commit-discipline")
+	sn := Snippet{Name: "all-rules", Targets: []string{"all"}, Body: []byte("body\n")}
+	paths, err := Project(project, []Snippet{sn}, []string{"claude", "codex", "cursor"})
 	if err != nil {
-		t.Fatalf("Load: %v", err)
+		t.Fatalf("Project existing-only: %v", err)
 	}
-	if string(sn.Body) != "# Body\n" {
-		t.Fatalf("Body = %q, want frontmatter stripped", sn.Body)
+	if len(paths) != 1 || filepath.Base(paths[0]) != "AGENTS.md" {
+		t.Fatalf("paths = %v, want only AGENTS.md", paths)
 	}
-	if len(sn.Targets) != 2 || sn.Targets[0] != "claude" || sn.Targets[1] != "codex" {
-		t.Fatalf("Targets = %v", sn.Targets)
+	for _, rel := range []string{"CLAUDE.md", ".cursorrules"} {
+		if _, err := os.Stat(filepath.Join(project, rel)); !os.IsNotExist(err) {
+			t.Fatalf("%s created without CreateTargets: %v", rel, err)
+		}
+	}
+
+	paths, err = ProjectWithOptions(project, []Snippet{sn}, []string{"claude", "codex", "cursor"}, ProjectOptions{CreateTargets: true})
+	if err != nil {
+		t.Fatalf("Project create-targets: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("paths = %v, want two newly created targets", paths)
+	}
+	for _, rel := range []string{"CLAUDE.md", "AGENTS.md", ".cursorrules"} {
+		data, err := os.ReadFile(filepath.Join(project, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if !strings.Contains(string(data), "body\n") {
+			t.Fatalf("%s missing snippet body:\n%s", rel, data)
+		}
+	}
+}
+
+func TestContentForBudget(t *testing.T) {
+	sn := Snippet{
+		Name:        "quotes",
+		Description: "Commit: \"carefully\"\nwith newline",
+		Targets:     []string{"cursor"},
+		Body:        []byte("# Body\n"),
+	}
+	if !strings.Contains(string(ContentForBudget(sn)), "description:") {
+		t.Fatalf("budget content missing description:\n%s", ContentForBudget(sn))
+	}
+	if strings.Contains(string(ContentForBudget(sn)), "name:") || strings.Contains(string(ContentForBudget(sn)), "targets:") {
+		t.Fatalf("budget content includes empty metadata:\n%s", ContentForBudget(sn))
 	}
 }

--- a/internal/workflow/sync_test.go
+++ b/internal/workflow/sync_test.go
@@ -352,7 +352,7 @@ func TestStepProjectSnippets_WritesTargetsAndState(t *testing.T) {
 		t.Fatalf("StepProjectSnippets: %v", err)
 	}
 
-	for _, rel := range []string{"CLAUDE.md", "AGENTS.md", filepath.Join(".cursor", "rules", "commit-discipline.mdc")} {
+	for _, rel := range []string{"CLAUDE.md", "AGENTS.md", ".cursorrules"} {
 		data, err := os.ReadFile(filepath.Join(projectDir, rel))
 		if err != nil {
 			t.Fatalf("read %s: %v", rel, err)


### PR DESCRIPTION
## Summary
- parse snippet frontmatter fields name, description, targets, and source from canonical snippet files
- project snippets into CLAUDE.md, AGENTS.md, and .cursorrules using scribe-managed marker blocks with body hashes
- keep projection idempotent, preserve user content outside managed blocks, and support all-target existing-only behavior with a create-targets core option

## Tests
- go test ./internal/snippet
- go test ./internal/workflow -run 'TestStepProjectSnippets'
- go test ./internal/doctor ./cmd -run 'Snippet|ProjectSnippets|Doctor'
- go test ./...

Follow-up: CLI/sync flag wiring for create-targets is intentionally not included in this narrow core PR.