### PR TITLE
Add structured source identity to state and locks

### DIFF
--- a/cmd/lock_plan.go
+++ b/cmd/lock_plan.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Naoray/scribe/internal/lockfile"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/source"
 	isync "github.com/Naoray/scribe/internal/sync"
 )
 
@@ -87,12 +88,23 @@ func buildLatestLockEntry(ctx context.Context, entry manifest.Entry, fetcher isy
 	if err != nil {
 		return lockfile.Entry{}, err
 	}
+	spec, ident, err := source.Canonicalize(source.SourceSpec{
+		Type: source.SourceGitHub,
+		Repo: src.Owner + "/" + src.Repo,
+		Ref:  src.Ref,
+	})
+	if err != nil {
+		return lockfile.Entry{}, err
+	}
 	return lockfile.Entry{
 		Name:               entry.Name,
 		SourceRegistry:     src.Owner + "/" + src.Repo,
 		CommitSHA:          commit,
 		ContentHash:        hash,
 		InstallCommandHash: installCommandHash(entry),
+		SourceKey:          ident.Key,
+		Source:             &spec,
+		ResolvedRev:        commit,
 	}, nil
 }
 

--- a/cmd/project_sync.go
+++ b/cmd/project_sync.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/projectstore"
 	"github.com/Naoray/scribe/internal/skillmd"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
@@ -332,6 +333,9 @@ func projectEntryFromState(name string, installed state.InstalledSkill) (lockfil
 			CommitSHA:          src.LastSHA,
 			ContentHash:        hash,
 			InstallCommandHash: sync.CommandHash(installed.InstallCmd, installed.UpdateCmd, installed.Installs, installed.Updates),
+			SourceKey:          src.SourceKey,
+			Source:             cloneSourceSpec(src.Source),
+			ResolvedRev:        sourceResolvedRev(src),
 		},
 		SourceRepo: src.SourceRepo,
 		Path:       src.Path,
@@ -341,6 +345,21 @@ func projectEntryFromState(name string, installed state.InstalledSkill) (lockfil
 		Installs:   cloneProjectStringMap(installed.Installs),
 		Updates:    cloneProjectStringMap(installed.Updates),
 	}, nil
+}
+
+func cloneSourceSpec(src *source.SourceSpec) *source.SourceSpec {
+	if src == nil {
+		return nil
+	}
+	cp := *src
+	return &cp
+}
+
+func sourceResolvedRev(src state.SkillSource) string {
+	if src.ResolvedRev != "" {
+		return src.ResolvedRev
+	}
+	return src.LastSHA
 }
 
 func cloneProjectStringMap(in map[string]string) map[string]string {

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Naoray/scribe/internal/source"
 	"gopkg.in/yaml.v3"
 )
 
