### PR TITLE
feat: registry-published kits (kits: in registry scribe.yaml)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 agents/
 entities.json
 mempalace.yaml
+.agents/
+.claude/settings.json
+.claude/skills/
+.codex/
+.lean-ctx/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
 agents/
 entities.json
 mempalace.yaml
-.agents/
-.claude/settings.json
-.claude/skills/
-.codex/
-.lean-ctx/

--- a/.scribe.yaml
+++ b/.scribe.yaml
@@ -1,0 +1,2 @@
+kits:
+    - orchestrator

--- a/.scribe.yaml
+++ b/.scribe.yaml
@@ -1,2 +1,0 @@
-kits:
-    - orchestrator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 ## Unreleased
 
 ### Added
+- **Registries can publish kits** — a `kits:` block in a registry's `scribe.yaml` is fetched and materialized into `~/.scribe/kits/` during `scribe registry connect`, stamped with the source registry. Projects can list those kits in `.scribe.yaml` like any local kit. Pass `--force-kits` to overwrite hand-authored or other-registry kit files with the same name. `scribe registry connect --json` includes `data.kits_installed` when one or more kits are installed.
+- **`scribe registry resync <repo> --refresh-kits` refreshes registry kit definitions** — this opt-in path re-fetches the registry manifest and kit files, writes source stamps, and persists `state.Kits`.
 - Add `visibility` to registry config as a foundation for future opt-in registry discovery; no telemetry is added.
 - Add a local public registry index at `~/.scribe/index/registries.json`, updated by connect/sync and readable with `scribe registry index --json`.
