### PR TITLE
chore: wire orchestrator kit into project loadout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 agents/
 entities.json
 mempalace.yaml
+.agents/
+.claude/settings.json
+.claude/skills/
+.codex/
+.lean-ctx/

--- a/.scribe.yaml
+++ b/.scribe.yaml
@@ -1,0 +1,2 @@
+kits:
+    - orchestrator


### PR DESCRIPTION
## Summary
Adopts the `orchestrator` kit in this repo's own `.scribe.yaml` and gitignores agent-local artifact dirs (`.agents/`, `.claude/skills/`, `.codex/`, `.lean-ctx/`) so they don't leak into feature branches.

## Why
Dogfooding the orchestrator kit. Cleanly separates project config from feature work (registry-published-kits PR #213 carried these inadvertently because the commit was authored locally but never pushed).

## Test plan
- [x] No source changes
- [x] No CI changes