@@ -33,11 +34,14 @@ type ProjectLockfile struct {
 }
 
 type Entry struct {
-	Name               string `yaml:"name" json:"name"`
-	SourceRegistry     string `yaml:"source_registry" json:"source_registry"`
-	CommitSHA          string `yaml:"commit_sha" json:"commit_sha"`
-	ContentHash        string `yaml:"content_hash" json:"content_hash"`
-	InstallCommandHash string `yaml:"install_command_hash,omitempty" json:"install_command_hash,omitempty"`
+	Name               string             `yaml:"name" json:"name"`
+	SourceRegistry     string             `yaml:"source_registry" json:"source_registry"`
+	CommitSHA          string             `yaml:"commit_sha" json:"commit_sha"`
+	ContentHash        string             `yaml:"content_hash" json:"content_hash"`
+	InstallCommandHash string             `yaml:"install_command_hash,omitempty" json:"install_command_hash,omitempty"`
+	SourceKey          string             `yaml:"source_key,omitempty" json:"source_key,omitempty"`
+	Source             *source.SourceSpec `yaml:"source,omitempty" json:"source,omitempty"`
+	ResolvedRev        string             `yaml:"resolved_rev,omitempty" json:"resolved_rev,omitempty"`
 }
 
 type ProjectEntry struct {

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -3,6 +3,8 @@ package lockfile
 import (
 	"strings"
 	"testing"
+
+	"github.com/Naoray/scribe/internal/source"
 )
 
 const hashA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -83,6 +85,46 @@ entries:
 	}
 	if !strings.Contains(string(encoded), "kind: ProjectLock") || !strings.Contains(string(encoded), "kits:") || !strings.Contains(string(encoded), "source_repo: acme/skills") {
 		t.Fatalf("encoded project lockfile missing fields: %s", encoded)
+	}
+}
+
+func TestParseProjectStructuredSourceIdentity(t *testing.T) {
+	raw := []byte(`
+format_version: 1
+kind: ProjectLock
+entries:
+  - name: recap
+    source_registry: git:https://example.com/acme/skills.git:packs
+    source_key: git:https://example.com/acme/skills.git:packs
+    source:
+      type: git
+      url: https://example.com/acme/skills.git
+      ref: main
+      path: packs
+    resolved_rev: abc123
+    commit_sha: abc123
+    content_hash: ` + hashA + `
+`)
+	lf, err := ParseProject(raw)
+	if err != nil {
+		t.Fatalf("ParseProject() error = %v", err)
+	}
+	entry, ok := lf.Entry("recap")
+	if !ok {
+		t.Fatal("Entry(recap) not found")
+	}
+	if entry.SourceKey != "git:https://example.com/acme/skills.git:packs" || entry.ResolvedRev != "abc123" {
+		t.Fatalf("structured identity = %+v", entry.Entry)
+	}
+	if entry.Source == nil || entry.Source.Type != source.SourceGit || entry.Source.Path != "packs" {
+		t.Fatalf("source = %+v", entry.Source)
+	}
+	encoded, err := lf.Encode()
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	if !strings.Contains(string(encoded), "source_key: git:https://example.com/acme/skills.git:packs") || !strings.Contains(string(encoded), "resolved_rev: abc123") {
+		t.Fatalf("encoded project lockfile missing structured identity: %s", encoded)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Naoray/scribe/internal/paths"
+	"github.com/Naoray/scribe/internal/source"
 )
 
 // State is the contents of ~/.scribe/state.json.
@@ -74,6 +75,7 @@ type VendorState struct {
 type RemovedSkill struct {
 	Name      string    `json:"name"`
 	Registry  string    `json:"registry"`
+	SourceKey string    `json:"source_key,omitempty"`
 	RemovedAt time.Time `json:"removed_at"`
 }
 
@@ -187,12 +189,35 @@ type SkillSource struct {
 	LastSHA    string            `json:"last_sha"`
 	BlobSHAs   map[string]string `json:"blob_shas,omitempty"`
 	LastSynced time.Time         `json:"last_synced"`
+
+	SourceKey   string             `json:"source_key,omitempty"`
+	Source      *source.SourceSpec `json:"source,omitempty"`
+	ResolvedRev string             `json:"resolved_rev,omitempty"`
 }
 
 // PushRegistry returns the repository that should receive local edits.
 func (s SkillSource) PushRegistry() string {
+	if s.Source != nil {
+		switch s.Source.Type {
+		case source.SourceGitHub, source.SourceGitLab:
+			if s.Source.Repo != "" {
+				return s.Source.Repo
+			}
+		default:
+			return ""
+		}
+	}
 	if s.SourceRepo != "" {
 		return s.SourceRepo
+	}
+	return s.Registry
+}
+
+// IdentityKey returns the structured source identity when present, falling back
+// to the legacy registry key used by old state files.
+func (s SkillSource) IdentityKey() string {
+	if s.SourceKey != "" {
+		return s.SourceKey
 	}
 	return s.Registry
 }
@@ -562,13 +587,15 @@ func (s *State) RecordRemovedByUser(name string, sources []SkillSource) {
 	}
 	now := time.Now().UTC()
 	for _, src := range sources {
-		if src.Registry == "" {
+		key := src.IdentityKey()
+		if key == "" {
 			continue
 		}
 		replaced := false
 		for i := range s.RemovedByUser {
-			if s.RemovedByUser[i].Name == name && s.RemovedByUser[i].Registry == src.Registry {
+			if s.RemovedByUser[i].Name == name && removedSkillMatches(s.RemovedByUser[i], key, name) {
 				s.RemovedByUser[i].RemovedAt = now
+				s.RemovedByUser[i].SourceKey = src.SourceKey
 				replaced = true
 				break
 			}
@@ -576,7 +603,8 @@ func (s *State) RecordRemovedByUser(name string, sources []SkillSource) {
 		if !replaced {
 			s.RemovedByUser = append(s.RemovedByUser, RemovedSkill{
 				Name:      name,
-				Registry:  src.Registry,
+				Registry:  key,
+				SourceKey: src.SourceKey,
 				RemovedAt: now,
 			})
 		}
@@ -589,7 +617,7 @@ func (s *State) IsRemovedByUser(registry, name string) bool {
 		return false
 	}
 	for _, removed := range s.RemovedByUser {
-		if removed.Registry == registry && removed.Name == name {
+		if removedSkillMatches(removed, registry, name) {
 			return true
 		}
 	}
@@ -606,7 +634,7 @@ func (s *State) ClearRemovedByUser(name, registry string) bool {
 	changed := false
 	for _, removed := range s.RemovedByUser {
 		matchName := removed.Name == name
-		matchRegistry := registry == "" || removed.Registry == registry
+		matchRegistry := registry == "" || removedSkillMatches(removed, registry, name)
 		if matchName && matchRegistry {
 			changed = true
 			continue
@@ -625,7 +653,7 @@ func (s *State) ClearRemovedByRegistry(registry string) bool {
 	kept := s.RemovedByUser[:0]
 	changed := false
 	for _, removed := range s.RemovedByUser {
-		if removed.Registry == registry {
+		if removedSkillMatches(removed, registry, removed.Name) {
 			changed = true
 			continue
 		}
@@ -633,6 +661,13 @@ func (s *State) ClearRemovedByRegistry(registry string) bool {
 	}
 	s.RemovedByUser = kept
 	return changed
+}
+
+func removedSkillMatches(removed RemovedSkill, key, name string) bool {
+	if key == "" || removed.Name != name {
+		return false
+	}
+	return removed.Registry == key || removed.SourceKey == key
 }
 
 func (s *State) HasMigration(name string) bool {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 )
 
@@ -94,6 +95,103 @@ func TestSaveAndLoad(t *testing.T) {
 	}
 	if skill.InstalledAt.IsZero() {
 		t.Error("expected InstalledAt to be set")
+	}
+}
+
+func TestSkillSourceStructuredIdentityRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	src := source.SourceSpec{
+		Type: source.SourceGit,
+		URL:  "https://example.com/acme/skills.git",
+		Ref:  "main",
+		Path: "packs",
+	}
+	s, _ := state.Load()
+	s.RecordInstall("recap", state.InstalledSkill{
+		Revision:      1,
+		InstalledHash: "hash",
+		Sources: []state.SkillSource{{
+			Registry:    "git:https://example.com/acme/skills.git:packs",
+			SourceKey:   "git:https://example.com/acme/skills.git:packs",
+			Source:      &src,
+			ResolvedRev: "abc123",
+			Ref:         "main",
+			LastSHA:     "abc123",
+		}},
+		Tools: []string{"claude"},
+		Paths: []string{"/tmp/recap"},
+	})
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := loaded.Installed["recap"].Sources[0]
+	if got.SourceKey != "git:https://example.com/acme/skills.git:packs" || got.ResolvedRev != "abc123" {
+		t.Fatalf("structured source identity = %+v", got)
+	}
+	if got.Source == nil || got.Source.Type != source.SourceGit || got.Source.Path != "packs" {
+		t.Fatalf("source spec = %+v", got.Source)
+	}
+}
+
+func TestSkillSourceLegacyShapeStillLoads(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".scribe"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw := []byte(`{
+  "schema_version": 6,
+  "installed": {
+    "recap": {
+      "revision": 1,
+      "installed_hash": "hash",
+      "sources": [{
+        "registry": "acme/skills",
+        "ref": "main",
+        "last_sha": "abc123",
+        "last_synced": "2026-05-11T00:00:00Z"
+      }],
+      "tools": ["claude"],
+      "paths": ["/tmp/recap"]
+    }
+  },
+  "kits": {},
+  "snippets": {},
+  "removed_by_user": []
+}`)
+	if err := os.WriteFile(filepath.Join(home, ".scribe", "state.json"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := loaded.Installed["recap"].Sources[0]
+	if got.Registry != "acme/skills" || got.SourceKey != "" || got.Source != nil {
+		t.Fatalf("legacy source changed on load: %+v", got)
+	}
+}
+
+func TestRemovedByUserMatchesSourceKey(t *testing.T) {
+	st := &state.State{}
+	st.RecordRemovedByUser("recap", []state.SkillSource{{
+		Registry:  "display",
+		SourceKey: "git:https://example.com/acme/skills.git:packs",
+	}})
+	if !st.IsRemovedByUser("git:https://example.com/acme/skills.git:packs", "recap") {
+		t.Fatal("IsRemovedByUser(source key) = false, want true")
+	}
+	if !st.ClearRemovedByUser("recap", "git:https://example.com/acme/skills.git:packs") {
+		t.Fatal("ClearRemovedByUser(source key) = false, want true")
+	}
+	if st.IsRemovedByUser("git:https://example.com/acme/skills.git:packs", "recap") {
+		t.Fatal("source-key removal remained after clear")
 	}
 }
 

--- a/internal/sync/compare.go
+++ b/internal/sync/compare.go
@@ -71,7 +71,8 @@ func compareEntry(entry manifest.Entry, installed *state.InstalledSkill, latestS
 
 func findSourceForRegistry(installed *state.InstalledSkill, registryRepo string) *state.SkillSource {
 	for i := range installed.Sources {
-		if installed.Sources[i].Registry == registryRepo {
+		src := &installed.Sources[i]
+		if src.IdentityKey() == registryRepo || src.Registry == registryRepo {
 			return &installed.Sources[i]
 		}
 	}

--- a/internal/sync/compare_test.go
+++ b/internal/sync/compare_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 )
 
@@ -77,6 +78,24 @@ func TestCompareEntrySourceLookup(t *testing.T) {
 	got := compareEntry(entry("github:a/b@v1.0.0"), inst, "", "a/b", false)
 	if got != StatusMissing {
 		t.Errorf("got %s, want %s", got, StatusMissing)
+	}
+}
+
+func TestCompareEntrySourceKeyLookup(t *testing.T) {
+	spec := source.SourceSpec{Type: source.SourceGit, URL: "https://example.com/acme/skills.git", Ref: "main", Path: "packs"}
+	inst := &state.InstalledSkill{
+		Revision: 1,
+		Sources: []state.SkillSource{{
+			Registry:  "legacy-display",
+			SourceKey: "git:https://example.com/acme/skills.git:packs",
+			Source:    &spec,
+			Ref:       "main",
+			LastSHA:   "abc123",
+		}},
+	}
+	got := compareEntry(entry("github:a/b@main"), inst, "abc123", "git:https://example.com/acme/skills.git:packs", false)
+	if got != StatusCurrent {
+		t.Errorf("got %s, want %s", got, StatusCurrent)
 	}
 }
 

--- a/internal/sync/events.go
+++ b/internal/sync/events.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Naoray/scribe/internal/lockfile"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/reconcile"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 )
 
@@ -52,6 +53,10 @@ type SkillStatus struct {
 	LatestSHA  string // resolved SHA for branch-pinned skills; empty if unavailable
 	BlobSHAs   map[string]string
 	LockEntry  *lockfile.Entry
+
+	SourceKey   string
+	Source      *source.SourceSpec
+	ResolvedRev string
 }
 
 // DisplayVersion returns the best human-readable version for this skill.

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -449,15 +449,36 @@ func (s *Syncer) RunProject(ctx context.Context, st *state.State, lf *lockfile.P
 		}
 		statuses = filtered
 	}
+	type projectSourceGroup struct {
+		registry string
+		spec     *source.SourceSpec
+	}
 	byRegistry := map[string][]SkillStatus{}
+	groups := map[string]projectSourceGroup{}
 	for _, status := range statuses {
 		registry := ""
 		if status.LockEntry != nil {
 			registry = status.LockEntry.SourceRegistry
 		}
+		if status.SourceKey != "" {
+			registry = status.SourceKey
+		}
 		byRegistry[registry] = append(byRegistry[registry], status)
+		if _, ok := groups[registry]; !ok {
+			groups[registry] = projectSourceGroup{
+				registry: registry,
+				spec:     cloneSourceSpecPtrValue(status.Source),
+			}
+		}
 	}
 	for registry, group := range byRegistry {
+		sourceGroup := groups[registry]
+		if sourceGroup.spec != nil {
+			if err := s.applySource(ctx, sourceGroup.registry, sourceGroup.spec, group, st); err != nil {
+				return err
+			}
+			continue
+		}
 		if err := s.apply(ctx, registry, group, st); err != nil {
 			return err
 		}
@@ -542,6 +563,35 @@ func (s *Syncer) projectLockStatuses(lf *lockfile.ProjectLockfile, st *state.Sta
 }
 
 func manifestEntryFromProjectEntry(pin lockfile.ProjectEntry) (manifest.Entry, error) {
+	if pin.Source != nil {
+		entry := manifest.Entry{
+			Name:     pin.Name,
+			Path:     pin.Path,
+			Type:     pin.Type,
+			Install:  pin.Install,
+			Update:   pin.Update,
+			Installs: pin.Installs,
+			Updates:  pin.Updates,
+		}
+		spec, _, err := source.Canonicalize(*pin.Source)
+		if err != nil {
+			return manifest.Entry{}, err
+		}
+		if spec.Type == source.SourceGitHub {
+			ref := pin.CommitSHA
+			if ref == "" {
+				ref = spec.Ref
+			}
+			parts := strings.SplitN(spec.Repo, "/", 2)
+			entry.Source = manifest.Source{
+				Host:  "github",
+				Owner: parts[0],
+				Repo:  parts[1],
+				Ref:   ref,
+			}.String()
+		}
+		return entry, nil
+	}
 	repo := pin.SourceRepo
 	if repo == "" {
 		repo = pin.SourceRegistry

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -207,10 +207,11 @@ func (s *Syncer) Diff(ctx context.Context, teamRepo string, st *state.State) ([]
 // DiffSource fetches a SourceSpec-backed registry and computes status for each skill.
 // registryKey is the legacy/display identity used in state and JSON during phase 2.
 func (s *Syncer) DiffSource(ctx context.Context, registryKey string, spec source.SourceSpec, st *state.State) ([]SkillStatus, *manifest.Manifest, error) {
-	spec, err := source.CanonicalSpec(spec)
+	spec, ident, err := source.Canonicalize(spec)
 	if err != nil {
 		return nil, nil, err
 	}
+	compareKey := sourceComparisonKey(registryKey, spec, ident)
 	m, err := s.FetchManifestSource(ctx, spec)
 	if err != nil {
 		return nil, nil, fmt.Errorf("parse loadout: %w", err)
@@ -290,17 +291,21 @@ func (s *Syncer) DiffSource(ctx context.Context, registryKey string, spec source
 			}
 		}
 
-		status := compareEntry(entry, installedPtr, latestSHA, registryKey, locallyModified)
+		status := compareEntry(entry, installedPtr, latestSHA, compareKey, locallyModified)
+		resolvedRev := latestSHA
 		statuses = append(statuses, SkillStatus{
-			Name:       entry.Name,
-			Status:     status,
-			Installed:  installedPtr,
-			Entry:      &entry,
-			LoadoutRef: loadoutRef(entry),
-			Maintainer: entry.Maintainer(),
-			IsPackage:  entry.IsPackage(),
-			LatestSHA:  latestSHA,
-			BlobSHAs:   blobSHAs,
+			Name:        entry.Name,
+			Status:      status,
+			Installed:   installedPtr,
+			Entry:       &entry,
+			LoadoutRef:  loadoutRef(entry),
+			Maintainer:  entry.Maintainer(),
+			IsPackage:   entry.IsPackage(),
+			LatestSHA:   latestSHA,
+			BlobSHAs:    blobSHAs,
+			SourceKey:   ident.Key,
+			Source:      cloneSourceSpecPtr(spec),
+			ResolvedRev: resolvedRev,
 		})
 	}
 
@@ -315,9 +320,9 @@ func (s *Syncer) DiffSource(ctx context.Context, registryKey string, spec source
 		if catalogNames[name] {
 			continue // already accounted for above
 		}
-		// Check if any source matches this registry.
+		// Check if any source matches this registry/source identity.
 		for _, src := range skill.Sources {
-			if src.Registry == registryKey {
+			if src.IdentityKey() == compareKey || src.Registry == registryKey {
 				extraNames = append(extraNames, name)
 				break
 			}
@@ -490,8 +495,12 @@ func (s *Syncer) projectLockStatuses(lf *lockfile.ProjectLockfile, st *state.Sta
 		if installed != nil {
 			status = StatusCurrent
 			sourceCurrent := false
+			sourceKey := pin.SourceKey
+			if sourceKey == "" {
+				sourceKey = pin.SourceRegistry
+			}
 			for _, src := range installed.Sources {
-				if src.Registry == pin.SourceRegistry && src.LastSHA == pin.CommitSHA {
+				if (src.IdentityKey() == sourceKey || src.Registry == pin.SourceRegistry) && src.LastSHA == pin.CommitSHA {
 					sourceCurrent = true
 					break
 				}
@@ -512,15 +521,18 @@ func (s *Syncer) projectLockStatuses(lf *lockfile.ProjectLockfile, st *state.Sta
 		}
 		lockEntry := pin.Entry
 		statuses = append(statuses, SkillStatus{
-			Name:       pin.Name,
-			Status:     status,
-			Installed:  installed,
-			Entry:      &entry,
-			LoadoutRef: loadoutRef(entry),
-			Maintainer: entry.Maintainer(),
-			IsPackage:  entry.IsPackage(),
-			LatestSHA:  latestSHA,
-			LockEntry:  &lockEntry,
+			Name:        pin.Name,
+			Status:      status,
+			Installed:   installed,
+			Entry:       &entry,
+			LoadoutRef:  loadoutRef(entry),
+			Maintainer:  entry.Maintainer(),
+			IsPackage:   entry.IsPackage(),
+			LatestSHA:   latestSHA,
+			LockEntry:   &lockEntry,
+			SourceKey:   pin.SourceKey,
+			Source:      cloneSourceSpecPtrValue(pin.Source),
+			ResolvedRev: pin.ResolvedRev,
 		})
 	}
 	if len(refused) > 0 {
@@ -740,6 +752,9 @@ func (s *Syncer) apply(ctx context.Context, teamRepo string, statuses []SkillSta
 }
 
 func (s *Syncer) applySource(ctx context.Context, teamRepo string, spec *source.SourceSpec, statuses []SkillStatus, st *state.State) error {
+	for i := range statuses {
+		populateStatusSourceIdentity(&statuses[i], spec)
+	}
 	// Emit resolved status for each skill (populates list view before downloads start).
 	for _, sk := range statuses {
 		s.emit(SkillResolvedMsg{sk})
@@ -770,8 +785,9 @@ func (s *Syncer) applySource(ctx context.Context, teamRepo string, spec *source.
 			fallthrough
 
 		case StatusMissing, StatusOutdated:
-			if st.IsRemovedByUser(teamRepo, sk.Name) {
-				s.emit(SkillSkippedByDenyListMsg{Name: sk.Name, Registry: teamRepo})
+			denyKey := statusSourceKey(teamRepo, sk)
+			if st.IsRemovedByUser(denyKey, sk.Name) {
+				s.emit(SkillSkippedByDenyListMsg{Name: sk.Name, Registry: denyKey})
 				summary.Skipped++
 				continue
 			}
@@ -1041,7 +1057,7 @@ func (s *Syncer) applySource(ctx context.Context, teamRepo string, spec *source.
 			}
 
 			// Build sources: merge with existing sources from other registries.
-			newSource := skillSourceFromEntry(teamRepo, sk.Entry, ref, sk.LatestSHA, sk.BlobSHAs)
+			newSource := skillSourceFromStatus(teamRepo, sk, ref)
 			sources := mergeSources(installed, newSource)
 
 			// Preserve pinned ToolsMode across re-syncs. New skills default to
@@ -1636,7 +1652,7 @@ func (s *Syncer) applyPackage(ctx context.Context, sk SkillStatus, teamRepo stri
 		}
 
 		installed := lookupInstalled(st, stateName)
-		newSource := skillSourceFromEntry(teamRepo, sk.Entry, ref, sk.LatestSHA, sk.BlobSHAs)
+		newSource := skillSourceFromStatus(teamRepo, sk, ref)
 
 		st.RecordInstall(stateName, state.InstalledSkill{
 			Revision:   nextRevision(installed),
@@ -1708,12 +1724,7 @@ func (s *Syncer) applyPackage(ctx context.Context, sk SkillStatus, teamRepo stri
 		if parseErr == nil {
 			ref = src.Ref
 		}
-		newSource := state.SkillSource{
-			Registry:   teamRepo,
-			Ref:        ref,
-			LastSHA:    sk.LatestSHA,
-			LastSynced: time.Now().UTC(),
-		}
+		newSource := skillSourceFromStatus(teamRepo, sk, ref)
 		existing.Sources = mergeSources(&existing, newSource)
 		existing.InstallCmd = sk.Entry.Install
 		existing.UpdateCmd = sk.Entry.Update
@@ -1812,7 +1823,7 @@ func mergeSources(installed *state.InstalledSkill, newSource state.SkillSource) 
 	sources := make([]state.SkillSource, 0, len(installed.Sources)+1)
 	found := false
 	for _, s := range installed.Sources {
-		if s.Registry == newSource.Registry {
+		if s.IdentityKey() == newSource.IdentityKey() || s.Registry == newSource.Registry {
 			sources = append(sources, newSource)
 			found = true
 		} else {
@@ -1823,6 +1834,20 @@ func mergeSources(installed *state.InstalledSkill, newSource state.SkillSource) 
 		sources = append(sources, newSource)
 	}
 	return sources
+}
+
+func skillSourceFromStatus(teamRepo string, sk SkillStatus, ref string) state.SkillSource {
+	src := skillSourceFromEntry(teamRepo, sk.Entry, ref, sk.LatestSHA, sk.BlobSHAs)
+	src.SourceKey = sk.SourceKey
+	src.Source = cloneSourceSpecPtrValue(sk.Source)
+	src.ResolvedRev = sk.ResolvedRev
+	if src.ResolvedRev == "" {
+		src.ResolvedRev = sk.LatestSHA
+	}
+	if src.SourceKey != "" && src.Registry == "" {
+		src.Registry = src.SourceKey
+	}
+	return src
 }
 
 func skillSourceFromEntry(teamRepo string, entry *manifest.Entry, ref, lastSHA string, blobSHAs map[string]string) state.SkillSource {
@@ -1848,6 +1873,54 @@ func skillSourceFromEntry(teamRepo string, entry *manifest.Entry, ref, lastSHA s
 		}
 	}
 	return source
+}
+
+func populateStatusSourceIdentity(sk *SkillStatus, spec *source.SourceSpec) {
+	if sk == nil || spec == nil {
+		return
+	}
+	canonical, ident, err := source.Canonicalize(*spec)
+	if err != nil {
+		return
+	}
+	if sk.SourceKey == "" {
+		sk.SourceKey = ident.Key
+	}
+	if sk.Source == nil {
+		sk.Source = cloneSourceSpecPtr(canonical)
+	}
+	if sk.ResolvedRev == "" {
+		sk.ResolvedRev = sk.LatestSHA
+	}
+}
+
+func sourceComparisonKey(registryKey string, spec source.SourceSpec, ident source.SourceIdentity) string {
+	if spec.Type == source.SourceGitHub {
+		return registryKey
+	}
+	if ident.Key != "" {
+		return ident.Key
+	}
+	return registryKey
+}
+
+func statusSourceKey(teamRepo string, sk SkillStatus) string {
+	if sk.SourceKey != "" {
+		return sk.SourceKey
+	}
+	return teamRepo
+}
+
+func cloneSourceSpecPtr(spec source.SourceSpec) *source.SourceSpec {
+	return &spec
+}
+
+func cloneSourceSpecPtrValue(spec *source.SourceSpec) *source.SourceSpec {
+	if spec == nil {
+		return nil
+	}
+	cp := *spec
+	return &cp
 }
 
 func cloneBlobSHAs(blobSHAs map[string]string) map[string]string {
@@ -1880,7 +1953,7 @@ func (s *Syncer) updateSourceEntry(st *state.State, skillName, teamRepo string, 
 	if parseErr == nil {
 		ref = src.Ref
 	}
-	newSource := skillSourceFromEntry(teamRepo, sk.Entry, ref, sk.LatestSHA, sk.BlobSHAs)
+	newSource := skillSourceFromStatus(teamRepo, sk, ref)
 
 	existing := st.Installed[skillName]
 	existing.Sources = mergeSources(installed, newSource)
@@ -1950,7 +2023,7 @@ func (s *Syncer) applyTreePackage(ctx context.Context, sk SkillStatus, teamRepo 
 	// projects them into tool skill dirs — the package ran its own install
 	// and anything it needs now lives wherever that script decided.
 	src, _ := manifest.ParseSource(entrySource(sk.Entry))
-	newSource := skillSourceFromEntry(teamRepo, sk.Entry, src.Ref, sk.LatestSHA, sk.BlobSHAs)
+	newSource := skillSourceFromStatus(teamRepo, sk, src.Ref)
 
 	st.RecordInstall(sk.Name, state.InstalledSkill{
 		Revision:   nextRevision(installed),

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -237,6 +237,67 @@ func TestRunProject_FetchesPinnedRegistryEntry(t *testing.T) {
 	}
 }
 
+func TestRunProject_ConsumesStructuredNonOwnerLockSource(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	projectRoot := t.TempDir()
+	files := []tools.SkillFile{{Path: "SKILL.md", Content: []byte("# deploy\n")}}
+	contentHash, err := sync.HashInstallableFiles(files)
+	if err != nil {
+		t.Fatalf("HashInstallableFiles: %v", err)
+	}
+	spec := source.SourceSpec{
+		Type: source.SourceGit,
+		URL:  "https://example.com/acme/skills.git",
+		Ref:  "main",
+		Path: "packs",
+	}
+	_, ident, err := source.Canonicalize(spec)
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	prov := &mockProvider{files: files}
+	syncer := &sync.Syncer{
+		Provider:    prov,
+		Tools:       []tools.Tool{tools.ClaudeTool{}},
+		ProjectRoot: projectRoot,
+	}
+	st := &state.State{Installed: map[string]state.InstalledSkill{}}
+	lf := &lockfile.ProjectLockfile{
+		FormatVersion: lockfile.SchemaVersion,
+		Kind:          lockfile.ProjectKind,
+		Entries: []lockfile.ProjectEntry{{
+			Entry: lockfile.Entry{
+				Name:           "deploy",
+				SourceRegistry: ident.Key,
+				SourceKey:      ident.Key,
+				Source:         &spec,
+				CommitSHA:      "abc123",
+				ContentHash:    contentHash,
+			},
+			Path: "skills/deploy",
+			Type: "skill",
+		}},
+	}
+
+	if err := syncer.RunProject(context.Background(), st, lf); err != nil {
+		t.Fatalf("RunProject: %v", err)
+	}
+	if len(prov.fetchedSpecs) != 1 {
+		t.Fatalf("fetched specs = %#v", prov.fetchedSpecs)
+	}
+	if prov.fetchedSpecs[0].URL != "https://example.com/acme/skills.git" || prov.fetchedSpecs[0].Path != "packs" {
+		t.Fatalf("fetched spec = %#v", prov.fetchedSpecs[0])
+	}
+	installed := st.Installed["deploy"]
+	if len(installed.Sources) != 1 || installed.Sources[0].SourceKey != ident.Key || installed.Sources[0].Source == nil {
+		t.Fatalf("Sources = %#v", installed.Sources)
+	}
+	if _, err := os.Lstat(filepath.Join(projectRoot, ".claude", "skills", "deploy")); err != nil {
+		t.Fatalf("Claude projection missing: %v", err)
+	}
+}
+
 func TestRunProject_KitFilterLimitsLockfilePins(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/workflow/sync.go
+++ b/internal/workflow/sync.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"charm.land/huh/v2"
 	"github.com/BurntSushi/toml"
@@ -30,6 +31,7 @@ import (
 	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/reconcile"
 	"github.com/Naoray/scribe/internal/snippet"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/sync"
 	"github.com/Naoray/scribe/internal/tools"
@@ -977,7 +979,7 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 		if err != nil {
 			return err
 		}
-		if err := validateProjectRegistriesConnected(projectLock, b.Config.TeamRepos()); err != nil {
+		if err := validateProjectRegistriesConnected(projectLock, b.Config.EnabledSources()); err != nil {
 			return err
 		}
 		clear(resolved)
@@ -1013,18 +1015,21 @@ func StepSyncSkills(ctx context.Context, b *Bag) error {
 	return nil
 }
 
-func validateProjectRegistriesConnected(lf *lockfile.ProjectLockfile, connected []string) error {
+func validateProjectRegistriesConnected(lf *lockfile.ProjectLockfile, connected []config.RegistrySource) error {
 	if lf == nil {
 		return nil
 	}
 	set := map[string]bool{}
-	for _, repo := range connected {
-		set[repo] = true
+	for _, src := range connected {
+		for _, key := range connectedSourceKeys(src) {
+			set[key] = true
+		}
 	}
 	for _, entry := range lf.Entries {
-		if !set[entry.SourceRegistry] {
-			return clierrors.Wrap(fmt.Errorf("registry %q is not connected", entry.SourceRegistry), "PROJECT_REGISTRY_NOT_CONNECTED", clierrors.ExitPerm,
-				clierrors.WithRemediation("Run `scribe registry connect "+entry.SourceRegistry+"` before `scribe sync`."),
+		key := projectEntryConnectedKey(entry)
+		if !set[key] {
+			return clierrors.Wrap(fmt.Errorf("registry %q is not connected", key), "PROJECT_REGISTRY_NOT_CONNECTED", clierrors.ExitPerm,
+				clierrors.WithRemediation("Run `scribe registry connect "+key+"` before `scribe sync`."),
 			)
 		}
 	}
@@ -1036,6 +1041,36 @@ func validateProjectRegistriesConnected(lf *lockfile.ProjectLockfile, connected 
 		}
 	}
 	return nil
+}
+
+func connectedSourceKeys(src config.RegistrySource) []string {
+	keys := []string{}
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			keys = append(keys, value)
+		}
+	}
+	add(src.Config.Repo)
+	add(src.Config.ID)
+	add(src.ID)
+	add(src.Identity.Key)
+	add(src.Source.Repo)
+	add(src.Source.URL)
+	add(src.Source.Path)
+	return keys
+}
+
+func projectEntryConnectedKey(entry lockfile.ProjectEntry) string {
+	if entry.Source != nil {
+		if _, ident, err := source.Canonicalize(*entry.Source); err == nil && ident.Key != "" {
+			return ident.Key
+		}
+	}
+	if strings.TrimSpace(entry.SourceKey) != "" {
+		return entry.SourceKey
+	}
+	return entry.SourceRegistry
 }
 
 func workflowSkipMissing(b *Bag) bool {

--- a/internal/workflow/sync_test.go
+++ b/internal/workflow/sync_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Naoray/scribe/internal/lockfile"
 	"github.com/Naoray/scribe/internal/projectfile"
 	"github.com/Naoray/scribe/internal/projectstore"
+	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/tools"
 )
@@ -88,12 +89,57 @@ func TestValidateProjectRegistriesConnectedChecksKitPins(t *testing.T) {
 			ContentHash:    "hash",
 		}},
 	}
-	err := validateProjectRegistriesConnected(lf, []string{"other/skills"})
+	connected := []config.RegistrySource{{
+		Config: config.RegistryConfig{Repo: "other/skills"},
+		Source: source.SourceSpec{
+			Type: source.SourceGitHub,
+			Repo: "other/skills",
+		},
+		Identity: source.SourceIdentity{Key: "github:other/skills"},
+	}}
+	err := validateProjectRegistriesConnected(lf, connected)
 	if err == nil {
 		t.Fatal("expected missing registry error")
 	}
 	if !strings.Contains(err.Error(), `registry "acme/skills" is not connected`) {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestValidateProjectRegistriesConnectedAcceptsStructuredSourceKey(t *testing.T) {
+	spec := source.SourceSpec{
+		Type: source.SourceGit,
+		URL:  "https://example.com/acme/skills.git",
+		Ref:  "main",
+		Path: "packs",
+	}
+	_, ident, err := source.Canonicalize(spec)
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	lf := &lockfile.ProjectLockfile{
+		FormatVersion: lockfile.SchemaVersion,
+		Kind:          lockfile.ProjectKind,
+		Entries: []lockfile.ProjectEntry{{
+			Entry: lockfile.Entry{
+				Name:           "deploy",
+				SourceRegistry: ident.Key,
+				SourceKey:      ident.Key,
+				Source:         &spec,
+				CommitSHA:      "abc123",
+				ContentHash:    "hash",
+			},
+			Path: "skills/deploy",
+		}},
+	}
+	connected := []config.RegistrySource{{
+		Config:   config.RegistryConfig{Source: &spec, Enabled: true},
+		Source:   spec,
+		Identity: ident,
+	}}
+
+	if err := validateProjectRegistriesConnected(lf, connected); err != nil {
+		t.Fatalf("validateProjectRegistriesConnected: %v", err)
 	}
 }
 


### PR DESCRIPTION
Adds SourceSpec phase 4 state/lockfile identity without removing legacy fields. New installs and project lock writes now carry source_key, structured source, and resolved_rev where source info exists, while source_registry/registry stay populated for old readers.

Also switches source matching paths that can see typed source identity to compare by source key for non-GitHub sources: diff/update matching, extra detection, removed-by-user checks, and project lock matching. Legacy owner/repo matching remains the fallback.

Tests:
- go test ./internal/state ./internal/lockfile ./internal/sync ./internal/workflow ./cmd
- go test ./...