+
+### Changed
+- **Deprecation: `scribe registry resync` will refresh kits by default in the next minor release** — this release keeps the legacy no-refresh default and prints a one-line stderr banner unless `--json` or `--refresh-kits` is passed. Scripted callers should add `--refresh-kits` now to adopt the future behavior explicitly.
+- **Legacy `scribe.toml` registries do not publish kits** — the legacy manifest path ignores `kits:` blocks. Migrate registries to `scribe.yaml` to ship kits.
 
 ## v1.3.0 — 2026-05-09
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,14 +85,14 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe project` | --json | no |
 | `scribe push` | --json | yes |
 | `scribe registry add` | --install, --json, --no-interaction, --registry | no |
-| `scribe registry connect` | --install-all, --json | yes |
+| `scribe registry connect` | --force-kits, --install-all, --json | yes |
 | `scribe registry create` | --json, --owner, --private, --repo, --team | no |
 | `scribe registry disable` | --json | no |
 | `scribe registry enable` | --json | no |
 | `scribe registry forget` | --json | no |
 | `scribe registry list` | --json | no |
 | `scribe registry migrate` | --json | no |
-| `scribe registry resync` | --json | no |
+| `scribe registry resync` | --force-kits, --json, --refresh-kits | yes |
 | `scribe registry` | --json | no |
 | `scribe remove` | --json, --no-interaction | no |
 | `scribe resolve` | --json, --ours, --theirs | no |

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -31,6 +31,7 @@ Examples:
 		RunE: runConnect,
 	}
 	cmd.Flags().Bool("install-all", false, "Install every discovered skill from the connected registry")
+	cmd.Flags().Bool("force-kits", false, "Overwrite existing kit files from this registry")
 	addSourceFlags(cmd, false)
 	return markJSONSupported(cmd)
 }
@@ -45,6 +46,7 @@ func runConnect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	installAll, _ := cmd.Flags().GetBool("install-all")
+	forceKits, _ := cmd.Flags().GetBool("force-kits")
 	jsonFlag := jsonFlagPassed(cmd)
 	spec, ident, display, err := sourceSpecFromFlags(sourceFlags)
 	if err != nil {
@@ -58,6 +60,7 @@ func runConnect(cmd *cobra.Command, args []string) error {
 		RepoArg:        repo,
 		JSONFlag:       jsonFlag,
 		InstallAllFlag: installAll,
+		ForceKits:      forceKits,
 		Factory:        commandFactory(),
 	}
 	if sourceFlags.hasTyped() {

--- a/cmd/connect_integration_test.go
+++ b/cmd/connect_integration_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/app"
+	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/kit"
+	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+type connectFakeGitHubClient struct {
+	files map[string][]byte
+}
+
+func (c connectFakeGitHubClient) FetchFile(_ context.Context, owner, repo, path, _ string) ([]byte, error) {
+	key := owner + "/" + repo + "/" + path
+	if body, ok := c.files[key]; ok {
+		return body, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (connectFakeGitHubClient) FetchDirectory(context.Context, string, string, string, string) ([]tools.SkillFile, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (connectFakeGitHubClient) LatestCommitSHA(context.Context, string, string, string) (string, error) {
+	return "abc123", nil
+}
+
+func (connectFakeGitHubClient) GetTree(context.Context, string, string, string) ([]provider.TreeEntry, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (connectFakeGitHubClient) HasPushAccess(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+func TestConnectMaterialisesRegistryKits(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	fakeClient := connectFakeGitHubClient{files: map[string][]byte{
+		"Naoray/skills/scribe.yaml": []byte(`apiVersion: scribe/v1
+kind: Registry
+team:
+  name: test
+catalog:
+  - name: plan-my-day
+    source: github:Naoray/skills@HEAD
+    path: skills/plan-my-day
+kits:
+  - name: daily-workflow
+    path: kits/daily-workflow.yaml
+`),
+		"Naoray/skills/kits/daily-workflow.yaml": []byte(`apiVersion: scribe/v1
+kind: Kit
+name: daily-workflow
+skills: [plan-my-day]
+`),
+	}}
+	restore := installConnectFakeFactory(t, fakeClient)
+	defer restore()
+
+	cmd := newConnectCommand()
+	cmd.SetArgs([]string{"Naoray/skills"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	kitPath := filepath.Join(home, ".scribe", "kits", "daily-workflow.yaml")
+	k, err := kit.Load(kitPath)
+	if err != nil {
+		t.Fatalf("load kit: %v", err)
+	}
+	if k.Source == nil || k.Source.Registry != "Naoray/skills" {
+		t.Fatalf("kit source = %+v", k.Source)
+	}
+
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("reload state: %v", err)
+	}
+	got, ok := st.Kits["daily-workflow"]
+	if !ok {
+		t.Fatalf("state.Kits missing daily-workflow: %+v", st.Kits)
+	}
+	if got.Source != "Naoray/skills" {
+		t.Fatalf("state.Kits[daily-workflow].Source = %q, want Naoray/skills", got.Source)
+	}
+	if got.Version != "HEAD" {
+		t.Fatalf("state.Kits[daily-workflow].Version = %q, want HEAD", got.Version)
+	}
+}
+
+func installConnectFakeFactory(t *testing.T, client connectFakeGitHubClient) func() {
+	t.Helper()
+	old := commandFactory
+	commandFactory = func() *app.Factory {
+		f := app.NewFactory()
+		f.Client = func() (*gh.Client, error) { return nil, nil }
+		f.Provider = func() (provider.Provider, error) {
+			return provider.NewGitHubProvider(client), nil
+		}
+		return f
+	}
+	return func() { commandFactory = old }
+}

--- a/cmd/connect_test.go
+++ b/cmd/connect_test.go
@@ -104,4 +104,11 @@ func TestNewConnectCommand_InstallAllFlag(t *testing.T) {
 	if flag.DefValue != "false" {
 		t.Errorf("install-all default = %q, want false", flag.DefValue)
 	}
+	forceKits := cmd.Flags().Lookup("force-kits")
+	if forceKits == nil {
+		t.Fatal("expected force-kits flag to be registered")
+	}
+	if forceKits.DefValue != "false" {
+		t.Errorf("force-kits default = %q, want false", forceKits.DefValue)
+	}
 }

--- a/cmd/registry_forget.go
+++ b/cmd/registry_forget.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/registryindex"
+	"github.com/Naoray/scribe/internal/workflow"
 )
 
 func newRegistryForgetCommand() *cobra.Command {
@@ -21,18 +23,21 @@ func newRegistryForgetCommand() *cobra.Command {
 }
 
 func newRegistryResyncCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "resync <owner/repo>",
 		Short: "Clear mute state for a registry so it will be retried",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return resyncRegistry(args[0])
+			return resyncRegistry(cmd, args[0])
 		},
 	}
+	cmd.Flags().Bool("force-kits", false, "Overwrite existing kit files while refreshing registry kits")
+	cmd.Flags().Bool("refresh-kits", false, "Refresh registry-published kits during resync")
+	return markJSONSupported(cmd)
 }
 
 func forgetRegistry(repo string) error {
-	factory := newCommandFactory()
+	factory := commandFactory()
 	cfg, err := factory.Config()
 	if err != nil {
 		return err
@@ -87,8 +92,8 @@ func forgetRegistry(repo string) error {
 	return nil
 }
 
-func resyncRegistry(repo string) error {
-	factory := newCommandFactory()
+func resyncRegistry(cmd *cobra.Command, repo string) error {
+	factory := commandFactory()
 	cfg, err := factory.Config()
 	if err != nil {
 		return err
@@ -107,11 +112,51 @@ func resyncRegistry(repo string) error {
 		return err
 	}
 
-	st.ClearRegistryFailure(resolved)
-	if err := st.Save(); err != nil {
-		return err
+	refreshKits, _ := cmd.Flags().GetBool("refresh-kits")
+	forceKits, _ := cmd.Flags().GetBool("force-kits")
+	jsonFlag := jsonFlagPassed(cmd)
+	failureCleared := st.ClearRegistryFailure(resolved)
+
+	if !refreshKits {
+		if !jsonFlag {
+			fmt.Fprintln(cmd.ErrOrStderr(), "W: `scribe registry resync` will refresh kits by default in the next minor release; pass --refresh-kits to opt in now")
+		}
+		if failureCleared {
+			if err := st.Save(); err != nil {
+				return err
+			}
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Registry %s will be retried on the next sync\n", resolved)
+		return nil
 	}
 
-	fmt.Printf("Registry %s will be retried on the next sync\n", resolved)
+	bag := &workflow.Bag{
+		RepoArg:     resolved,
+		JSONFlag:    jsonFlag,
+		ForceKits:   forceKits,
+		RefreshKits: true,
+		Factory:     factory,
+	}
+	if failureCleared {
+		bag.MarkStateDirty()
+	}
+	steps := []workflow.Step{
+		{Name: "LoadConfig", Fn: workflow.StepLoadConfig},
+		{Name: "ResolveFormatter", Fn: workflow.StepResolveFormatter},
+		{Name: "FetchManifest", Fn: workflow.StepFetchManifest},
+		{Name: "ValidateManifest", Fn: workflow.StepValidateManifest},
+		{Name: "LoadState", Fn: workflow.StepLoadState},
+		{Name: "InstallKits", Fn: workflow.StepInstallKits},
+		{Name: "ShowAvailable", Fn: workflow.StepShowAvailableSkills},
+	}
+	if err := workflow.Run(cmd.Context(), steps, bag); err != nil {
+		return err
+	}
+	if err := saveWorkflowState(bag); err != nil {
+		return err
+	}
+	if bag.Partial {
+		return clierrors.Wrap(clierrors.ErrPartialSuccess, "RESYNC_PARTIAL", clierrors.ExitPartial, clierrors.WithRendered(true))
+	}
 	return nil
 }

--- a/cmd/registry_forget_test.go
+++ b/cmd/registry_forget_test.go
@@ -1,13 +1,46 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/Naoray/scribe/internal/app"
 	"github.com/Naoray/scribe/internal/config"
+	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
 )
+
+type registryResyncProvider struct{}
+
+func (registryResyncProvider) Discover(context.Context, string) (*provider.DiscoverResult, error) {
+	return &provider.DiscoverResult{
+		IsTeam: true,
+		Entries: []manifest.Entry{{
+			Name:   "plan-my-day",
+			Source: "github:Naoray/skills@main",
+		}},
+		Kits: []provider.KitFile{{
+			Name: "daily-workflow",
+			Path: "kits/daily-workflow.yaml",
+			Body: []byte("apiVersion: scribe/v1\nkind: Kit\nname: daily-workflow\nskills: [plan-my-day]\n"),
+			Ref:  "abc123",
+		}},
+	}, nil
+}
+
+func (registryResyncProvider) Fetch(context.Context, manifest.Entry) ([]tools.SkillFile, error) {
+	return nil, nil
+}
 
 func TestForgetRegistryRemovesConfigAndFailureState(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
@@ -81,7 +114,11 @@ func TestResyncRegistryClearsMuteState(t *testing.T) {
 		t.Fatalf("st.Save(): %v", err)
 	}
 
-	if err := resyncRegistry("acme/skills"); err != nil {
+	cmd := newRegistryResyncCommand()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	if err := resyncRegistry(cmd, "acme/skills"); err != nil {
 		t.Fatalf("resyncRegistry(): %v", err)
 	}
 
@@ -96,4 +133,121 @@ func TestResyncRegistryClearsMuteState(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".scribe", "state.json")); err != nil {
 		t.Fatalf("state file missing: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".scribe", "kits")); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("legacy resync should not create kits dir; stat err=%v", err)
+	}
+	if !strings.Contains(errOut.String(), "will refresh kits by default") {
+		t.Fatalf("expected deprecation banner, got %q", errOut.String())
+	}
+	if !strings.Contains(out.String(), "will be retried") {
+		t.Fatalf("expected legacy stdout, got %q", out.String())
+	}
+}
+
+func TestResyncRegistryRefreshKitsRunsFullPipeline(t *testing.T) {
+	home := setupResyncRegistryHome(t)
+	restore := installResyncProviderFactory(t)
+	defer restore()
+
+	cmd := newRegistryResyncCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := cmd.Flags().Set("refresh-kits", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := resyncRegistry(cmd, "Naoray/skills"); err != nil {
+		t.Fatalf("resyncRegistry(): %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(home, ".scribe", "kits", "daily-workflow.yaml")); err != nil {
+		t.Fatalf("kit file missing: %v", err)
+	}
+	loaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("state.Load(): %v", err)
+	}
+	if got := loaded.Kits["daily-workflow"]; got.Source != "Naoray/skills" || got.Version != "abc123" {
+		t.Fatalf("state kit stamp = %+v", got)
+	}
+}
+
+func TestResyncRegistryDeprecationBannerSuppressedInJSON(t *testing.T) {
+	setupResyncRegistryHome(t)
+	cmd := newRegistryResyncCommand()
+	cmd.Flags().Bool("json", false, "test json flag")
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatal(err)
+	}
+	var errOut bytes.Buffer
+	cmd.SetErr(&errOut)
+
+	if err := resyncRegistry(cmd, "Naoray/skills"); err != nil {
+		t.Fatalf("resyncRegistry(): %v", err)
+	}
+	if strings.Contains(errOut.String(), "will refresh kits by default") {
+		t.Fatalf("banner should be suppressed in JSON mode: %q", errOut.String())
+	}
+}
+
+func TestResyncRefreshKitsPersistsState(t *testing.T) {
+	home := setupResyncRegistryHome(t)
+	restore := installResyncProviderFactory(t)
+	defer restore()
+
+	cmd := newRegistryResyncCommand()
+	cmd.Flags().Bool("json", false, "test json flag")
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("refresh-kits", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := resyncRegistry(cmd, "Naoray/skills"); err != nil {
+		t.Fatalf("resyncRegistry(): %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(home, ".scribe", "state.json"))
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	var st state.State
+	if err := json.Unmarshal(raw, &st); err != nil {
+		t.Fatalf("unmarshal state: %v\n%s", err, string(raw))
+	}
+	if got := st.Kits["daily-workflow"]; got.Source != "Naoray/skills" || len(got.Skills) != 1 {
+		t.Fatalf("persisted state kit stamp = %+v", got)
+	}
+}
+
+func setupResyncRegistryHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfg := &config.Config{
+		Registries: []config.RegistryConfig{{Repo: "Naoray/skills", Enabled: true}},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("cfg.Save(): %v", err)
+	}
+	st, err := state.Load()
+	if err != nil {
+		t.Fatalf("state.Load(): %v", err)
+	}
+	st.RecordRegistryFailure("Naoray/skills", nil, 1)
+	if err := st.Save(); err != nil {
+		t.Fatalf("st.Save(): %v", err)
+	}
+	return home
+}
+
+func installResyncProviderFactory(t *testing.T) func() {
+	t.Helper()
+	old := commandFactory
+	commandFactory = func() *app.Factory {
+		f := app.NewFactory()
+		f.Client = func() (*gh.Client, error) { return nil, nil }
+		f.Provider = func() (provider.Provider, error) { return registryResyncProvider{}, nil }
+		return f
+	}
+	return func() { commandFactory = old }
 }

--- a/docs/projects-and-kits.md
+++ b/docs/projects-and-kits.md
@@ -103,25 +103,39 @@ mcp_servers:
 
 Projects list which kits they want via `kits:` in `.scribe.yaml`. Multiple kits union; the project may add or remove individual skills on top with `add:` / `remove:`. MCP servers can also be declared through kits or directly in `.scribe.yaml` with `mcp:` / `mcp_servers:`; `scribe sync` uses those names to select definitions from project `.mcp.json`. Claude gets enabled server names in `.claude/settings.json`, Codex gets selected definitions in `.codex/config.toml`, and Cursor gets selected definitions in `.cursor/mcp.json`. Existing unmanaged Codex/Cursor entries are preserved; Scribe only replaces entries it previously projected. Scribe does not start MCP server processes.
 
-Registries can publish kits by adding `kits:` entries to their registry `scribe.yaml`. Kit bodies live in the registry repo, conventionally under `kits/<name>.yaml`:
+Use `scribe kit list --remote` to list kits from connected registries, `scribe kit list --registry <owner/repo>` to restrict discovery, and `scribe kit show <owner/repo>:<kit> --json` to inspect a remote kit body. Remote show classifies each skill ref as same-registry, cross-registry, or local and reports whether referenced registries are connected.
+
+### Kits from registries
+
+A registry can ship kits beside its skill catalog. The registry's `scribe.yaml` declares a top-level `kits:` block, each entry pointing at a repo-relative kit YAML file:
 
 ```yaml
 apiVersion: scribe/v1
 kind: Registry
 team:
-  name: acme
-catalog:
-  - name: tdd
-    source: github:acme/skills@main
+  name: example
+catalog: [...]
 kits:
