### PR TITLE
docs(release): v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,31 @@
-## Unreleased
+## v1.4.0 — 2026-05-13
 
 ### Added
 - **Registries can publish kits** — a `kits:` block in a registry's `scribe.yaml` is fetched and materialized into `~/.scribe/kits/` during `scribe registry connect`, stamped with the source registry. Projects can list those kits in `.scribe.yaml` like any local kit. Pass `--force-kits` to overwrite hand-authored or other-registry kit files with the same name. `scribe registry connect --json` includes `data.kits_installed` when one or more kits are installed.
-- **`scribe registry resync <repo> --refresh-kits` refreshes registry kit definitions** — this opt-in path re-fetches the registry manifest and kit files, writes source stamps, and persists `state.Kits`.
-- Add `visibility` to registry config as a foundation for future opt-in registry discovery; no telemetry is added.
-- Add a local public registry index at `~/.scribe/index/registries.json`, updated by connect/sync and readable with `scribe registry index --json`.
+- **`scribe registry resync <repo> --refresh-kits` refreshes registry kit definitions** — opt-in path re-fetches the registry manifest and kit files, writes source stamps, and persists `state.Kits`.
+- **Typed source providers** — `scribe add`, `scribe browse`, and `scribe registry connect` accept `--source github|git|local`, `--repo`, `--url`, `--ref`, `--path`, and `--id`. Local directories and arbitrary git URLs can now back a registry alongside GitHub. The legacy `--registry owner/repo` form keeps working as a shorthand alias.
+- **Structured source identity in state and lockfiles** — `scribe.lock` and registry state now carry a structured source identity (type, repo/URL, ref, path, ID) instead of an opaque repo string, so cross-provider provenance survives `sync` and `update`.
+- **`scribe mcp list`** — read-only inspector for declared MCP servers and their projection state into Claude, Codex, and Cursor. Supports `--json` against the new `scribe mcp list` schema.
+- **`--resync` flag on `scribe add` and `scribe browse`** — overwrites local edits with the upstream version for modified skills; without it, modified skills are skipped with a hint.
+- **`scribe doctor` detects snippet projection drift** — new `snippet_projection_drift` issue kind covers missing or stale managed blocks in `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` / `.cursor/rules/*.mdc`. Remediation is `scribe sync`.
+- **`scribe browse` understands Vercel `skills.sh`-style layouts** — narrow GitHub browse support for repositories that ship skills without a `scribe.yaml`.
+- **`visibility` on registry config** — foundation for future opt-in public discovery. Public / private / unknown is resolved on connect; no telemetry is sent.
+- **Local public registry index at `~/.scribe/index/registries.json`** — `scribe registry connect` and successful `scribe sync` runs update the cache for `public` registries. Inspect with `scribe registry index --json`.
 
 ### Changed
 - **Deprecation: `scribe registry resync` will refresh kits by default in the next minor release** — this release keeps the legacy no-refresh default and prints a one-line stderr banner unless `--json` or `--refresh-kits` is passed. Scripted callers should add `--refresh-kits` now to adopt the future behavior explicitly.
 - **Legacy `scribe.toml` registries do not publish kits** — the legacy manifest path ignores `kits:` blocks. Migrate registries to `scribe.yaml` to ship kits.
+
+### Fixed
+- **`scribe sync --json` surfaces modified skills** — sync output now reports modified skills explicitly instead of folding them into `skipped`, so agents can decide whether to re-run with `--resync`.
+- **`scribe registry add` package prompts respect active tools** — the package install path now prompts for the currently active tool set instead of the global default, fixing dropped projections after registry-add of multi-skill packages.
+- **`scribe doctor` projection drift output is summarized** — the text formatter groups drift entries by skill instead of printing one line per projection target, matching the JSON sample shape.
+- **Reconcile drops stale missing projection paths** — leftover projection entries for skills whose target links are gone are now cleaned up during reconcile.
+- **Codex budget checks stay correct under project loadouts** — Codex description-budget accounting respects the project's resolved kit set, so global state no longer inflates the project budget total.
+
+### Documentation
+- **MIT license and Code of Conduct added** to the repo root.
+- **README uses the CLI logo lockup** in the header (replaces the old ASCII art block).
 
 ## v1.3.0 — 2026-05-09
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,9 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 
 | Command | Flags | Output schema |
 |---|---|---|
-| `scribe add` | --alias, --force, --json, --no-interaction, --registry | yes |
+| `scribe add` | --alias, --force, --id, --json, --no-interaction, --path, --ref, --registry, --repo, --resync, --source, --url | yes |
 | `scribe adopt` | --dry-run, --json, --no-interaction, --verbose | yes |
-| `scribe browse` | --install, --json, --no-interaction, --query, --registry | no |
+| `scribe browse` | --id, --install, --json, --no-interaction, --path, --query, --ref, --registry, --repo, --resync, --source, --url | no |
 | `scribe check` | --json | yes |
 | `scribe config adoption` | --add-path, --json, --mode, --remove-path | no |
 | `scribe config set editor` | --json | no |
