### PR TITLE
test: cover snippet sync and budget guardrails

### DIFF
--- a/cmd/budget_helpers_test.go
+++ b/cmd/budget_helpers_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Naoray/scribe/internal/app"
 	"github.com/Naoray/scribe/internal/budget"
+	"github.com/Naoray/scribe/internal/config"
 	"github.com/Naoray/scribe/internal/state"
 )
 
@@ -163,6 +165,75 @@ func TestProjectBudgetIncludesTargetedSnippets(t *testing.T) {
 	}
 	if codex.has("snippet:commit-discipline") {
 		t.Fatalf("codex budget included claude-only snippet: %#v", codex)
+	}
+}
+
+func TestEnforceCurrentBudgetReportsOverflowContributors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wd := t.TempDir()
+	t.Chdir(wd)
+
+	writeBudgetSkill(t, home, "huge-alpha", longBudgetSkillContent("huge-alpha", 4000))
+	writeBudgetSkill(t, home, "huge-beta", longBudgetSkillContent("huge-beta", 1800))
+	writeBudgetKit(t, home, "over-budget", []string{"huge-alpha", "huge-beta"})
+	if err := os.WriteFile(filepath.Join(wd, ".scribe.yaml"), []byte("kits:\n - over-budget\n"), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+
+	factory := budgetTestFactory(&state.State{Installed: map[string]state.InstalledSkill{
+		"huge-alpha": {Tools: []string{"codex"}},
+		"huge-beta":  {Tools: []string{"codex"}},
+	}})
+	err := enforceCurrentBudget(factory, false)
+	if err == nil {
+		t.Fatal("enforceCurrentBudget returned nil, want budget refusal")
+	}
+	got := err.Error()
+	for _, want := range []string{
+		"Codex skill budget exceeded",
+		"estimated: 5800 / 5440 bytes",
+		"biggest contributors:",
+		"huge-alpha: 4000 bytes",
+		"huge-beta: 1800 bytes",
+		"rerun with --force",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestEnforceCurrentBudgetForceBypassesRefusal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wd := t.TempDir()
+	t.Chdir(wd)
+
+	writeBudgetSkill(t, home, "huge-alpha", longBudgetSkillContent("huge-alpha", 4000))
+	writeBudgetSkill(t, home, "huge-beta", longBudgetSkillContent("huge-beta", 1800))
+	writeBudgetKit(t, home, "over-budget", []string{"huge-alpha", "huge-beta"})
+	if err := os.WriteFile(filepath.Join(wd, ".scribe.yaml"), []byte("kits:\n - over-budget\n"), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+
+	factory := budgetTestFactory(&state.State{Installed: map[string]state.InstalledSkill{
+		"huge-alpha": {Tools: []string{"codex"}},
+		"huge-beta":  {Tools: []string{"codex"}},
+	}})
+	if err := enforceCurrentBudget(factory, true); err != nil {
+		t.Fatalf("enforceCurrentBudget(force=true): %v", err)
+	}
+}
+
+func budgetTestFactory(st *state.State) *app.Factory {
+	return &app.Factory{
+		Config: func() (*config.Config, error) {
+			return &config.Config{}, nil
+		},
+		State: func() (*state.State, error) {
+			return st, nil
+		},
 	}
 }
 

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -58,6 +58,25 @@ func TestEstimateDescriptionBytes(t *testing.T) {
 	}
 }
 
+func TestEstimateDescriptionBytesTracksRenderedDescriptionWithinTolerance(t *testing.T) {
+	description := "Short summary for the agent."
+	firstParagraph := "First paragraph spans two lines and is what Codex lists."
+	content := "---\n" +
+		"name: rendered\n" +
+		"description: " + description + "\n" +
+		"---\n\n" +
+		"First paragraph spans two lines\n" +
+		"and is what Codex lists.\n\n" +
+		"Second paragraph is full instructions and should not be counted.\n"
+
+	got := EstimateDescriptionBytes(Skill{Name: "rendered", Content: []byte(content)})
+	realBytes := len([]byte(description + "\n\n" + firstParagraph))
+	tolerance := 2
+	if got < realBytes-tolerance || got > realBytes+tolerance {
+		t.Fatalf("EstimateDescriptionBytes() = %d, want within %d bytes of rendered %d", got, tolerance, realBytes)
+	}
+}
+
 func TestCheckBudgetThresholdBoundaries(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/snippet/snippet_test.go
+++ b/internal/snippet/snippet_test.go
@@ -113,7 +113,14 @@ func TestProjectUpdatesExistingBlockWhenHashChanges(t *testing.T) {
 
 func TestProjectPreservesUserContentAroundManagedBlocks(t *testing.T) {
 	project := t.TempDir()
-	existing := "top\n<!-- scribe:start name=old hash=abc -->\nold\n<!-- scribe:end name=old -->\nbetween\n<!-- scribe:start name=keep hash=abc -->\nstale\n<!-- scribe:end name=keep -->\nbottom\n"
+	above := "top: user bytes stay exactly\n\n"
+	between := "between: keep spacing\tand punctuation!\n\n"
+	below := "bottom: no rewrite\n"
+	existing := above +
+		"<!-- scribe:start name=old hash=abc -->\nold\n<!-- scribe:end name=old -->\n" +
+		between +
+		"<!-- scribe:start name=keep hash=abc -->\nstale\n<!-- scribe:end name=keep -->\n" +
+		below
 	if err := os.WriteFile(filepath.Join(project, "AGENTS.md"), []byte(existing), 0o644); err != nil {
 		t.Fatalf("write AGENTS.md: %v", err)
 	}
@@ -126,10 +133,13 @@ func TestProjectPreservesUserContentAroundManagedBlocks(t *testing.T) {
 		t.Fatalf("read AGENTS.md: %v", err)
 	}
 	got := string(data)
-	for _, want := range []string{"top\n", "\nbetween\n", "\nbottom\n"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("user content %q not preserved byte-for-byte:\n%s", want, got)
-		}
+	managedStart := strings.Index(got, "<!-- scribe:start name=keep hash=")
+	if managedStart < 0 {
+		t.Fatalf("updated managed block missing:\n%s", got)
+	}
+	unmanaged := got[:managedStart]
+	if unmanaged != above+between+below+"\n" {
+		t.Fatalf("unmanaged content changed\n got: %q\nwant: %q", unmanaged, above+between+below+"\n")
 	}
 	if strings.Contains(got, "old\n") || strings.Contains(got, "stale\n") || !strings.Contains(got, "fresh\n") {
 		t.Fatalf("managed block content mismatch:\n%s", got)


### PR DESCRIPTION
Adds focused regression coverage for todo #382. Snippet tests now assert exact unmanaged byte preservation while replacing stale managed blocks, and budget tests cover estimator sizing, overflow contributor output, and force bypass behavior.

Tests:
- go test ./internal/snippet ./internal/budget ./cmd
- go test ./...