-  - name: laravel-baseline
-    description: Laravel app defaults
-    path: kits/laravel-baseline.yaml
+  - name: daily-workflow
+    description: Plan, capture, and close the day
+    path: kits/daily-workflow.yaml
+  - name: release-pipeline
+    path: kits/release-pipeline.yaml
 ```
 
-Omit `path` to use `kits/<name>.yaml`. Manifest validation rejects duplicate kit names, kit names that collide with skill catalog entries, and paths outside the registry repo.
+Omit `path` to use `kits/<name>.yaml`. Manifest validation rejects duplicate kit names, kit names that collide with skill catalog entries, and paths outside the registry repo. Each referenced file is a normal Kit YAML (`kind: Kit`, `name:`, `skills:`, `mcp_servers:`).
 
-Use `scribe kit list --remote` to list kits from connected registries, `scribe kit list --registry <owner/repo>` to restrict discovery, and `scribe kit show <owner/repo>:<kit> --json` to inspect a remote kit body. Remote show classifies each skill ref as same-registry, cross-registry, or local and reports whether referenced registries are connected. `scribe kit install` is not part of this phase.
+`scribe registry connect <repo>` fetches every referenced kit body, validates the body name against the manifest ref, and writes it to `~/.scribe/kits/<name>.yaml` with `source.registry` stamped. From there, `scribe kit list`, `scribe kit show`, `scribe project init --kits`, and `.scribe.yaml` project `kits:` all see it like any local kit.
+
+`scribe registry resync <repo>` keeps its legacy behavior this release: it only clears mute state. Pass `--refresh-kits` to re-fetch registry kit definitions now. The next minor release will refresh kits by default. Use `--force-kits` with connect or resync when you intentionally want registry content to overwrite an existing kit file.
+
+Resolution precedence:
+
+- Project-local kits in `<project>/.scribe/kits/<name>.yaml` win over global kits in `~/.scribe/kits/<name>.yaml`.
+- Hand-authored global kits with no `source.registry` are protected by default. Scribe refuses to overwrite them unless you pass `--force-kits`.
+- If another registry already owns the same global kit name, Scribe skips that kit and tells you to pass `--force-kits` or run `scribe kit rename` to keep both.
+
+Legacy `scribe.toml` registry manifests do not support `kits:`. Any such block is ignored by the legacy path; migrate the registry to `scribe.yaml` to publish kits.
 
 ### Authoring kits and snippets (today)
 

--- a/internal/kit/kit.go
+++ b/internal/kit/kit.go
@@ -7,9 +7,13 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 
+	"github.com/Naoray/scribe/internal/manifest"
 	"gopkg.in/yaml.v3"
 )
+
+var kitNameRE = regexp.MustCompile(manifest.KitNamePattern)
 
 // Kit is a named bundle of Scribe skills.
 type Kit struct {
@@ -135,7 +139,15 @@ func Parse(data []byte) (*Kit, error) {
 	if kit.MCPServers == nil {
 		kit.MCPServers = []string{}
 	}
+	if kit.Name != "" && !kitNameRE.MatchString(kit.Name) {
+		return nil, fmt.Errorf("invalid kit name %q: must match %s", kit.Name, manifest.KitNamePattern)
+	}
 	return &kit, nil
+}
+
+// ParseYAML parses a kit YAML document from bytes.
+func ParseYAML(data []byte) (*Kit, error) {
+	return Parse(data)
 }
 
 // LoadAll reads all *.yaml kit files in dir, keyed by kit name.

--- a/internal/kit/parse_test.go
+++ b/internal/kit/parse_test.go
@@ -1,0 +1,73 @@
+package kit_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/kit"
+)
+
+func TestParseYAMLRoundTripSource(t *testing.T) {
+	body := []byte(`apiVersion: scribe/v1
+kind: Kit
+name: daily-workflow
+description: Plan, capture, and close the day
+skills: [plan-my-day, evaluate-day]
+mcp_servers: []
+source:
+  registry: Naoray/skills
+  rev: abc123
+`)
+	parsed, err := kit.ParseYAML(body)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if parsed.Source == nil || parsed.Source.Registry != "Naoray/skills" || parsed.Source.Rev != "abc123" {
+		t.Fatalf("source not parsed: %+v", parsed.Source)
+	}
+
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "daily-workflow.yaml")
+	if err := kit.Save(dst, parsed); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	reloaded, err := kit.Load(dst)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.Source == nil || reloaded.Source.Registry != "Naoray/skills" || reloaded.Source.Rev != "abc123" {
+		t.Errorf("source lost on round-trip: %+v", reloaded.Source)
+	}
+	if len(reloaded.Skills) != 2 {
+		t.Errorf("skills lost on round-trip: %v", reloaded.Skills)
+	}
+}
+
+func TestParseYAMLEmpty(t *testing.T) {
+	k, err := kit.ParseYAML(nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if k.Name != "" || len(k.Skills) != 0 {
+		t.Errorf("expected empty kit, got %+v", k)
+	}
+}
+
+func TestParseYAMLRejectsInvalidName(t *testing.T) {
+	cases := []string{
+		"../etc/passwd",
+		"./escape",
+		"name/with/slash",
+		"name with space",
+		"name\\..\\windows",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			body := []byte("apiVersion: scribe/v1\nkind: Kit\nname: " + name + "\n")
+			if _, err := kit.ParseYAML(body); err == nil || !strings.Contains(err.Error(), "invalid kit name") {
+				t.Errorf("expected invalid kit name error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -27,6 +28,12 @@ type Manifest struct {
 	Kits       []KitEntry `yaml:"kits,omitempty"`
 	Targets    *Targets   `yaml:"targets,omitempty"`
 }
+
+// KitNamePattern is the local-safe name shape for registry-published kit refs
+// and kit body names. Keep in sync with internal/kit.
+const KitNamePattern = `^[a-zA-Z0-9._-]+$`
+
+var kitNameRE = regexp.MustCompile(KitNamePattern)
 
 type Team struct {
 	Name        string `yaml:"name"`
@@ -173,7 +180,10 @@ func (m *Manifest) Validate() error {
 	seenKits := make(map[string]bool, len(m.Kits))
 	for _, k := range m.Kits {
 		if k.Name == "" {
-			return errors.New("kit entry has empty name")
+			return errors.New("kit name is required")
+		}
+		if !kitNameRE.MatchString(k.Name) {
+			return fmt.Errorf("invalid kit name %q: must match %s", k.Name, KitNamePattern)
 		}
 		if seenKits[k.Name] {
 			return fmt.Errorf("duplicate kit entry name %q", k.Name)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1,6 +1,7 @@
 package manifest_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -406,6 +407,91 @@ catalog:
 	}
 	if want := `duplicate catalog entry name "foo"`; err.Error() != want {
 		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestParseKitsBlock(t *testing.T) {
+	input := []byte(`
+apiVersion: scribe/v1
+kind: Registry
+team:
+  name: test
+catalog: []
+kits:
+  - name: daily-workflow
+    path: kits/daily-workflow.yaml
+    description: Plan, capture, and close the day
+  - name: release-pipeline
+    path: kits/release-pipeline.yaml
+`)
+	m, err := manifest.Parse(input)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(m.Kits) != 2 {
+		t.Fatalf("kits count: got %d, want 2", len(m.Kits))
+	}
+	if m.Kits[0].Name != "daily-workflow" || m.Kits[0].Path != "kits/daily-workflow.yaml" {
+		t.Errorf("kit[0] mismatch: %+v", m.Kits[0])
+	}
+	if m.Kits[0].Description == "" {
+		t.Error("description should round-trip")
+	}
+}
+
+func TestParseKitsBlockValidation(t *testing.T) {
+	cases := []struct {
+		name          string
+		path          string
+		wantErrSubstr string
+	}{
+		{"daily", "../etc/passwd", "must stay under repository root"},
+		{"daily", "/etc/passwd", "must stay under repository root"},
+		{"", "kits/foo.yaml", "kit name is required"},
+		{"../../../etc/cron.daily/pwn", "kits/foo.yaml", "invalid kit name"},
+		{"./escape", "kits/foo.yaml", "invalid kit name"},
+		{"name with space", "kits/foo.yaml", "invalid kit name"},
+		{"name/with/slash", "kits/foo.yaml", "invalid kit name"},
+		{"name\\..\\windows", "kits/foo.yaml", "invalid kit name"},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%s|%s", c.name, c.path), func(t *testing.T) {
+			input := []byte(fmt.Sprintf(`
+apiVersion: scribe/v1
+kind: Registry
+team:
+  name: test
+catalog: []
+kits:
+  - name: %q
+    path: %q
+`, c.name, c.path))
+			_, err := manifest.Parse(input)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", c.wantErrSubstr)
+			}
+			if !strings.Contains(err.Error(), c.wantErrSubstr) {
+				t.Errorf("error %q missing %q", err, c.wantErrSubstr)
+			}
+		})
+	}
+}
+
+func TestParseKitsBlockDuplicateName(t *testing.T) {
+	input := []byte(`
+apiVersion: scribe/v1
+kind: Registry
+team:
+  name: test
+catalog: []
+kits:
+  - name: same
+    path: kits/a.yaml
+  - name: same
+    path: kits/b.yaml
+`)
+	if _, err := manifest.Parse(input); err == nil || !strings.Contains(err.Error(), "duplicate kit entry name") {
+		t.Errorf("expected duplicate kit name error, got %v", err)
 	}
 }
 

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -84,7 +84,7 @@ func (p *GitHubProvider) DiscoverSource(ctx context.Context, spec source.SourceS
 	// Step 2: Try scribe.toml (legacy).
 	m, err := p.discoverScribeTOML(ctx, owner, repoName, spec.Path, ref)
 	if err == nil {
-		p.warn(fmt.Sprintf("%s uses legacy scribe.toml format — consider migrating to scribe.yaml", spec.Repo))
+		p.warn(spec.Repo)
 		return &DiscoverResult{Entries: m.Catalog, IsTeam: true, Manifest: m}, nil
 	}
 

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -5,12 +5,19 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"sync"
 
 	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/kit"
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/migrate"
 	"github.com/Naoray/scribe/internal/source"
 	"github.com/Naoray/scribe/internal/tools"
+)
+
+const (
+	maxKitsPerManifest = 50
+	maxKitBodyBytes    = 64 * 1024
 )
 
 // TreeEntry mirrors github.TreeEntry so the provider package doesn't import github directly.
@@ -69,13 +76,13 @@ func (p *GitHubProvider) DiscoverSource(ctx context.Context, spec source.SourceS
 	ref := sourceRef(spec)
 
 	// Step 1: Try scribe.yaml.
-	m, err := p.discoverScribeYAML(ctx, owner, repoName, spec.Path, ref)
+	raw, err := p.client.FetchFile(ctx, owner, repoName, ScopedPath(spec.Path, manifest.ManifestFilename), ref)
 	if err == nil {
-		return &DiscoverResult{Entries: m.Catalog, IsTeam: true, Manifest: m}, nil
+		return p.parseScribeYAML(ctx, owner, repoName, spec.Path, ref, raw)
 	}
 
 	// Step 2: Try scribe.toml (legacy).
-	m, err = p.discoverScribeTOML(ctx, owner, repoName, spec.Path, ref)
+	m, err := p.discoverScribeTOML(ctx, owner, repoName, spec.Path, ref)
 	if err == nil {
 		p.warn(fmt.Sprintf("%s uses legacy scribe.toml format — consider migrating to scribe.yaml", spec.Repo))
 		return &DiscoverResult{Entries: m.Catalog, IsTeam: true, Manifest: m}, nil
@@ -96,16 +103,22 @@ func (p *GitHubProvider) DiscoverSource(ctx context.Context, spec source.SourceS
 	return nil, fmt.Errorf("%s: no skills found (looked for scribe.yaml, scribe.toml, marketplace.json, and SKILL.md files)", spec.Repo)
 }
 
-func (p *GitHubProvider) discoverScribeYAML(ctx context.Context, owner, repo, scope, ref string) (*manifest.Manifest, error) {
-	raw, err := p.client.FetchFile(ctx, owner, repo, ScopedPath(scope, manifest.ManifestFilename), ref)
-	if err != nil {
-		return nil, err
-	}
+func (p *GitHubProvider) parseScribeYAML(ctx context.Context, owner, repo, scope, ref string, raw []byte) (*DiscoverResult, error) {
 	m, err := manifest.Parse(raw)
 	if err != nil {
 		return nil, err
 	}
-	return m, nil
+	kits, kitErrors, err := p.fetchKits(ctx, owner, repo, scope, ref, m.Kits)
+	if err != nil {
+		return nil, err
+	}
+	return &DiscoverResult{
+		Entries:   m.Catalog,
+		Kits:      kits,
+		KitErrors: kitErrors,
+		IsTeam:    true,
+		Manifest:  m,
+	}, nil
 }
 
 func (p *GitHubProvider) discoverScribeTOML(ctx context.Context, owner, repo, scope, ref string) (*manifest.Manifest, error) {
@@ -169,6 +182,89 @@ func (p *GitHubProvider) discoverTreeScan(ctx context.Context, owner, repo, scop
 		entries[i] = enriched
 	}
 	return entries, nil
+}
+
+func (p *GitHubProvider) fetchKits(ctx context.Context, owner, repo, scope, ref string, refs []manifest.KitEntry) ([]KitFile, KitFetchErrors, error) {
+	if len(refs) == 0 {
+		return nil, nil, nil
+	}
+	if len(refs) > maxKitsPerManifest {
+		return nil, nil, fmt.Errorf("manifest declares %d kits; maximum is %d", len(refs), maxKitsPerManifest)
+	}
+
+	type result struct {
+		index int
+		file  KitFile
+		err   KitFetchError
+		ok    bool
+	}
+
+	sem := make(chan struct{}, 4)
+	results := make(chan result, len(refs))
+	var wg sync.WaitGroup
+	for i, kitRef := range refs {
+		i, kitRef := i, kitRef
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			kitPath := kitRef.PathOrDefault()
+			fetchPath := ScopedPath(scope, kitPath)
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				results <- result{index: i, err: KitFetchError{Name: kitRef.Name, Path: fetchPath, Err: ctx.Err()}}
+				return
+			}
+
+			body, err := p.client.FetchFile(ctx, owner, repo, fetchPath, ref)
+			if err != nil {
+				results <- result{index: i, err: KitFetchError{Name: kitRef.Name, Path: fetchPath, Err: err}}
+				return
+			}
+			if len(body) > maxKitBodyBytes {
+				results <- result{index: i, err: KitFetchError{
+					Name: kitRef.Name,
+					Path: fetchPath,
+					Err:  fmt.Errorf("kit body exceeds %d bytes", maxKitBodyBytes),
+				}}
+				return
+			}
+			if _, err := kit.ParseYAML(body); err != nil {
+				results <- result{index: i, err: KitFetchError{Name: kitRef.Name, Path: fetchPath, Err: err}}
+				return
+			}
+			results <- result{
+				index: i,
+				file: KitFile{
+					Name: kitRef.Name,
+					Path: fetchPath,
+					Body: body,
+					Ref:  ref,
+				},
+				ok: true,
+			}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	byIndex := make(map[int]KitFile, len(refs))
+	errs := make(KitFetchErrors, 0)
+	for r := range results {
+		if r.ok {
+			byIndex[r.index] = r.file
+			continue
+		}
+		errs = append(errs, r.err)
+	}
+	kits := make([]KitFile, 0, len(byIndex))
+	for i := range refs {
+		if file, ok := byIndex[i]; ok {
+			kits = append(kits, file)
+		}
+	}
+	return kits, errs, nil
 }
 
 // clientAdapter adapts *gh.Client to GitHubClient interface.

--- a/internal/provider/github_test.go
+++ b/internal/provider/github_test.go
@@ -3,6 +3,7 @@ package provider_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/Naoray/scribe/internal/manifest"
@@ -82,6 +83,172 @@ catalog:
 	}
 	if result.Entries[0].Author != "alice" {
 		t.Errorf("author: got %q", result.Entries[0].Author)
+	}
+}
+
+func TestDiscoverScribeYAMLFetchesKits(t *testing.T) {
+	yamlContent := `
+apiVersion: scribe/v1
+kind: Registry
+team:
+  name: test-team
+catalog:
+  - name: deploy
+    source: "github:acme/skills@main"
+kits:
+  - name: daily-workflow
+    path: kits/daily-workflow.yaml
+  - name: release-pipeline
+    path: kits/release-pipeline.yaml
+`
+	client := &stubClient{
+		files: map[string][]byte{
+			"acme/team-skills/scribe.yaml": []byte(yamlContent),
+			"acme/team-skills/kits/daily-workflow.yaml": []byte(`apiVersion: scribe/v1
+kind: Kit
+name: daily-workflow
+skills: [deploy]
+`),
+			"acme/team-skills/kits/release-pipeline.yaml": []byte(`apiVersion: scribe/v1
+kind: Kit
+name: release-pipeline
+skills: [deploy]
+`),
+		},
+	}
+
+	p := provider.NewGitHubProvider(client)
+	result, err := p.Discover(context.Background(), "acme/team-skills")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	if len(result.KitErrors) != 0 {
+		t.Fatalf("KitErrors = %v, want none", result.KitErrors)
+	}
+	if len(result.Kits) != 2 {
+		t.Fatalf("kits: got %d, want 2", len(result.Kits))
+	}
+	if result.Kits[0].Name != "daily-workflow" || result.Kits[0].Path != "kits/daily-workflow.yaml" {
+		t.Errorf("kit[0] = %+v", result.Kits[0])
+	}
+	if result.Kits[1].Name != "release-pipeline" || result.Kits[1].Ref != "HEAD" {
+		t.Errorf("kit[1] = %+v", result.Kits[1])
+	}
+}
+
+func TestDiscoverScribeYAMLKitBodySizeCap(t *testing.T) {
+	yamlContent := `
+apiVersion: scribe/v1
+kind: Registry
+team:
+  name: test-team
+catalog: []
+kits:
+  - name: huge
+    path: kits/huge.yaml
+`
+	client := &stubClient{
+		files: map[string][]byte{
+			"acme/team-skills/scribe.yaml":    []byte(yamlContent),
+			"acme/team-skills/kits/huge.yaml": []byte(strings.Repeat("x", 64*1024+1)),
+		},
+	}
+
+	p := provider.NewGitHubProvider(client)
+	result, err := p.Discover(context.Background(), "acme/team-skills")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(result.Kits) != 0 {
+		t.Fatalf("kits: got %d, want 0", len(result.Kits))
+	}
+	if len(result.KitErrors) != 1 {
+		t.Fatalf("KitErrors: got %d, want 1", len(result.KitErrors))
+	}
+	if !strings.Contains(result.KitErrors[0].Error(), "exceeds") {
+		t.Errorf("KitErrors[0] = %v", result.KitErrors[0])
+	}
+}
+
+func TestDiscoverScribeYAMLKitCountCap(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(`
+apiVersion: scribe/v1
+kind: Registry
+team:
+  name: test-team
+catalog: []
+kits:
+`)
+	for i := 0; i < 51; i++ {
+		b.WriteString("  - name: kit-")
+		b.WriteString(string(rune('a' + i%26)))
+		b.WriteString("-")
+		b.WriteString(string(rune('a' + i/26)))
+		b.WriteString("\n    path: kits/kit.yaml\n")
+	}
+	client := &stubClient{
+		files: map[string][]byte{
+			"acme/team-skills/scribe.yaml": []byte(b.String()),
+		},
+	}
+
+	p := provider.NewGitHubProvider(client)
+	_, err := p.Discover(context.Background(), "acme/team-skills")
+	if err == nil {
+		t.Fatal("expected count cap error")
+	}
+	if !strings.Contains(err.Error(), "maximum is 50") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestDiscoverScribeYAMLKitPartialErrors(t *testing.T) {
+	yamlContent := `
+apiVersion: scribe/v1
+kind: Registry
+team:
+  name: test-team
+catalog: []
+kits:
+  - name: good
+    path: kits/good.yaml
+  - name: missing
+    path: kits/missing.yaml
+  - name: invalid
+    path: kits/invalid.yaml
+`
+	client := &stubClient{
+		files: map[string][]byte{
+			"acme/team-skills/scribe.yaml": []byte(yamlContent),
+			"acme/team-skills/kits/good.yaml": []byte(`apiVersion: scribe/v1
+kind: Kit
+name: good
+skills: []
+`),
+			"acme/team-skills/kits/invalid.yaml": []byte(`apiVersion: scribe/v1
+kind: Kit
+name: ../bad
+skills: []
+`),
+		},
+	}
+
+	p := provider.NewGitHubProvider(client)
+	result, err := p.Discover(context.Background(), "acme/team-skills")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(result.Kits) != 1 || result.Kits[0].Name != "good" {
+		t.Fatalf("kits = %+v, want good only", result.Kits)
+	}
+	if len(result.KitErrors) != 2 {
+		t.Fatalf("KitErrors: got %d, want 2: %v", len(result.KitErrors), result.KitErrors)
+	}
+	var typed provider.KitFetchErrors = result.KitErrors
+	if typed.Error() == "" {
+		t.Fatal("typed error list should render non-empty error")
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/source"
@@ -14,9 +16,46 @@ type File = tools.SkillFile
 
 // DiscoverResult holds the output of a Discover call.
 type DiscoverResult struct {
-	Entries  []manifest.Entry
-	IsTeam   bool // true if discovery found a scribe.yaml/toml with a team section
-	Manifest *manifest.Manifest
+	Entries   []manifest.Entry
+	Kits      []KitFile
+	KitErrors KitFetchErrors
+	IsTeam    bool // true if discovery found a scribe.yaml/toml with a team section
+	Manifest  *manifest.Manifest
+}
+
+// KitFile is a registry-published kit body fetched during discovery.
+type KitFile struct {
+	Name string
+	Path string
+	Body []byte
+	Ref  string
+}
+
+// KitFetchError records one non-fatal kit fetch/pre-parse failure.
+type KitFetchError struct {
+	Name string
+	Path string
+	Err  error
+}
+
+func (e KitFetchError) Error() string {
+	if e.Name == "" {
+		return fmt.Sprintf("%s: %v", e.Path, e.Err)
+	}
+	return fmt.Sprintf("%s (%s): %v", e.Name, e.Path, e.Err)
+}
+
+func (e KitFetchError) Unwrap() error { return e.Err }
+
+// KitFetchErrors is a typed partial-error list returned alongside fetched kits.
+type KitFetchErrors []KitFetchError
+
+func (e KitFetchErrors) Error() string {
+	parts := make([]string, 0, len(e))
+	for _, err := range e {
+		parts = append(parts, err.Error())
+	}
+	return strings.Join(parts, "; ")
 }
 
 // Provider abstracts how skills are discovered and fetched from a repository.

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -34,6 +34,8 @@ type Bag struct {
 	TrustAllFlag       bool   // --trust-all: approve all package commands without prompting
 	InstallAllFlag     bool   // --all: install all available skills without prompting
 	ForceBudget        bool   // --force: allow projection over agent description-byte budgets
+	ForceKits          bool   // --force-kits: overwrite existing kit files from connect/resync
+	RefreshKits        bool   // --refresh-kits: opt into kit refresh during registry resync
 	AliasName          string // --alias: install incoming skill under another name on projection conflict
 	SkillAliases       map[string]string
 	PinnedSkillSources map[string]string
@@ -96,6 +98,10 @@ type Bag struct {
 	RegistryRepos   []string                // connected registries
 	RegistryConfigs []config.RegistryConfig // connected registry config rows
 	RegistryCounts  map[string]int          // skills per registry
+
+	// Registry-published kits populated by connect/resync.
+	Kits          []provider.KitFile
+	KitsInstalled []string
 
 	// Internal fields populated by steps
 	manifest *manifest.Manifest

--- a/internal/workflow/connect.go
+++ b/internal/workflow/connect.go
@@ -98,6 +98,9 @@ func StepFetchManifest(ctx context.Context, b *Bag) error {
 	if b.Provider == nil {
 		return fmt.Errorf("internal: Provider not set in workflow bag")
 	}
+	if p, ok := b.Provider.(*provider.GitHubProvider); ok && b.Formatter != nil {
+		p.OnWarning = b.Formatter.OnLegacyFormat
+	}
 
 	var result *provider.DiscoverResult
 	var err error

--- a/internal/workflow/connect.go
+++ b/internal/workflow/connect.go
@@ -38,7 +38,7 @@ func ConnectInstallAllTail() []Step {
 }
 
 func connectBaseSteps(loadConfig bool) []Step {
-	steps := make([]Step, 0, 7)
+	steps := make([]Step, 0, 9)
 	if loadConfig {
 		steps = append(steps, Step{Name: "LoadConfig", Fn: StepLoadConfig})
 	}
@@ -47,7 +47,10 @@ func connectBaseSteps(loadConfig bool) []Step {
 		Step{Name: "DedupCheck", Fn: StepDedupCheck},
 		Step{Name: "FetchManifest", Fn: StepFetchManifest},
 		Step{Name: "ValidateManifest", Fn: StepValidateManifest},
+		// LoadState is idempotent; connect --install-all also calls it in the sync tail.
+		Step{Name: "LoadState", Fn: StepLoadState},
 		Step{Name: "InferRegistryType", Fn: StepInferRegistryType},
+		Step{Name: "InstallKits", Fn: StepInstallKits},
 		Step{Name: "SaveConfig", Fn: StepSaveConfig},
 		Step{Name: "IndexPublicRegistry", Fn: StepIndexPublicRegistry},
 	)
@@ -110,6 +113,16 @@ func StepFetchManifest(ctx context.Context, b *Bag) error {
 	if err != nil {
 		return fmt.Errorf("could not discover skills in %s: %w", workflowSourceDisplay(b), err)
 	}
+	if len(result.KitErrors) > 0 {
+		if UseJSONOutputForProcess(b.JSONFlag) {
+			return fmt.Errorf("could not fetch all kits in %s: %w", b.RepoArg, result.KitErrors)
+		}
+		for _, kitErr := range result.KitErrors {
+			b.Formatter.OnKitInstallWarning(kitErr.Name, kitErr.Err)
+		}
+		b.Partial = true
+	}
+	b.Kits = result.Kits
 
 	if result.Manifest != nil {
 		b.manifest = result.Manifest

--- a/internal/workflow/connect_partial_test.go
+++ b/internal/workflow/connect_partial_test.go
@@ -1,0 +1,131 @@
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
+	"github.com/Naoray/scribe/internal/config"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/tools"
+)
+
+type partialKitProvider struct {
+	result *provider.DiscoverResult
+}
+
+func (p partialKitProvider) Discover(context.Context, string) (*provider.DiscoverResult, error) {
+	return p.result, nil
+}
+
+func (p partialKitProvider) Fetch(context.Context, manifest.Entry) ([]tools.SkillFile, error) {
+	return nil, errors.New("unused")
+}
+
+func TestConnectKitPartialFailureWarnsInTTY(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	restoreTTY := forceWorkflowTTY(t, true)
+	defer restoreTTY()
+
+	var out, errOut bytes.Buffer
+	bag := &Bag{
+		RepoArg:   "acme/skills",
+		Config:    &config.Config{},
+		State:     newPartialKitState(),
+		Formatter: NewFormatterWithWriters(false, false, &out, &errOut),
+		Provider:  partialKitProvider{result: partialKitDiscoverResult()},
+	}
+
+	if err := StepFetchManifest(context.Background(), bag); err != nil {
+		t.Fatalf("StepFetchManifest: %v", err)
+	}
+	if !bag.Partial {
+		t.Fatal("Partial = false, want true")
+	}
+	if got := errOut.String(); !strings.Contains(got, "warning: kit broken-kit skipped: fetch failed") {
+		t.Fatalf("kit warning missing from formatter output: %q", got)
+	}
+	if err := StepInstallKits(context.Background(), bag); err != nil {
+		t.Fatalf("StepInstallKits: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".scribe", "kits", "daily-workflow.yaml")); err != nil {
+		t.Fatalf("expected kit written to disk: %v", err)
+	}
+}
+
+func TestConnectKitPartialFailureAbortsInJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	restoreTTY := forceWorkflowTTY(t, true)
+	defer restoreTTY()
+
+	bag := &Bag{
+		RepoArg:   "acme/skills",
+		JSONFlag:  true,
+		Config:    &config.Config{},
+		State:     newPartialKitState(),
+		Formatter: NewFormatterWithWriters(true, false, &bytes.Buffer{}, &bytes.Buffer{}),
+		Provider:  partialKitProvider{result: partialKitDiscoverResult()},
+	}
+
+	err := StepFetchManifest(context.Background(), bag)
+	if err == nil {
+		t.Fatal("StepFetchManifest error = nil, want abort")
+	}
+	if got := clierrors.ExitCode(err); got != clierrors.ExitGeneral {
+		t.Fatalf("ExitCode = %d, want %d; err=%v", got, clierrors.ExitGeneral, err)
+	}
+	if bag.Partial {
+		t.Fatal("Partial = true, want false on abort")
+	}
+	if bag.StateDirty {
+		t.Fatal("StateDirty = true, want false")
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".scribe", "kits", "daily-workflow.yaml")); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Fatalf("abort touched kit disk path; stat err = %v", statErr)
+	}
+	if len(bag.State.Kits) != 0 {
+		t.Fatalf("abort stamped kit state: %+v", bag.State.Kits)
+	}
+}
+
+func forceWorkflowTTY(t *testing.T, tty bool) func() {
+	t.Helper()
+	orig := conflictModeIsTerminal
+	conflictModeIsTerminal = func(uintptr) bool { return tty }
+	return func() { conflictModeIsTerminal = orig }
+}
+
+func partialKitDiscoverResult() *provider.DiscoverResult {
+	return &provider.DiscoverResult{
+		Entries: []manifest.Entry{{Name: "deploy", Source: "github:acme/skills@main", Path: "skills/deploy"}},
+		Kits: []provider.KitFile{{
+			Name: "daily-workflow",
+			Path: "kits/daily-workflow.yaml",
+			Body: []byte("apiVersion: scribe/v1\nkind: Kit\nname: daily-workflow\nskills: [deploy]\n"),
+			Ref:  "abc123",
+		}},
+		KitErrors: provider.KitFetchErrors{{
+			Name: "broken-kit",
+			Path: "kits/broken-kit.yaml",
+			Err:  errors.New("fetch failed"),
+		}},
+	}
+}
+
+func newPartialKitState() *state.State {
+	return &state.State{
+		SchemaVersion: state.CurrentSchemaVersion,
+		Installed:     map[string]state.InstalledSkill{},
+		Kits:          map[string]state.InstalledKit{},
+	}
+}

--- a/internal/workflow/connect_test.go
+++ b/internal/workflow/connect_test.go
@@ -1,11 +1,13 @@
 package workflow_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Naoray/scribe/internal/config"
@@ -19,6 +21,59 @@ import (
 type connectTestProvider struct {
 	isTeam   bool
 	manifest *manifest.Manifest
+}
+
+type workflowGitHubClient struct {
+	files map[string][]byte
+}
+
+func (c workflowGitHubClient) FetchFile(_ context.Context, owner, repo, path, _ string) ([]byte, error) {
+	key := owner + "/" + repo + "/" + path
+	if body, ok := c.files[key]; ok {
+		return body, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (workflowGitHubClient) FetchDirectory(context.Context, string, string, string, string) ([]tools.SkillFile, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (workflowGitHubClient) LatestCommitSHA(context.Context, string, string, string) (string, error) {
+	return "abc123", nil
+}
+
+func (workflowGitHubClient) GetTree(context.Context, string, string, string) ([]provider.TreeEntry, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (workflowGitHubClient) HasPushAccess(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+func TestStepFetchManifestWiresGitHubProviderWarnings(t *testing.T) {
+	var out, errOut bytes.Buffer
+	p := provider.NewGitHubProvider(workflowGitHubClient{files: map[string][]byte{
+		"acme/skills/scribe.toml": []byte(`
+[team]
+name = "legacy"
+
+[skills.deploy]
+source = "github:acme/skills@main"
+`),
+	}})
+	bag := &workflow.Bag{
+		RepoArg:   "acme/skills",
+		Provider:  p,
+		Formatter: workflow.NewFormatterWithWriters(false, false, &out, &errOut),
+	}
+
+	if err := workflow.StepFetchManifest(context.Background(), bag); err != nil {
+		t.Fatalf("StepFetchManifest: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "legacy scribe.toml") {
+		t.Fatalf("provider warning not routed through formatter: %q", errOut.String())
+	}
 }
 
 func (p connectTestProvider) Discover(context.Context, string) (*provider.DiscoverResult, error) {

--- a/internal/workflow/formatter.go
+++ b/internal/workflow/formatter.go
@@ -36,6 +36,9 @@ type Formatter interface {
 	OnConnectSyncing()
 	OnConnectSyncWarning(repo string, err error)
 	OnConnectAvailable(repo string, count int)
+	OnKitsInstalled(repo string, kitNames []string)
+	OnKitInstallWarning(kitName string, err error)
+	OnKitConflict(kitName, existingSource string)
 
 	// Package lifecycle
 	OnPackageInstallPrompt(name, command, source string)

--- a/internal/workflow/formatter_json.go
+++ b/internal/workflow/formatter_json.go
@@ -20,8 +20,15 @@ type jsonFormatter struct {
 	adoption   adoptionResult
 	resolution *nameConflictResolutionResult
 	reconcile  *reconcileResult
+	kits       []string
+	kitWarns   []kitWarning
 	meta       func() envelope.Meta
 	renderer   output.Renderer
+}
+
+type kitWarning struct {
+	Name  string `json:"name"`
+	Error string `json:"error"`
 }
 
 type reconcileResult struct {
@@ -305,6 +312,24 @@ func (f *jsonFormatter) OnConnectAvailable(_ string, _ int) {
 	// JSON mode: available skill count is not emitted.
 }
 
+func (f *jsonFormatter) OnKitsInstalled(_ string, kitNames []string) {
+	f.kits = append(f.kits, kitNames...)
+}
+
+func (f *jsonFormatter) OnKitInstallWarning(kitName string, err error) {
+	f.kitWarns = append(f.kitWarns, kitWarning{Name: kitName, Error: err.Error()})
+}
+
+func (f *jsonFormatter) OnKitConflict(kitName, existingSource string) {
+	if existingSource == "" {
+		existingSource = "hand-authored"
+	}
+	f.kitWarns = append(f.kitWarns, kitWarning{
+		Name:  kitName,
+		Error: fmt.Sprintf("kit already exists (source=%s); pass --force-kits to overwrite, or `scribe kit rename` to keep both", existingSource),
+	})
+}
+
 func (f *jsonFormatter) OnLegacyFormat(_ string) {}
 
 func (f *jsonFormatter) Flush() error {
@@ -328,6 +353,12 @@ func (f *jsonFormatter) Flush() error {
 	}
 	if len(f.denied) > 0 {
 		out["skipped_by_deny_list"] = f.denied
+	}
+	if len(f.kits) > 0 {
+		out["kits_installed"] = f.kits
+	}
+	if len(f.kitWarns) > 0 {
+		out["kit_warnings"] = f.kitWarns
 	}
 	status := envelope.StatusOK
 	if f.summary.Failed > 0 || f.adoption.Failed > 0 {

--- a/internal/workflow/formatter_test.go
+++ b/internal/workflow/formatter_test.go
@@ -93,6 +93,26 @@ func TestTextFormatter_BudgetWarning(t *testing.T) {
 	}
 }
 
+func TestTextFormatter_KitsInstalledAndWarnings(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	var out, errOut bytes.Buffer
+	fmtr := workflow.NewFormatterWithWriters(false, false, &out, &errOut)
+
+	fmtr.OnKitsInstalled("acme/skills", []string{"daily-workflow", "release-pipeline"})
+	fmtr.OnKitInstallWarning("broken", fmt.Errorf("fetch failed"))
+	fmtr.OnKitConflict("daily-workflow", "Other/skills")
+
+	if !strings.Contains(out.String(), "2 kits installed") {
+		t.Fatalf("expected installed summary, got %q", out.String())
+	}
+	if !strings.Contains(errOut.String(), "kit broken skipped: fetch failed") {
+		t.Fatalf("expected kit warning, got %q", errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "pass --force-kits to overwrite") {
+		t.Fatalf("expected remediation hint, got %q", errOut.String())
+	}
+}
+
 func TestTextFormatter_AdoptionWithDeferredConflicts(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 	var out, errOut bytes.Buffer
@@ -179,5 +199,47 @@ func TestJSONFormatter(t *testing.T) {
 	}
 	if denied[0].(map[string]any)["name"] != "removed" {
 		t.Fatalf("unexpected deny-list skip payload: %v", denied[0])
+	}
+}
+
+func TestJSONFormatterKitsInstalledEnvelope(t *testing.T) {
+	var out bytes.Buffer
+	fmtr := workflow.NewFormatterWithWriters(true, false, &out, &bytes.Buffer{})
+
+	fmtr.OnKitsInstalled("acme/skills", []string{"daily-workflow"})
+	fmtr.OnKitInstallWarning("broken", fmt.Errorf("fetch failed"))
+
+	if err := fmtr.Flush(); err != nil {
+		t.Fatalf("Flush() error: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\nraw: %s", err, out.String())
+	}
+	data := result["data"].(map[string]any)
+	kits := data["kits_installed"].([]any)
+	if len(kits) != 1 || kits[0] != "daily-workflow" {
+		t.Fatalf("kits_installed = %v", kits)
+	}
+	warnings := data["kit_warnings"].([]any)
+	if len(warnings) != 1 || warnings[0].(map[string]any)["name"] != "broken" {
+		t.Fatalf("kit_warnings = %v", warnings)
+	}
+}
+
+func TestJSONFormatterOmitsKitsInstalledWhenEmpty(t *testing.T) {
+	var out bytes.Buffer
+	fmtr := workflow.NewFormatterWithWriters(true, false, &out, &bytes.Buffer{})
+
+	if err := fmtr.Flush(); err != nil {
+		t.Fatalf("Flush() error: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\nraw: %s", err, out.String())
+	}
+	data := result["data"].(map[string]any)
+	if _, ok := data["kits_installed"]; ok {
+		t.Fatalf("kits_installed should be omitted when empty: %v", data)
 	}
 }

--- a/internal/workflow/formatter_text.go
+++ b/internal/workflow/formatter_text.go
@@ -250,6 +250,28 @@ func (f *textFormatter) OnConnectAvailable(_ string, count int) {
 	fmt.Fprintf(f.out, "%d skills available — run `scribe add` to install\n", count)
 }
 
+func (f *textFormatter) OnKitsInstalled(_ string, kitNames []string) {
+	if len(kitNames) == 0 {
+		return
+	}
+	noun := "kits"
+	if len(kitNames) == 1 {
+		noun = "kit"
+	}
+	fmt.Fprintf(f.out, "%d %s installed\n", len(kitNames), noun)
+}
+
+func (f *textFormatter) OnKitInstallWarning(kitName string, err error) {
+	fmt.Fprintf(f.errOut, "warning: kit %s skipped: %v\n", kitName, err)
+}
+
+func (f *textFormatter) OnKitConflict(kitName, existingSource string) {
+	if existingSource == "" {
+		existingSource = "hand-authored"
+	}
+	fmt.Fprintf(f.errOut, "warning: kit %s already exists (source=%s); pass --force-kits to overwrite, or `scribe kit rename` to keep both\n", kitName, existingSource)
+}
+
 func (f *textFormatter) OnLegacyFormat(repo string) {
 	fmt.Fprintf(f.errOut, "note: %s uses legacy scribe.toml — consider migrating to scribe.yaml\n", repo)
 }

--- a/internal/workflow/kits_install.go
+++ b/internal/workflow/kits_install.go
@@ -1,0 +1,156 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Naoray/scribe/internal/kit"
+	"github.com/Naoray/scribe/internal/lockfile"
+	"github.com/Naoray/scribe/internal/paths"
+	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/state"
+)
+
+type parsedKitFile struct {
+	file provider.KitFile
+	kit  *kit.Kit
+	dst  string
+}
+
+// StepInstallKits materializes registry-published kits into ~/.scribe/kits.
+func StepInstallKits(_ context.Context, b *Bag) error {
+	if len(b.Kits) == 0 {
+		return nil
+	}
+	kitsDir, err := registryKitsDir()
+	if err != nil {
+		return err
+	}
+	// preflight validates incoming bodies only; pre-existing disk corruption is out-of-contract.
+	parsed, err := preflightKitFiles(kitsDir, b.Kits)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(kitsDir, 0o755); err != nil {
+		return fmt.Errorf("create kits dir: %w", err)
+	}
+
+	written := make([]string, 0, len(parsed))
+	for _, item := range parsed {
+		sourceRegistry := kitSourceRegistry(b)
+		ok, existingSource, err := canWriteKit(item.dst, item.kit.Name, sourceRegistry, b.ForceKits)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			b.Partial = true
+			b.Formatter.OnKitConflict(item.kit.Name, existingSource)
+			continue
+		}
+
+		item.kit.Source = &kit.Source{Registry: sourceRegistry, Rev: item.file.Ref}
+		if err := kit.Save(item.dst, item.kit); err != nil {
+			return fmt.Errorf("save kit %q: %w", item.kit.Name, err)
+		}
+		if err := stampKitState(b, item, sourceRegistry); err != nil {
+			return err
+		}
+		written = append(written, item.kit.Name)
+	}
+
+	if len(written) > 0 {
+		b.KitsInstalled = append(b.KitsInstalled, written...)
+		b.Formatter.OnKitsInstalled(b.RepoArg, written)
+	}
+	return nil
+}
+
+func registryKitsDir() (string, error) {
+	scribeDir, err := paths.ScribeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve scribe dir: %w", err)
+	}
+	return filepath.Join(scribeDir, "kits"), nil
+}
+
+func preflightKitFiles(kitsDir string, files []provider.KitFile) ([]parsedKitFile, error) {
+	parsed := make([]parsedKitFile, 0, len(files))
+	for _, file := range files {
+		k, err := kit.ParseYAML(file.Body)
+		if err != nil {
+			return nil, fmt.Errorf("parse kit %q: %w", file.Name, err)
+		}
+		if k.Name != file.Name {
+			return nil, fmt.Errorf("kit %q: body name %q doesn't match manifest ref", file.Name, k.Name)
+		}
+		dst := filepath.Join(kitsDir, k.Name+".yaml")
+		rel, err := filepath.Rel(kitsDir, dst)
+		if err != nil {
+			return nil, fmt.Errorf("check kit path %q: %w", k.Name, err)
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+			return nil, fmt.Errorf("kit %q: destination escapes kits dir", k.Name)
+		}
+		parsed = append(parsed, parsedKitFile{file: file, kit: k, dst: dst})
+	}
+	return parsed, nil
+}
+
+func canWriteKit(dst, name, repo string, force bool) (bool, string, error) {
+	existing, err := kit.Load(dst)
+	if errors.Is(err, fs.ErrNotExist) {
+		return true, "", nil
+	}
+	if err != nil {
+		return false, "", fmt.Errorf("load existing kit %q: %w", name, err)
+	}
+	existingSource := ""
+	if existing.Source != nil {
+		existingSource = existing.Source.Registry
+	}
+	if force || existingSource == repo {
+		return true, existingSource, nil
+	}
+	return false, existingSource, nil
+}
+
+func stampKitState(b *Bag, item parsedKitFile, sourceRegistry string) error {
+	if b.State == nil {
+		return nil
+	}
+	if b.State.Kits == nil {
+		b.State.Kits = map[string]state.InstalledKit{}
+	}
+	contentHash, err := lockfile.HashFiles([]lockfile.File{{Path: item.kit.Name + ".yaml", Content: item.file.Body}})
+	if err != nil {
+		return fmt.Errorf("hash kit %q: %w", item.kit.Name, err)
+	}
+	b.State.Kits[item.kit.Name] = state.InstalledKit{
+		Name:           item.kit.Name,
+		SourceRegistry: sourceRegistry,
+		Rev:            item.file.Ref,
+		ContentHash:    contentHash,
+		InstalledAt:    time.Now(),
+		Source:         sourceRegistry,
+		Version:        item.file.Ref,
+		Skills:         append([]string(nil), item.kit.Skills...),
+	}
+	b.MarkStateDirty()
+	return nil
+}
+
+func kitSourceRegistry(b *Bag) string {
+	if b.SourceKey != "" {
+		return b.SourceKey
+	}
+	if b.SourceID != "" {
+		return b.SourceID
+	}
+	return b.RepoArg
+}

--- a/internal/workflow/kits_install_test.go
+++ b/internal/workflow/kits_install_test.go
@@ -1,0 +1,179 @@
+package workflow_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Naoray/scribe/internal/kit"
+	"github.com/Naoray/scribe/internal/provider"
+	"github.com/Naoray/scribe/internal/state"
+	"github.com/Naoray/scribe/internal/workflow"
+)
+
+func TestStepInstallKitsWritesAndStampsState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	bag := &workflow.Bag{
+		RepoArg:   "Naoray/skills",
+		State:     newKitInstallState(),
+		Formatter: workflow.NewFormatterWithWriters(false, false, &bytes.Buffer{}, &bytes.Buffer{}),
+		Kits:      []provider.KitFile{kitFile("daily-workflow", "kits/daily-workflow.yaml", []string{"plan-my-day"}, "abc123")},
+	}
+	if err := workflow.StepInstallKits(context.Background(), bag); err != nil {
+		t.Fatalf("StepInstallKits: %v", err)
+	}
+
+	written := loadKitFile(t, home, "daily-workflow")
+	if written.Source == nil || written.Source.Registry != "Naoray/skills" || written.Source.Rev != "abc123" {
+		t.Fatalf("written source = %+v", written.Source)
+	}
+	if !bag.StateDirty {
+		t.Fatal("StateDirty = false, want true")
+	}
+	stamped := bag.State.Kits["daily-workflow"]
+	if stamped.Source != "Naoray/skills" || stamped.Version != "abc123" || len(stamped.Skills) != 1 {
+		t.Fatalf("state stamp = %+v", stamped)
+	}
+	if len(bag.KitsInstalled) != 1 || bag.KitsInstalled[0] != "daily-workflow" {
+		t.Fatalf("KitsInstalled = %v", bag.KitsInstalled)
+	}
+}
+
+func TestStepInstallKitsConflictMatrix(t *testing.T) {
+	cases := []struct {
+		name           string
+		existing       *kit.Source
+		force          bool
+		wantWritten    bool
+		wantPartial    bool
+		wantWarnSubstr string
+	}{
+		{name: "same registry", existing: &kit.Source{Registry: "Naoray/skills"}, wantWritten: true},
+		{name: "hand authored nil source", existing: nil, wantPartial: true, wantWarnSubstr: "source=hand-authored"},
+		{name: "hand authored empty registry", existing: &kit.Source{Registry: ""}, wantPartial: true, wantWarnSubstr: "source=hand-authored"},
+		{name: "other registry", existing: &kit.Source{Registry: "Other/skills"}, wantPartial: true, wantWarnSubstr: "source=Other/skills"},
+		{name: "force overwrites hand authored", existing: nil, force: true, wantWritten: true},
+		{name: "force overwrites other registry", existing: &kit.Source{Registry: "Other/skills"}, force: true, wantWritten: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			writeExistingKit(t, home, "daily-workflow", tc.existing)
+			var out, errOut bytes.Buffer
+			bag := &workflow.Bag{
+				RepoArg:   "Naoray/skills",
+				State:     newKitInstallState(),
+				ForceKits: tc.force,
+				Formatter: workflow.NewFormatterWithWriters(false, false, &out, &errOut),
+				Kits:      []provider.KitFile{kitFile("daily-workflow", "kits/daily-workflow.yaml", []string{"plan-my-day"}, "abc123")},
+			}
+
+			if err := workflow.StepInstallKits(context.Background(), bag); err != nil {
+				t.Fatalf("StepInstallKits: %v", err)
+			}
+			got := loadKitFile(t, home, "daily-workflow")
+			wroteIncoming := got.Source != nil && got.Source.Registry == "Naoray/skills"
+			if wroteIncoming != tc.wantWritten {
+				t.Fatalf("wrote incoming = %v, want %v; source=%+v", wroteIncoming, tc.wantWritten, got.Source)
+			}
+			if bag.Partial != tc.wantPartial {
+				t.Fatalf("Partial = %v, want %v", bag.Partial, tc.wantPartial)
+			}
+			if tc.wantWarnSubstr != "" && !strings.Contains(errOut.String(), tc.wantWarnSubstr) {
+				t.Fatalf("warning %q missing %q", errOut.String(), tc.wantWarnSubstr)
+			}
+		})
+	}
+}
+
+func TestStepInstallKitsBodyNameMismatchIsFatal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	bag := &workflow.Bag{
+		RepoArg:   "Naoray/skills",
+		State:     newKitInstallState(),
+		Formatter: workflow.NewFormatterWithWriters(false, false, &bytes.Buffer{}, &bytes.Buffer{}),
+		Kits: []provider.KitFile{{
+			Name: "daily-workflow",
+			Path: "kits/daily-workflow.yaml",
+			Body: []byte("apiVersion: scribe/v1\nkind: Kit\nname: other\nskills: []\n"),
+			Ref:  "abc123",
+		}},
+	}
+	err := workflow.StepInstallKits(context.Background(), bag)
+	if err == nil || !strings.Contains(err.Error(), "doesn't match manifest ref") {
+		t.Fatalf("expected mismatch error, got %v", err)
+	}
+}
+
+func TestStepInstallKitsPreflightAtomic(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	bag := &workflow.Bag{
+		RepoArg:   "Naoray/skills",
+		State:     newKitInstallState(),
+		Formatter: workflow.NewFormatterWithWriters(false, false, &bytes.Buffer{}, &bytes.Buffer{}),
+		Kits: []provider.KitFile{
+			kitFile("daily-workflow", "kits/daily-workflow.yaml", []string{"plan-my-day"}, "abc123"),
+			{
+				Name: "bad-kit",
+				Path: "kits/bad-kit.yaml",
+				Body: []byte("apiVersion: scribe/v1\nkind: Kit\nname: ../bad\nskills: []\n"),
+				Ref:  "abc123",
+			},
+		},
+	}
+	err := workflow.StepInstallKits(context.Background(), bag)
+	if err == nil {
+		t.Fatal("expected preflight parse error")
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".scribe", "kits", "daily-workflow.yaml")); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Fatalf("preflight failure wrote first kit; stat err = %v", statErr)
+	}
+	if len(bag.State.Kits) != 0 {
+		t.Fatalf("preflight failure stamped state: %+v", bag.State.Kits)
+	}
+}
+
+func kitFile(name, path string, skills []string, ref string) provider.KitFile {
+	return provider.KitFile{
+		Name: name,
+		Path: path,
+		Body: []byte("apiVersion: scribe/v1\nkind: Kit\nname: " + name + "\nskills: [" + strings.Join(skills, ", ") + "]\n"),
+		Ref:  ref,
+	}
+}
+
+func newKitInstallState() *state.State {
+	return &state.State{
+		SchemaVersion: state.CurrentSchemaVersion,
+		Installed:     map[string]state.InstalledSkill{},
+		Kits:          map[string]state.InstalledKit{},
+	}
+}
+
+func writeExistingKit(t *testing.T, home, name string, source *kit.Source) {
+	t.Helper()
+	k := &kit.Kit{Name: name, Skills: []string{"existing"}, Source: source}
+	if err := kit.Save(filepath.Join(home, ".scribe", "kits", name+".yaml"), k); err != nil {
+		t.Fatalf("save existing kit: %v", err)
+	}
+}
+
+func loadKitFile(t *testing.T, home, name string) *kit.Kit {
+	t.Helper()
+	k, err := kit.Load(filepath.Join(home, ".scribe", "kits", name+".yaml"))
+	if err != nil {
+		t.Fatalf("load kit: %v", err)
+	}
+	return k
+}

--- a/internal/workflow/sync_adopt_test.go
+++ b/internal/workflow/sync_adopt_test.go
@@ -62,6 +62,9 @@ func (r *adoptRecorder) OnConnectSaved(_ string)                                
 func (r *adoptRecorder) OnConnectSyncing()                                        {}
 func (r *adoptRecorder) OnConnectSyncWarning(_ string, _ error)                   {}
 func (r *adoptRecorder) OnConnectAvailable(_ string, _ int)                       {}
+func (r *adoptRecorder) OnKitsInstalled(_ string, _ []string)                     {}
+func (r *adoptRecorder) OnKitInstallWarning(_ string, _ error)                    {}
+func (r *adoptRecorder) OnKitConflict(_, _ string)                                {}
 func (r *adoptRecorder) OnPackageInstallPrompt(_, _, _ string)                    {}
 func (r *adoptRecorder) OnPackageApproved(_ string)                               {}
 func (r *adoptRecorder) OnPackageDenied(_ string)                                 {}


### PR DESCRIPTION
## Summary
- Registries can declare `kits:` in their `scribe.yaml`; bodies fetched on `scribe registry connect` and (opt-in this release) on `scribe registry resync --refresh-kits` into `~/.scribe/kits/<name>.yaml`, source-stamped.
- `.scribe.yaml` references the kit name as before — `scribe sync` resolves through existing kit loader.
- Closes the gap documented in counselors synthesis 1908 and patch report 1911.

## Phases (1 commit each)
1. Manifest schema (`kits:` + name regex + traversal-attempt tests)
2. `kit.ParseYAML` + round-trip Source test
3. Provider fetches kit blobs (caps, partial-error list)
4. `StepInstallKits` (preflight-atomic, warn-continue conflicts, `errors.Is(fs.ErrNotExist)`, state stamping)
5. Formatter + JSON envelope (`data.kits_installed` length-gated; `OnWarning` wired via type-assert)
6. CLI flags `--force-kits`, `--refresh-kits`; resync rollout opt-in this release + deprecation banner
7. State-stamping integration test (fake GitHub via `commandFactory()` seam)
8. Docs (`projects-and-kits.md` + `CHANGELOG.md v1.4.0` + `CLAUDE.md` table)

## Test plan
- [x] `go test ./...` green
- [ ] `scribe registry connect Naoray/skills` materialises 5 kit files (smoke test against live registry)
- [ ] `scribe kit show daily-workflow` reports `Source: Naoray/skills`
- [ ] `.scribe.yaml: kits: [daily-workflow]` + `scribe sync` installs all 5 referenced skills
- [x] `scribe registry resync naoray-skills --refresh-kits` refreshes kits and persists state (covered by fake-provider cmd test)
- [x] Existing tests still pass; no false-positive drift warnings on existing `~/.scribe/kits/` users
- [x] Path traversal attempts (`name: ../etc/passwd`) rejected by manifest validation
- [x] Conflict matrix (`Source==nil`, `Source.Registry==""`, `Source.Registry==X` vs new registry `Y`) refuses without `--force-kits`, overwrites with `--force-kits`

## References
- Plan: solo scratchpad 1901 r2
- Counselors r1: 1908 (PATCH PLAN)
- Counselors r2: 1919 (DISPATCH IMPL, 9 NITS folded in)