@@ -71,10 +71,15 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe init` | --force, --json | yes |
 | `scribe install` | --alias, --all, --force, --json, --registry | no |
 | `scribe kit create` | --description, --force, --json, --mcp-servers, --registry, --skills | no |
-| `scribe kit list` | --fields, --json | no |
+| `scribe kit install` | --alias, --force, --json, --no-deps, --no-interaction | no |
+| `scribe kit list` | --fields, --json, --registry, --remote | no |
+| `scribe kit push` | --json, --registry | no |
 | `scribe kit show` | --json | no |
+| `scribe kit sync` | --force, --json, --no-deps, --no-interaction | no |
 | `scribe kit` | --json | no |
 | `scribe list` | --fields, --json, --registry, --remote | yes |
+| `scribe mcp list` | --json | yes |
+| `scribe mcp` | --json | no |
 | `scribe migrate global-to-projects` | --dry-run, --force, --json, --no-interaction, --project, --undo | yes |
 | `scribe migrate` | --json | no |
 | `scribe project init` | --force, --json, --kits | yes |
@@ -85,11 +90,12 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe project` | --json | no |
 | `scribe push` | --json | yes |
 | `scribe registry add` | --install, --json, --no-interaction, --registry | no |
-| `scribe registry connect` | --force-kits, --install-all, --json | yes |
+| `scribe registry connect` | --force-kits, --id, --install-all, --json, --path, --ref, --repo, --source, --url | yes |
 | `scribe registry create` | --json, --owner, --private, --repo, --team | no |
 | `scribe registry disable` | --json | no |
 | `scribe registry enable` | --json | no |
 | `scribe registry forget` | --json | no |
+| `scribe registry index` | --json | no |
 | `scribe registry list` | --json | no |
 | `scribe registry migrate` | --json | no |
 | `scribe registry resync` | --force-kits, --json, --refresh-kits | yes |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Migrated commands emit this on stdout:
     "duration_ms": 12,
     "bootstrap_ms": 3,
     "command": "scribe list",
