### PR TITLE
Add local and git source providers

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -132,7 +132,8 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		if err := runAddDirectInstallSourceForCommand(cmd, ctx, display, ident.Key, spec, args[0], cfg, st, syncer, client.IsAuthenticated(), useJSON, skipConfirm, resync); err != nil {
+		authenticated := client.IsAuthenticated() || !requiresSourceGitHubAuth(spec)
+		if err := runAddDirectInstallSourceForCommand(cmd, ctx, display, ident.Key, spec, args[0], cfg, st, syncer, authenticated, useJSON, skipConfirm, resync); err != nil {
 			return handleNameConflictError(cmd, err)
 		}
 		return nil
@@ -144,7 +145,8 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		if err := runAddDirectInstallSourceForCommand(cmd, ctx, display, ident.Key, spec, skillName, cfg, st, syncer, client.IsAuthenticated(), useJSON, skipConfirm, resync); err != nil {
+		authenticated := client.IsAuthenticated() || !requiresSourceGitHubAuth(spec)
+		if err := runAddDirectInstallSourceForCommand(cmd, ctx, display, ident.Key, spec, skillName, cfg, st, syncer, authenticated, useJSON, skipConfirm, resync); err != nil {
 			return handleNameConflictError(cmd, err)
 		}
 		return nil
@@ -154,7 +156,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	if len(cfg.EnabledSources()) == 0 {
 		return fmt.Errorf("no registries connected — run: scribe connect <owner/repo>")
 	}
-	if !client.IsAuthenticated() {
+	if requiresGitHubAuth(cfg.EnabledSources()) && !client.IsAuthenticated() {
 		return clierrors.Wrap(
 			fmt.Errorf("authentication required"),
 			"GH_AUTH_FAILED",
@@ -435,6 +437,19 @@ func isLegacyGitHubSource(spec source.SourceSpec) bool {
 	return spec.Type == source.SourceGitHub && spec.Path == "" && spec.Ref == ""
 }
 
+func requiresSourceGitHubAuth(spec source.SourceSpec) bool {
+	return spec.Type == source.SourceGitHub
+}
+
+func requiresGitHubAuth(sources []config.RegistrySource) bool {
+	for _, src := range sources {
+		if requiresSourceGitHubAuth(src.Source) {
+			return true
+		}
+	}
+	return false
+}
+
 // installSelected installs the user-selected entries from the browser. Each
 // entry may belong to a different registry; auto-connects as needed.
 func installSelected(
@@ -548,7 +563,7 @@ func newInstallSyncer(client *gh.Client, targets []tools.Tool, forceBudgetOpt ..
 func newInstallSyncerWithOptions(client *gh.Client, targets []tools.Tool, forceBudget bool, aliasName string) *sync.Syncer {
 	return &sync.Syncer{
 		Client:      sync.WrapGitHubClient(client),
-		Provider:    provider.NewGitHubProvider(provider.WrapGitHubClient(client)),
+		Provider:    provider.NewCompositeProvider(provider.NewGitHubProvider(provider.WrapGitHubClient(client))),
 		Tools:       targets,
 		Executor:    &sync.ShellExecutor{},
 		ProjectRoot: resolveCurrentProjectRoot(),
@@ -628,7 +643,7 @@ func discoverEntries(
 ) ([]browseEntry, []error) {
 	syncer := &sync.Syncer{
 		Client:   sync.WrapGitHubClient(client),
-		Provider: provider.NewGitHubProvider(provider.WrapGitHubClient(client)),
+		Provider: provider.NewCompositeProvider(provider.NewGitHubProvider(provider.WrapGitHubClient(client))),
 		Tools:    targets,
 	}
 
@@ -660,7 +675,7 @@ func discoverSourceEntries(
 ) ([]browseEntry, []error) {
 	syncer := &sync.Syncer{
 		Client:   sync.WrapGitHubClient(client),
-		Provider: provider.NewGitHubProvider(provider.WrapGitHubClient(client)),
+		Provider: provider.NewCompositeProvider(provider.NewGitHubProvider(provider.WrapGitHubClient(client))),
 		Tools:    targets,
 	}
 

--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -76,10 +76,18 @@ func runBrowse(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("resolve active tools: %w", err)
 	}
 
-	sourceFilter := sourceFlags.source
-	sources, err := browseSources(sourceFilter, cfg)
-	if err != nil {
-		return err
+	var sources []config.RegistrySource
+	if sourceFlags.hasTyped() && !sourceFlagsMatchConnectedSource(sourceFlags, cfg) {
+		spec, ident, display, err := sourceSpecFromFlags(sourceFlags)
+		if err != nil {
+			return err
+		}
+		sources = []config.RegistrySource{{ID: display, Source: spec, Identity: ident}}
+	} else {
+		sources, err = browseSources(sourceFlags.source, cfg)
+		if err != nil {
+			return err
+		}
 	}
 	repos := legacyReposFromSources(sources)
 
@@ -354,7 +362,8 @@ func browseInstall(
 		if err != nil {
 			return err
 		}
-		return runAddDirectInstallSourceForCommand(nil, ctx, display, ident.Key, spec, skillName, cfg, st, newInstallSyncer(client, targets), client.IsAuthenticated(), useJSON, skipConfirm, resync)
+		authenticated := client.IsAuthenticated() || !requiresSourceGitHubAuth(spec)
+		return runAddDirectInstallSourceForCommand(nil, ctx, display, ident.Key, spec, skillName, cfg, st, newInstallSyncer(client, targets), authenticated, useJSON, skipConfirm, resync)
 	}
 
 	var matches []browseEntry
@@ -380,7 +389,8 @@ func browseInstall(
 
 	match := matches[0]
 	if match.SourceKey != "" {
-		return runAddDirectInstallSourceForCommand(nil, ctx, match.Registry, match.SourceKey, match.Source, match.Status.Name, cfg, st, newInstallSyncer(client, targets), client.IsAuthenticated(), useJSON, skipConfirm, resync)
+		authenticated := client.IsAuthenticated() || !requiresSourceGitHubAuth(match.Source)
+		return runAddDirectInstallSourceForCommand(nil, ctx, match.Registry, match.SourceKey, match.Source, match.Status.Name, cfg, st, newInstallSyncer(client, targets), authenticated, useJSON, skipConfirm, resync)
 	}
 	return runAddDirectInstall(ctx, match.Registry, match.Status.Name, cfg, st, newInstallSyncer(client, targets), client.IsAuthenticated(), useJSON, skipConfirm, resync)
 }

--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -299,7 +299,7 @@ func runBrowseWithDeps(
 			Tools:            targets,
 			FilterRegistries: filterRegistries,
 		}
-		bag.Provider = provider.NewGitHubProvider(provider.WrapGitHubClient(client))
+		bag.Provider = provider.NewCompositeProvider(provider.NewGitHubProvider(provider.WrapGitHubClient(client)))
 		repos := legacyReposFromSources(sources)
 		if len(repos) == 1 {
 			bag.RepoFlag = repos[0]

--- a/cmd/browse_test.go
+++ b/cmd/browse_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -215,5 +216,38 @@ func TestBrowseInstallRejectsMissingName(t *testing.T) {
 	err := browseInstall(context.Background(), "cleanup", nil, nil, nil, nil, nil, true, true, false)
 	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Fatalf("browseInstall() error = %v, want not found error", err)
+	}
+}
+
+func TestDiscoverSourceEntriesReadsLocalProvider(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "skills", "deploy")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Deploy\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	spec, ident, err := source.Canonicalize(source.SourceSpec{Type: source.SourceLocal, Path: root})
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+
+	entries, errs := discoverSourceEntries(context.Background(), []config.RegistrySource{{
+		ID:       "local-fixture",
+		Source:   spec,
+		Identity: ident,
+	}}, nil, nil, &state.State{Installed: map[string]state.InstalledSkill{}})
+	if len(errs) != 0 {
+		t.Fatalf("errs = %#v", errs)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(entries))
+	}
+	if entries[0].Status.Name != "deploy" || entries[0].Status.Status != sync.StatusMissing {
+		t.Fatalf("entry = %#v", entries[0])
+	}
+	if entries[0].SourceKey != ident.Key || entries[0].Source.Type != source.SourceLocal {
+		t.Fatalf("source fields = %#v", entries[0])
 	}
 }

--- a/cmd/browse_test.go
+++ b/cmd/browse_test.go
@@ -196,6 +196,97 @@ func TestBrowseReposPrefersConnectedRegistryAlias(t *testing.T) {
 	}
 }
 
+func TestRunBrowseAcceptsTypedLocalSourceFlags(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := writeBrowseLocalSkill(t, "deploy")
+
+	stdout, stderr, err := executeBrowseCommand(t, "browse", "--source", "local", "--path", root, "--json")
+	if err != nil {
+		t.Fatalf("browse typed local: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+
+	var out struct {
+		Results []struct {
+			Name      string            `json:"name"`
+			SourceKey string            `json:"source_key"`
+			Source    source.SourceSpec `json:"source"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal browse json: %v\nstdout=%s", err, stdout)
+	}
+	if len(out.Results) != 1 || out.Results[0].Name != "deploy" {
+		t.Fatalf("results = %+v, want deploy", out.Results)
+	}
+	if out.Results[0].Source.Type != source.SourceLocal || out.Results[0].Source.Path != root || out.Results[0].SourceKey == "" {
+		t.Fatalf("source fields = %+v", out.Results[0])
+	}
+}
+
+func TestRunBrowseInstallLocalSourceDoesNotRequireGitHubAuth(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GITHUB_TOKEN", "")
+	root := writeBrowseLocalSkill(t, "deploy")
+
+	stdout, stderr, err := executeBrowseCommand(t, "browse", "--source", root, "--install", "deploy", "--json", "--no-interaction")
+	if err != nil {
+		if strings.Contains(err.Error(), "GH_AUTH_FAILED") || strings.Contains(stderr, "GH_AUTH_FAILED") {
+			t.Fatalf("browse install local source required GitHub auth: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+		}
+		t.Fatalf("browse install local source: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+
+	var out struct {
+		Installed []installResult `json:"installed"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal install json: %v\nstdout=%s", err, stdout)
+	}
+	if len(out.Installed) != 1 || out.Installed[0].Name != "deploy" || out.Installed[0].Status == "error" {
+		t.Fatalf("installed = %+v, want successful deploy install", out.Installed)
+	}
+}
+
+func writeBrowseLocalSkill(t *testing.T, name string) string {
+	t.Helper()
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "skills", name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# "+name+"\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	return root
+}
+
+func executeBrowseCommand(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	root := newRootCmd()
+	root.SetArgs(args)
+	var stderr bytes.Buffer
+	root.SetErr(&stderr)
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	execErr := root.Execute()
+	if closeErr := w.Close(); closeErr != nil && execErr == nil {
+		execErr = closeErr
+	}
+
+	var stdout bytes.Buffer
+	if _, err := stdout.ReadFrom(r); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return stdout.String(), stderr.String(), execErr
+}
+
 func TestNewBrowseCommandSupportsJSON(t *testing.T) {
 	if !commandSupportsJSON(newBrowseCommand()) {
 		t.Fatal("browse should be marked JSON-supported")

--- a/internal/app/factory.go
+++ b/internal/app/factory.go
@@ -36,7 +36,7 @@ func NewFactory() *Factory {
 		if err != nil {
 			return nil, err
 		}
-		return provider.NewGitHubProvider(provider.WrapGitHubClient(client)), nil
+		return provider.NewCompositeProvider(provider.NewGitHubProvider(provider.WrapGitHubClient(client))), nil
 	})
 
 	return f

--- a/internal/provider/composite.go
+++ b/internal/provider/composite.go
@@ -1,0 +1,69 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/source"
+)
+
+// CompositeProvider dispatches SourceSpec-aware calls to the matching backend.
+type CompositeProvider struct {
+	github *GitHubProvider
+	git    *GitProvider
+	local  *FilesystemProvider
+}
+
+func NewCompositeProvider(github *GitHubProvider) *CompositeProvider {
+	return &CompositeProvider{
+		github: github,
+		git:    NewGitProvider(),
+		local:  NewFilesystemProvider(),
+	}
+}
+
+func (p *CompositeProvider) Discover(ctx context.Context, repo string) (*DiscoverResult, error) {
+	spec, err := source.ParseSourceArg(repo)
+	if err != nil {
+		return nil, err
+	}
+	return p.DiscoverSource(ctx, spec)
+}
+
+func (p *CompositeProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]File, error) {
+	return p.github.Fetch(ctx, entry)
+}
+
+func (p *CompositeProvider) DiscoverSource(ctx context.Context, spec source.SourceSpec) (*DiscoverResult, error) {
+	backend, err := p.backend(spec)
+	if err != nil {
+		return nil, err
+	}
+	return backend.DiscoverSource(ctx, spec)
+}
+
+func (p *CompositeProvider) FetchSource(ctx context.Context, spec source.SourceSpec, entry manifest.Entry) ([]File, error) {
+	backend, err := p.backend(spec)
+	if err != nil {
+		return nil, err
+	}
+	return backend.FetchSource(ctx, spec, entry)
+}
+
+func (p *CompositeProvider) backend(spec source.SourceSpec) (SourceProvider, error) {
+	spec, err := source.CanonicalSpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	switch spec.Type {
+	case source.SourceGitHub:
+		return p.github, nil
+	case source.SourceGitLab, source.SourceGit:
+		return p.git, nil
+	case source.SourceLocal:
+		return p.local, nil
+	default:
+		return nil, fmt.Errorf("unsupported source type %q", spec.Type)
+	}
+}

--- a/internal/provider/filesystem.go
+++ b/internal/provider/filesystem.go
@@ -1,0 +1,233 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/migrate"
+	"github.com/Naoray/scribe/internal/source"
+)
+
+// FilesystemProvider discovers and fetches skills from a directory tree.
+type FilesystemProvider struct {
+	sourceName string
+	author     string
+}
+
+func NewFilesystemProvider() *FilesystemProvider {
+	return &FilesystemProvider{sourceName: "local", author: "local"}
+}
+
+func (p *FilesystemProvider) Discover(ctx context.Context, repo string) (*DiscoverResult, error) {
+	return p.DiscoverSource(ctx, source.SourceSpec{Type: source.SourceLocal, Path: repo})
+}
+
+func (p *FilesystemProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]File, error) {
+	return nil, fmt.Errorf("local fetch requires SourceSpec path")
+}
+
+func (p *FilesystemProvider) DiscoverSource(ctx context.Context, spec source.SourceSpec) (*DiscoverResult, error) {
+	root, sourceID, err := filesystemRoot(spec)
+	if err != nil {
+		return nil, err
+	}
+	return p.discoverRoot(ctx, root, sourceID)
+}
+
+func (p *FilesystemProvider) FetchSource(ctx context.Context, spec source.SourceSpec, entry manifest.Entry) ([]File, error) {
+	root, _, err := filesystemRoot(spec)
+	if err != nil {
+		return nil, err
+	}
+	skillPath := entry.Path
+	if skillPath == "" {
+		skillPath = entry.Name
+	}
+	fullPath, err := safeJoin(root, skillPath)
+	if err != nil {
+		return nil, err
+	}
+	return fetchPath(ctx, fullPath)
+}
+
+func (p *FilesystemProvider) discoverRoot(ctx context.Context, root, sourceID string) (*DiscoverResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if st, err := os.Stat(root); err != nil {
+		return nil, fmt.Errorf("open local source %s: %w", root, err)
+	} else if !st.IsDir() {
+		return nil, fmt.Errorf("local source %s is not a directory", root)
+	}
+
+	if m, err := readManifest(root, manifest.ManifestFilename); err == nil {
+		return &DiscoverResult{Entries: m.Catalog, IsTeam: true, Manifest: m}, nil
+	}
+	if m, err := readLegacyManifest(root); err == nil {
+		return &DiscoverResult{Entries: m.Catalog, IsTeam: true, Manifest: m}, nil
+	}
+	if entries, err := readMarketplace(root, p.author, sourceID); err == nil && len(entries) > 0 {
+		return &DiscoverResult{Entries: entries, IsTeam: false}, nil
+	}
+	entries, err := scanFilesystem(ctx, root, p.author, filepath.Base(root), sourceID)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) > 0 {
+		return &DiscoverResult{Entries: entries, IsTeam: false}, nil
+	}
+	return nil, fmt.Errorf("%s: no skills found (looked for scribe.yaml, scribe.toml, marketplace.json, and SKILL.md files)", root)
+}
+
+func filesystemRoot(spec source.SourceSpec) (string, string, error) {
+	spec, err := source.CanonicalSpec(spec)
+	if err != nil {
+		return "", "", err
+	}
+	if spec.Type != source.SourceLocal {
+		return "", "", fmt.Errorf("unsupported source type %q for local provider", spec.Type)
+	}
+	return spec.Path, "local:" + spec.Path, nil
+}
+
+func readManifest(root, name string) (*manifest.Manifest, error) {
+	data, err := os.ReadFile(filepath.Join(root, name))
+	if err != nil {
+		return nil, err
+	}
+	return manifest.Parse(data)
+}
+
+func readLegacyManifest(root string) (*manifest.Manifest, error) {
+	data, err := os.ReadFile(filepath.Join(root, manifest.LegacyManifestFilename))
+	if err != nil {
+		return nil, err
+	}
+	return migrate.Convert(data)
+}
+
+func readMarketplace(root, author, sourceID string) ([]manifest.Entry, error) {
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(marketplacePath)))
+	if err != nil {
+		return nil, err
+	}
+	return parseMarketplaceWithSource(data, author, sourceID)
+}
+
+func scanFilesystem(ctx context.Context, root, owner, repo, sourceID string) ([]manifest.Entry, error) {
+	var tree []TreeEntry
+	err := filepath.WalkDir(root, func(filePath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(root, filePath)
+		if err != nil {
+			return err
+		}
+		tree = append(tree, TreeEntry{Path: filepath.ToSlash(rel), Type: "blob"})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan %s: %w", root, err)
+	}
+	entries := scanTreeForSkillsWithSource(tree, owner, repo, sourceID)
+	for i := range entries {
+		skillPath := entries[i].Path
+		if path.Base(skillPath) != skillFileName {
+			skillPath = path.Join(skillPath, skillFileName)
+		}
+		fullPath, err := safeJoin(root, skillPath)
+		if err != nil {
+			continue
+		}
+		data, err := os.ReadFile(fullPath)
+		if err != nil {
+			continue
+		}
+		enriched, err := EnrichTreeSkillEntry(entries[i], data)
+		if err == nil {
+			entries[i] = enriched
+		}
+	}
+	return entries, nil
+}
+
+func fetchPath(ctx context.Context, fullPath string) ([]File, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("read skill path %s: %w", fullPath, err)
+	}
+	if !info.IsDir() {
+		if filepath.Base(fullPath) != skillFileName {
+			return nil, fmt.Errorf("skill path %s is a file, expected SKILL.md or directory", fullPath)
+		}
+		data, err := os.ReadFile(fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", fullPath, err)
+		}
+		return []File{{Path: skillFileName, Content: data}}, nil
+	}
+	var files []File
+	err = filepath.WalkDir(fullPath, func(filePath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(fullPath, filePath)
+		if err != nil {
+			return err
+		}
+		files = append(files, File{Path: filepath.ToSlash(rel), Content: data})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("read skill directory %s: %w", fullPath, err)
+	}
+	return files, nil
+}
+
+func safeJoin(root, rel string) (string, error) {
+	rel = strings.TrimSpace(rel)
+	if rel == "" || rel == "." {
+		return filepath.Clean(root), nil
+	}
+	if strings.Contains(rel, "\\") {
+		return "", fmt.Errorf("source path %q must use slash separators", rel)
+	}
+	cleaned := path.Clean(rel)
+	if path.IsAbs(cleaned) || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("source path %q cannot escape source root", rel)
+	}
+	return filepath.Join(root, filepath.FromSlash(cleaned)), nil
+}

--- a/internal/provider/filesystem_test.go
+++ b/internal/provider/filesystem_test.go
@@ -1,0 +1,128 @@
+package provider_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/source"
+)
+
+func TestFilesystemProviderDiscoversLocalTreeScanAndFetchesSkill(t *testing.T) {
+	root := t.TempDir()
+	writeProviderFile(t, root, "skills/deploy/SKILL.md", "---\nname: deploy\nsummary: Deploy things\n---\n# Deploy\n")
+	writeProviderFile(t, root, "skills/deploy/README.md", "# docs\n")
+
+	p := provider.NewFilesystemProvider()
+	result, err := p.DiscoverSource(context.Background(), source.SourceSpec{Type: source.SourceLocal, Path: root})
+	if err != nil {
+		t.Fatalf("DiscoverSource: %v", err)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(result.Entries))
+	}
+	entry := result.Entries[0]
+	if entry.Name != "deploy" || entry.Path != "skills/deploy" || entry.Source != "local:"+root {
+		t.Fatalf("entry = %#v", entry)
+	}
+
+	files, err := p.FetchSource(context.Background(), source.SourceSpec{Type: source.SourceLocal, Path: root}, entry)
+	if err != nil {
+		t.Fatalf("FetchSource: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("files = %d, want 2", len(files))
+	}
+}
+
+func TestFilesystemProviderManifestTakesPrecedenceOverTreeScan(t *testing.T) {
+	root := t.TempDir()
+	writeProviderFile(t, root, "scribe.yaml", `apiVersion: scribe/v1
+kind: Registry
+team:
+  name: local
+catalog:
+  - name: from-manifest
+    path: custom/skill
+`)
+	writeProviderFile(t, root, "skills/from-tree/SKILL.md", "# Tree\n")
+
+	p := provider.NewFilesystemProvider()
+	result, err := p.DiscoverSource(context.Background(), source.SourceSpec{Type: source.SourceLocal, Path: root})
+	if err != nil {
+		t.Fatalf("DiscoverSource: %v", err)
+	}
+	if !result.IsTeam {
+		t.Fatal("IsTeam = false, want true for scribe.yaml")
+	}
+	if len(result.Entries) != 1 || result.Entries[0].Name != "from-manifest" {
+		t.Fatalf("entries = %#v", result.Entries)
+	}
+}
+
+func TestGitProviderDiscoversGitLabSpecThroughClonePathAndRef(t *testing.T) {
+	remote := createGitFixture(t)
+
+	p := provider.NewGitProvider()
+	spec := source.SourceSpec{
+		Type: source.SourceGitLab,
+		Host: "gitlab.example.test",
+		Repo: "group/project",
+		URL:  remote,
+		Ref:  "main",
+		Path: "nested",
+	}
+	result, err := p.DiscoverSource(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("DiscoverSource: %v", err)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(result.Entries))
+	}
+	if result.Entries[0].Name != "review" || result.Entries[0].Path != "review" {
+		t.Fatalf("entry = %#v", result.Entries[0])
+	}
+	files, err := p.FetchSource(context.Background(), spec, result.Entries[0])
+	if err != nil {
+		t.Fatalf("FetchSource: %v", err)
+	}
+	if len(files) != 1 || files[0].Path != "SKILL.md" {
+		t.Fatalf("files = %#v", files)
+	}
+}
+
+func createGitFixture(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runProviderGit(t, repo, "init", "-b", "main")
+	runProviderGit(t, repo, "config", "user.email", "test@example.com")
+	runProviderGit(t, repo, "config", "user.name", "Test User")
+	writeProviderFile(t, repo, "nested/review/SKILL.md", "---\nname: review\n---\n# Review\n")
+	runProviderGit(t, repo, "add", "nested/review/SKILL.md")
+	runProviderGit(t, repo, "commit", "-m", "add skill")
+	return repo
+}
+
+func writeProviderFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func runProviderGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/internal/provider/git.go
+++ b/internal/provider/git.go
@@ -1,0 +1,129 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/source"
+)
+
+// GitProvider discovers and fetches skills from arbitrary git repositories by
+// cloning into a temporary directory per operation.
+type GitProvider struct {
+	fs *FilesystemProvider
+}
+
+func NewGitProvider() *GitProvider {
+	return &GitProvider{fs: &FilesystemProvider{sourceName: "git", author: "git"}}
+}
+
+func (p *GitProvider) Discover(ctx context.Context, repo string) (*DiscoverResult, error) {
+	return p.DiscoverSource(ctx, source.SourceSpec{Type: source.SourceGit, URL: repo})
+}
+
+func (p *GitProvider) Fetch(ctx context.Context, entry manifest.Entry) ([]File, error) {
+	return nil, fmt.Errorf("git fetch requires SourceSpec URL")
+}
+
+func (p *GitProvider) DiscoverSource(ctx context.Context, spec source.SourceSpec) (*DiscoverResult, error) {
+	root, sourceID, cleanup, err := p.checkout(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	return p.fs.discoverRoot(ctx, root, sourceID)
+}
+
+func (p *GitProvider) FetchSource(ctx context.Context, spec source.SourceSpec, entry manifest.Entry) ([]File, error) {
+	root, _, cleanup, err := p.checkout(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	skillPath := entry.Path
+	if skillPath == "" {
+		skillPath = entry.Name
+	}
+	fullPath, err := safeJoin(root, skillPath)
+	if err != nil {
+		return nil, err
+	}
+	return fetchPath(ctx, fullPath)
+}
+
+func (p *GitProvider) checkout(ctx context.Context, spec source.SourceSpec) (root string, sourceID string, cleanup func(), err error) {
+	spec, err = source.CanonicalSpec(spec)
+	if err != nil {
+		return "", "", nil, err
+	}
+	cloneURL, err := gitCloneURL(spec)
+	if err != nil {
+		return "", "", nil, err
+	}
+	tmp, err := os.MkdirTemp("", "scribe-source-*")
+	if err != nil {
+		return "", "", nil, fmt.Errorf("create temp clone dir: %w", err)
+	}
+	cleanup = func() { _ = os.RemoveAll(tmp) }
+	if err := runGit(ctx, tmp, "clone", "--quiet", cloneURL, "repo"); err != nil {
+		cleanup()
+		return "", "", nil, fmt.Errorf("clone %s: %w", cloneURL, err)
+	}
+	repoDir := tmp + string(os.PathSeparator) + "repo"
+	if spec.Ref != "" {
+		if err := runGit(ctx, repoDir, "checkout", "--quiet", spec.Ref); err != nil {
+			cleanup()
+			return "", "", nil, fmt.Errorf("checkout ref %q from %s: %w", spec.Ref, cloneURL, err)
+		}
+	}
+	root = repoDir
+	if spec.Path != "" {
+		root, err = safeJoin(repoDir, spec.Path)
+		if err != nil {
+			cleanup()
+			return "", "", nil, err
+		}
+	}
+	return root, gitSourceID(spec), cleanup, nil
+}
+
+func gitCloneURL(spec source.SourceSpec) (string, error) {
+	switch spec.Type {
+	case source.SourceGit:
+		return spec.URL, nil
+	case source.SourceGitLab:
+		return spec.URL, nil
+	default:
+		return "", fmt.Errorf("unsupported source type %q for git provider", spec.Type)
+	}
+}
+
+func gitSourceID(spec source.SourceSpec) string {
+	prefix := "git:"
+	locator := spec.URL
+	if spec.Type == source.SourceGitLab {
+		prefix = "gitlab:"
+		locator = spec.Host + "/" + spec.Repo
+	}
+	id := prefix + locator
+	if spec.Ref != "" {
+		id += "@" + spec.Ref
+	}
+	if spec.Path != "" {
+		id += ":" + spec.Path
+	}
+	return id
+}
+
+func runGit(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", string(out), err)
+	}
+	return nil
+}

--- a/internal/provider/marketplace.go
+++ b/internal/provider/marketplace.go
@@ -26,14 +26,16 @@ type marketplacePlugin struct {
 // ParseMarketplace parses a marketplace.json byte slice and returns catalog entries.
 // Each plugin's skills are flattened into individual entries with Group set to the plugin name.
 func ParseMarketplace(data []byte, owner, repo string) ([]manifest.Entry, error) {
+	return parseMarketplaceWithSource(data, owner, fmt.Sprintf("github:%s/%s@HEAD", owner, repo))
+}
+
+func parseMarketplaceWithSource(data []byte, owner, source string) ([]manifest.Entry, error) {
 	var mf marketplaceFile
 	if err := json.Unmarshal(data, &mf); err != nil {
 		return nil, fmt.Errorf("parse marketplace.json: %w", err)
 	}
 
 	var entries []manifest.Entry
-	source := fmt.Sprintf("github:%s/%s@HEAD", owner, repo)
-
 	for _, plugin := range mf.Plugins {
 		// Resolve the plugin source path (strip leading "./").
 		pluginDir := strings.TrimPrefix(plugin.Source, "./")

--- a/internal/provider/treescan.go
+++ b/internal/provider/treescan.go
@@ -17,8 +17,10 @@ var treeScanSkillName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 // catalog entries for each. The skill name is derived from the parent directory.
 // A root-level SKILL.md uses the repo name.
 func ScanTreeForSkills(tree []TreeEntry, owner, repo string) []manifest.Entry {
-	source := fmt.Sprintf("github:%s/%s@HEAD", owner, repo)
+	return scanTreeForSkillsWithSource(tree, owner, repo, fmt.Sprintf("github:%s/%s@HEAD", owner, repo))
+}
 
+func scanTreeForSkillsWithSource(tree []TreeEntry, owner, repo, source string) []manifest.Entry {
 	var entries []manifest.Entry
 	for _, entry := range tree {
 		if entry.Type != "blob" {


### PR DESCRIPTION
Adds the first non-GitHub provider backends for SourceSpec.

What changed:
- local filesystem sources discover via scribe.yaml, legacy scribe.toml, marketplace.json, then recursive SKILL.md scan
- generic git and GitLab sources clone into a temp checkout, respect ref/path, then reuse filesystem discovery/fetch
- default provider now dispatches GitHub/GitLab/git/local through a composite provider
- non-GitHub direct installs no longer require GitHub auth

Tests:
- go test ./internal/provider ./cmd
- go test ./...