-    "scribe_version": "1.1.0"
+    "scribe_version": "1.4.0"
   }
 }
 ```
@@ -203,7 +203,7 @@ scribe browse --query ...    # search registries before installing
 
 ## Status
 
-- v1.1.0 — active development.
+- v1.4.0 — active development.
 - Requires macOS or Linux. Windows install via the PowerShell snippet in [SKILL.md](SKILL.md).
 - `gh` CLI recommended for auth (not required for public repos).
 - Issues: [github.com/Naoray/scribe/issues](https://github.com/Naoray/scribe/issues) — each one has enough context to pick up.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,8 +12,8 @@ The commands you'll reach for every session — install, list, sync, and keep sk
 |---|---|
 | `scribe` | Open the local skill manager (interactive TUI when stdout is a TTY) |
 | `scribe list` | Show all skills on this machine (managed + unmanaged) |
-| `scribe browse` | Discover and install skills from connected registries |
-| `scribe add [query]` | Find and install skills from registries (legacy; prefer `browse`) |
+| `scribe browse` | Discover and install skills from connected registries. Accepts typed sources via `--source github\|git\|local`, `--repo`, `--url`, `--ref`, `--path`, `--id`. Pass `--resync` to overwrite local edits with the upstream version for modified skills. |
+| `scribe add [query]` | Find and install skills from registries (legacy; prefer `browse`). Accepts typed sources via `--source github\|git\|local`, `--repo`, `--url`, `--ref`, `--path`, `--id`. Pass `--resync` to overwrite local edits with the upstream version for modified skills. |
 | `scribe install --all` | Install every catalog entry from a registry in one shot |
 | `scribe adopt [name]` | Import hand-rolled skills from `~/.claude/skills` etc. into the canonical store |
 | `scribe remove <skill>` | Remove a skill from this machine (records a deny-list entry so it does not come back on the next sync) |
@@ -31,6 +31,7 @@ The commands you'll reach for every session — install, list, sync, and keep sk
 | `scribe status` | Show connected registries, installed count, and last sync |
 | `scribe tools` | List detected AI tools on this machine; enable, disable, or register custom ones |
 | `scribe explain <skill-or-snippet>` | AI-powered explanation for an installed skill or snippet (or `--raw` for the rendered body) |
+| `scribe mcp list` | Inspect declared MCP servers in `.scribe.yaml` and how they project into Claude, Codex, and Cursor (`--json` supported) |
 | `scribe upgrade-agent` | Refresh the embedded scribe bootstrap skill |
 
 ## Registry management
@@ -39,14 +40,14 @@ Connect, create, share, and audit the skill registries this machine pulls from. 
 
 | Command | What it does |
 |---|---|
-| `scribe registry connect <repo>` | Connect to a skill registry (alias: `scribe connect`) |
+| `scribe registry connect <repo>` | Connect to a skill registry (alias: `scribe connect`). Accepts typed sources via `--source github\|git\|local`, `--repo`, `--url`, `--ref`, `--path`, `--id` alongside the positional `owner/repo`. Pass `--force-kits` to overwrite existing kit files with the same name when the registry publishes kits. |
 | `scribe registry create` | Scaffold a new registry repo on GitHub interactively |
 | `scribe registry add [name]` | Share a local skill into a connected registry |
 | `scribe registry list` | Show connected registries with skill counts |
 | `scribe registry index` | Show the local cache of public registries under `~/.scribe/index/registries.json` |
 | `scribe registry enable <repo>` / `disable <repo>` | Toggle a connected registry without forgetting it |
 | `scribe registry forget <repo>` | Disconnect a registry (does not remove already-installed skills) |
-| `scribe registry resync <repo>` | Force-fetch a registry's catalog from upstream |
+| `scribe registry resync <repo>` | Force-fetch a registry's catalog from upstream. Pass `--refresh-kits` to also re-fetch registry-published kit definitions and write source stamps (becomes the default in the next minor release; a stderr deprecation banner fires otherwise). Combine with `--force-kits` to overwrite hand-authored or other-registry kit files. |
 | `scribe registry migrate` | Convert a `scribe.toml` registry to `scribe.yaml` |
 
 ## Skills and tools
@@ -65,6 +66,9 @@ Tune individual skills, project-author new ones, and decide which AI tools each 
 | `scribe kit create <name>` | Create a local kit — a named list of skills and MCP servers scoped to a project (saved to `~/.scribe/kits/<name>.yaml`). Use `--skills`, `--mcp-servers`, and `--registry` to populate it. Reference the kit by name in a project's `.scribe.yaml` under `kits:`. |
 | `scribe kit list` | List local kits from `~/.scribe/kits/*.yaml`. Supports `--fields` and `--json` for agent-readable output. Add `--remote` to include registry-published kits, or `--registry <owner/repo>` to restrict remote discovery to one connected registry. |
 | `scribe kit show <name>` | Show one local kit, including skills and source metadata. Use `scribe kit show <owner/repo>:<kit>` to inspect a registry-published kit without installing it. |
+| `scribe kit install <registry>:<kit>` | Install a registry-published kit into `~/.scribe/kits/`, stamping the source registry. |
+| `scribe kit sync` | Reconcile installed registry-published kits against their upstream registries. |
+| `scribe kit push <name>` | Push a local kit back to its source registry. |
 | `scribe project init` | Create a committed project `.scribe.yaml` for repo-local loadouts. Use `--kits a,b` for non-interactive setup or pick from local kits interactively. |
 
 ## Conflicts and recovery

--- a/docs/projects-and-kits.md
+++ b/docs/projects-and-kits.md
@@ -133,7 +133,7 @@ Resolution precedence:
 
 - Project-local kits in `<project>/.scribe/kits/<name>.yaml` win over global kits in `~/.scribe/kits/<name>.yaml`.
 - Hand-authored global kits with no `source.registry` are protected by default. Scribe refuses to overwrite them unless you pass `--force-kits`.
-- If another registry already owns the same global kit name, Scribe skips that kit and tells you to pass `--force-kits` or run `scribe kit rename` to keep both.
+- If another registry already owns the same global kit name, Scribe skips that kit. Pass `--force-kits` to overwrite the existing kit, or rename one side by hand in `~/.scribe/kits/<name>.yaml` to keep both.
 
 Legacy `scribe.toml` registry manifests do not support `kits:`. Any such block is ignored by the legacy path; migrate the registry to `scribe.yaml` to publish kits.
 


### PR DESCRIPTION
## Summary
Post-ship documentation sync for **v1.4.0**.

Covers everything that landed since v1.3.0:
- PR #213 registry-published kits (new `kits:` registry block, `--force-kits`, `--refresh-kits`, deprecation banner)
- PR #211 local + git source providers (`--source github|git|local`, `--repo`, `--url`, `--ref`, `--path`, `--id`)
- PR #209 structured source identity in state and locks
- PR #210 snippet sync + budget guardrails (test coverage)
- PR #212 MIT license + Code of Conduct
- PR #189 `--resync` on `scribe add` / `scribe browse`, sync surfaces modified skills
- PRs #190–#193 doctor drift output, stale reconcile cleanup, Codex budget under project loadouts, registry add package prompt fix
- New `scribe mcp list` and `scribe registry index` surfaces; `scribe browse` support for Vercel `skills.sh`-style repos

## Changes
- `docs/projects-and-kits.md`: drop stale `scribe kit rename` reference (command does not ship)
- `docs/commands.md`: kit install/sync/push rows, mcp list row, typed source + resync flag notes, resync deprecation note
- `CLAUDE.md`: command table refreshed with v1.4 flags + new commands
- `CHANGELOG.md`: `## Unreleased` → `## v1.4.0 — 2026-05-13`, voice polish, added missing v1.4 items
- `README.md`: status line + JSON envelope example bumped to v1.4.0

## Test plan
- [x] `go test ./...` green on the docs branch (docs-only changes — kept green)
- [ ] CHANGELOG renders cleanly on github.com (preview after push)
- [ ] All flag/command references match `scribe schema --all --json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)