### PR TITLE
feat(kit): kit discovery defaults + project init remote kits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Changed
+- **`scribe kit list` shows remote kits by default** — the merged view lists locally installed kits *and* kits from every connected registry, marking remote-only entries. `--local` skips the network for offline / fast iteration; `--remote` hides local-only kits; `--registry <owner/repo>` filters both views to one registry. Connected registries that lack a `scribe.yaml` kit manifest are skipped with a stderr warning instead of aborting the listing. `--local` and `--remote` are mutually exclusive.
+
+### Added
+- **`scribe project init` accepts remote kits** — the picker discovers kits from connected registries (shown as `owner/repo:name (remote)`); selecting one installs the kit and its skills, then writes the local kit name into `.scribe.yaml`. The `--kits` flag accepts the same `owner/repo:name` syntax for non-interactive setup. Already-installed local kits referenced by their remote selector resolve correctly. JSON callers see a single envelope on stdout — nested install output is suppressed.
+
 ## v1.4.0 — 2026-05-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ scribe adopt --dry-run --json | jq '.data.conflicts'
 | `scribe install` | --alias, --all, --force, --json, --registry | no |
 | `scribe kit create` | --description, --force, --json, --mcp-servers, --registry, --skills | no |
 | `scribe kit install` | --alias, --force, --json, --no-deps, --no-interaction | no |
-| `scribe kit list` | --fields, --json, --registry, --remote | no |
+| `scribe kit list` | --fields, --json, --local, --registry, --remote | no |
 | `scribe kit push` | --json, --registry | no |
 | `scribe kit show` | --json | no |
 | `scribe kit sync` | --force, --json, --no-deps, --no-interaction | no |

--- a/SKILL.md
+++ b/SKILL.md
@@ -111,8 +111,10 @@ Use it for installs, updates, removal, adoption of unmanaged local skills, and s
 | sync my skills | `scribe sync --json` |
 | show resolved project loadout | `scribe show --json` |
 | initialize project loadout | `scribe project init --json` |
-| initialize project with kits | `scribe project init --kits <kit1,kit2> --json` |
-| list local kits | `scribe kit list --json` |
+| initialize project with kits (local or remote) | `scribe project init --kits <kit1>,<owner/repo:kit2> --json` |
+| list kits (local + remote, default) | `scribe kit list --json` |
+| list only locally installed kits | `scribe kit list --local --json` |
+| list only remote kits from one registry | `scribe kit list --remote --registry <owner/repo> --json` |
 | show a local kit | `scribe kit show <name> --json` |
 | remove X | `scribe remove X --no-interaction --json` |
 | import existing local skills | `scribe adopt --dry-run --json` |

--- a/cmd/kit.go
+++ b/cmd/kit.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -41,6 +42,7 @@ type kitCreateOptions struct {
 
 type kitListOptions struct {
 	remote   bool
+	local    bool
 	registry string
 }
 
@@ -50,6 +52,7 @@ type kitInstallOptions struct {
 	noDeps        bool
 	noInteraction bool
 	json          bool
+	silent        bool
 }
 
 type kitPushOptions struct {
@@ -200,15 +203,22 @@ func newKitListCommand() *cobra.Command {
 	opts := &kitListOptions{}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List local skill kits",
-		Args:  cobra.NoArgs,
+		Short: "List local and remote skill kits",
+		Long: `List skill kits.
+
+By default, shows both locally installed kits and kits available from connected
+registries. Use --local to skip the network call, --remote to hide local-only
+kits, or --registry to filter both views to a single registry.`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runKitListWithOptions(cmd, args, opts)
 		},
 	}
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
-	cmd.Flags().BoolVar(&opts.remote, "remote", false, "List kits from connected registries")
-	cmd.Flags().StringVar(&opts.registry, "registry", "", "Limit remote kits to one connected registry")
+	cmd.Flags().BoolVar(&opts.remote, "remote", false, "Show only kits available from connected registries")
+	cmd.Flags().BoolVar(&opts.local, "local", false, "Show only locally installed kits (skip network)")
+	cmd.Flags().StringVar(&opts.registry, "registry", "", "Filter kits to one connected registry (owner/repo)")
+	cmd.MarkFlagsMutuallyExclusive("local", "remote")
 	output.AttachFieldsFlag(cmd, kitListFieldSet)
 	return markJSONSupported(cmd)
 }
@@ -350,8 +360,14 @@ func runKitListWithOptions(cmd *cobra.Command, args []string, opts *kitListOptio
 		return err
 	}
 
-	items := kitListItems(loaded)
-	if opts.remote || opts.registry != "" {
+	var items []kitListItem
+	if !opts.remote {
+		items = kitListItems(loaded)
+		if opts.registry != "" {
+			items = filterLocalKitsByRegistry(items, opts.registry)
+		}
+	}
+	if !opts.local {
 		remote, err := remoteKitListItems(cmd, opts, loaded)
 		if err != nil {
 			return err
@@ -504,7 +520,7 @@ func runKitInstall(cmd *cobra.Command, ref string, opts *kitInstallOptions) erro
 	}
 	installedSkills := flattenKitDeps(depsByRegistry)
 	if !opts.noDeps {
-		if err := runKitInstallDepsFn(cmd, factory, depsByRegistry, opts.forceBudget); err != nil {
+		if err := runKitInstallDepsFn(cmd, factory, depsByRegistry, opts.forceBudget, opts.silent); err != nil {
 			return err
 		}
 	}
@@ -538,6 +554,9 @@ func runKitInstall(cmd *cobra.Command, ref string, opts *kitInstallOptions) erro
 		SkillsInstalled:   installedSkills,
 		MissingRefs:       missingRefs,
 		MissingRegistries: missingRegistries,
+	}
+	if opts.silent {
+		return nil
 	}
 	if opts.json {
 		r := jsonRendererForCommand(cmd, true)
@@ -619,7 +638,7 @@ func installableKitRefs(k *kit.Kit, registryRepo string, cfg *config.Config) (ma
 	return deps, missing, missingRegistries, nil
 }
 
-func runKitInstallDeps(cmd *cobra.Command, factory *app.Factory, depsByRegistry map[string][]kitInstallDep, forceBudget bool) error {
+func runKitInstallDeps(cmd *cobra.Command, factory *app.Factory, depsByRegistry map[string][]kitInstallDep, forceBudget bool, silent bool) error {
 	registries := make([]string, 0, len(depsByRegistry))
 	for registryRepo := range depsByRegistry {
 		registries = append(registries, registryRepo)
@@ -650,6 +669,9 @@ func runKitInstallDeps(cmd *cobra.Command, factory *app.Factory, depsByRegistry 
 			FilterRegistries:   filterRegistries,
 			SkillAliases:       aliases,
 			PinnedSkillSources: pinnedSources,
+		}
+		if silent {
+			bag.Formatter = workflow.NewFormatterWithWriters(false, false, io.Discard, io.Discard)
 		}
 		if err := workflow.Run(cmd.Context(), workflow.InstallSteps(), bag); err != nil {
 			return handleNameConflictError(cmd, err)
@@ -758,7 +780,7 @@ func runKitSync(cmd *cobra.Command, opts *kitInstallOptions) error {
 		}
 		installedSkills := flattenKitDeps(depsByRegistry)
 		if !opts.noDeps {
-			if err := runKitInstallDepsFn(cmd, factory, depsByRegistry, opts.forceBudget); err != nil {
+			if err := runKitInstallDepsFn(cmd, factory, depsByRegistry, opts.forceBudget, opts.silent); err != nil {
 				return err
 			}
 		}
@@ -992,23 +1014,30 @@ func remoteKitListItems(cmd *cobra.Command, opts *kitListOptions, local map[stri
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
 	}
-	client, err := factory.Client()
-	if err != nil {
-		return nil, fmt.Errorf("load github client: %w", err)
-	}
 	repos, err := remoteKitRepos(opts.registry, cfg)
 	if err != nil {
 		return nil, err
+	}
+	if len(repos) == 0 {
+		return nil, nil
+	}
+	client, err := factory.Client()
+	if err != nil {
+		return nil, fmt.Errorf("load github client: %w", err)
 	}
 
 	var items []kitListItem
 	for _, repo := range repos {
 		kits, err := listRemoteKitsFn(cmd.Context(), client, repo)
 		if err != nil {
-			return nil, fmt.Errorf("list kits from %s: %w", repo, err)
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: skip remote kits from %s: %v\n", repo, err)
+			continue
 		}
 		for _, remote := range kits {
 			_, installed := local[remote.Name]
+			if installed && !opts.remote {
+				continue
+			}
 			items = append(items, kitListItem{
 				Name:             remote.Name,
 				Description:      remote.Description,
@@ -1101,17 +1130,34 @@ func kitListItems(kits map[string]*kit.Kit) []kitListItem {
 		if k == nil {
 			continue
 		}
-		items = append(items, kitListItem{
+		item := kitListItem{
 			Name:        k.Name,
 			Description: k.Description,
 			SkillsCount: len(k.Skills),
 			Skills:      append([]string(nil), k.Skills...),
-		})
+		}
+		if k.Source != nil {
+			item.Registry = k.Source.Registry
+		}
+		items = append(items, item)
 	}
 	sort.Slice(items, func(i, j int) bool {
 		return items[i].Name < items[j].Name
 	})
 	return items
+}
+
+func filterLocalKitsByRegistry(items []kitListItem, registryRepo string) []kitListItem {
+	if registryRepo == "" {
+		return items
+	}
+	out := items[:0]
+	for _, item := range items {
+		if strings.EqualFold(item.Registry, registryRepo) {
+			out = append(out, item)
+		}
+	}
+	return out
 }
 
 func projectKitListItems(items []kitListItem, fieldsFlag string) (any, error) {

--- a/cmd/kit.go
+++ b/cmd/kit.go
@@ -671,13 +671,23 @@ func runKitInstallDeps(cmd *cobra.Command, factory *app.Factory, depsByRegistry 
 			PinnedSkillSources: pinnedSources,
 		}
 		if silent {
-			bag.Formatter = workflow.NewFormatterWithWriters(false, false, io.Discard, io.Discard)
+			// Discard stdout (progress) so the caller's JSON envelope stays
+			// clean, but keep stderr open — per-skill failures surface there
+			// and would otherwise be invisible.
+			bag.Formatter = workflow.NewFormatterWithWriters(false, false, io.Discard, cmd.ErrOrStderr())
 		}
 		if err := workflow.Run(cmd.Context(), workflow.InstallSteps(), bag); err != nil {
 			return handleNameConflictError(cmd, err)
 		}
 		if err := saveWorkflowState(bag); err != nil {
 			return err
+		}
+		if bag.Partial {
+			return clierrors.Wrap(clierrors.ErrPartialSuccess, "KIT_DEPS_PARTIAL", clierrors.ExitPartial,
+				clierrors.WithMessage(fmt.Sprintf("one or more skills from %s failed to install", registryRepo)),
+				clierrors.WithResource(registryRepo),
+				clierrors.WithRemediation("Inspect stderr for per-skill errors and retry `scribe kit install` after fixing them."),
+			)
 		}
 	}
 	return nil

--- a/cmd/kit_install_test.go
+++ b/cmd/kit_install_test.go
@@ -72,7 +72,7 @@ func TestKitInstallWritesKitStateAndInstallsSameRegistryDeps(t *testing.T) {
 	}
 	var gotDeps map[string][]kitInstallDep
 	var gotForceBudget bool
-	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, forceBudget bool) error {
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, forceBudget bool, _ bool) error {
 		gotDeps = depsByRegistry
 		gotForceBudget = forceBudget
 		return nil
@@ -289,7 +289,7 @@ func TestKitInstallConnectPromptInstallsCrossRegistryRefs(t *testing.T) {
 		return nil
 	}
 	var gotDeps map[string][]kitInstallDep
-	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, _ bool) error {
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, _ bool, _ bool) error {
 		gotDeps = depsByRegistry
 		return nil
 	}
@@ -348,7 +348,7 @@ func TestKitInstallAliasMappingPassesSkillAlias(t *testing.T) {
 	}
 	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "abc123", nil }
 	var gotDeps map[string][]kitInstallDep
-	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, _ bool) error {
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, _ bool, _ bool) error {
 		gotDeps = depsByRegistry
 		return nil
 	}
@@ -402,7 +402,7 @@ func TestKitInstallPinnedGitHubRefPassesPinnedSource(t *testing.T) {
 	}
 	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "abc123", nil }
 	var gotDeps map[string][]kitInstallDep
-	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, _ bool) error {
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, _ bool, _ bool) error {
 		gotDeps = depsByRegistry
 		return nil
 	}
@@ -454,7 +454,7 @@ func TestKitSyncRefreshesInstalledRegistryKit(t *testing.T) {
 	}
 	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "new", nil }
 	var gotDeps map[string][]kitInstallDep
-	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, _ bool) error {
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, depsByRegistry map[string][]kitInstallDep, _ bool, _ bool) error {
 		gotDeps = depsByRegistry
 		return nil
 	}
@@ -529,7 +529,7 @@ func TestKitSyncRefusesToOverwriteLocallyEditedKit(t *testing.T) {
 		return &kit.Kit{Name: entry.Name, Skills: []string{"tdd", "upstream"}, Source: &kit.Source{Registry: registryRepo}}, nil
 	}
 	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "new", nil }
-	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, _ map[string][]kitInstallDep, _ bool) error {
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, _ map[string][]kitInstallDep, _ bool, _ bool) error {
 		t.Fatal("dependencies should not install after local kit conflict")
 		return nil
 	}

--- a/cmd/kit_list_test.go
+++ b/cmd/kit_list_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -115,7 +117,7 @@ skills:
 	}
 }
 
-func TestKitListRemoteJSON(t *testing.T) {
+func TestKitListDefaultMergesLocalAndRemote(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	writeKitFixture(t, home, "local-kit", `name: local-kit
@@ -123,16 +125,171 @@ skills:
   - local-skill
 `)
 
+	stubKitFactory(t, []string{"acme/skills"}, map[string][]registry.ManifestKit{
+		"acme/skills": {{
+			Registry:    "acme/skills",
+			Name:        "remote-kit",
+			Path:        "kits/remote-kit.yaml",
+			Description: "Remote kit",
+			Author:      "acme",
+		}},
+	})
+
+	data := executeKitListJSON(t, "--json")
+	if len(data) != 2 {
+		t.Fatalf("kits count = %d, want 2: %#v", len(data), data)
+	}
+	names := []string{data[0].Name, data[1].Name}
+	sort.Strings(names)
+	if names[0] != "local-kit" || names[1] != "remote-kit" {
+		t.Fatalf("names = %#v, want [local-kit remote-kit]", names)
+	}
+}
+
+func TestKitListRemoteOnlyHidesLocal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeKitFixture(t, home, "local-kit", `name: local-kit
+skills:
+  - local-skill
+`)
+
+	stubKitFactory(t, []string{"acme/skills"}, map[string][]registry.ManifestKit{
+		"acme/skills": {{Registry: "acme/skills", Name: "remote-kit", Path: "kits/remote-kit.yaml"}},
+	})
+
+	data := executeKitListJSON(t, "--remote", "--json")
+	if len(data) != 1 || data[0].Name != "remote-kit" || !data[0].Remote {
+		t.Fatalf("data = %#v, want one remote-kit row", data)
+	}
+}
+
+func TestKitListLocalSkipsNetwork(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeKitFixture(t, home, "local-kit", `name: local-kit
+skills:
+  - local-skill
+`)
+
+	stubKitFactory(t, []string{"acme/skills"}, map[string][]registry.ManifestKit{
+		"acme/skills": nil,
+	})
+	called := false
+	oldList := listRemoteKitsFn
+	listRemoteKitsFn = func(ctx context.Context, f registry.FileFetcher, repo string) ([]registry.ManifestKit, error) {
+		called = true
+		return nil, nil
+	}
+	t.Cleanup(func() { listRemoteKitsFn = oldList })
+
+	data := executeKitListJSON(t, "--local", "--json")
+	if called {
+		t.Fatal("--local must not call remote listing")
+	}
+	if len(data) != 1 || data[0].Name != "local-kit" {
+		t.Fatalf("data = %#v, want one local-kit row", data)
+	}
+}
+
+func TestKitListSkipsRegistryWithoutManifest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	stubKitFactory(t, []string{"broken/skills", "acme/skills"}, map[string][]registry.ManifestKit{
+		"broken/skills": nil,
+		"acme/skills":   {{Registry: "acme/skills", Name: "good-kit", Path: "kits/good-kit.yaml"}},
+	})
+	oldList := listRemoteKitsFn
+	listRemoteKitsFn = func(ctx context.Context, f registry.FileFetcher, repo string) ([]registry.ManifestKit, error) {
+		if repo == "broken/skills" {
+			return nil, fmt.Errorf("no manifest")
+		}
+		return []registry.ManifestKit{{Registry: repo, Name: "good-kit", Path: "kits/good-kit.yaml"}}, nil
+	}
+	t.Cleanup(func() { listRemoteKitsFn = oldList })
+
+	cmd := newKitListCommand()
+	cmd.SetArgs([]string{"--json"})
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute kit list: %v", err)
+	}
+	if !strings.Contains(errBuf.String(), "warning: skip remote kits from broken/skills") {
+		t.Fatalf("missing skip warning, stderr = %q", errBuf.String())
+	}
+	var env testEnvelope
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	var data struct {
+		Kits []kitJSONRow `json:"kits"`
+	}
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if len(data.Kits) != 1 || data.Kits[0].Name != "good-kit" {
+		t.Fatalf("data = %#v, want one good-kit row", data.Kits)
+	}
+}
+
+func TestKitListRegistryFiltersBoth(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeKitFixture(t, home, "acme-kit", `name: acme-kit
+source:
+  registry: acme/skills
+skills:
+  - x
+`)
+	writeKitFixture(t, home, "other-kit", `name: other-kit
+source:
+  registry: other/skills
+skills:
+  - y
+`)
+
+	stubKitFactory(t, []string{"acme/skills", "other/skills"}, map[string][]registry.ManifestKit{
+		"acme/skills":  {{Registry: "acme/skills", Name: "remote-acme", Path: "kits/remote-acme.yaml"}},
+		"other/skills": {{Registry: "other/skills", Name: "remote-other", Path: "kits/remote-other.yaml"}},
+	})
+
+	data := executeKitListJSON(t, "--registry", "acme/skills", "--json")
+	got := map[string]bool{}
+	for _, row := range data {
+		got[row.Name] = true
+	}
+	if !got["acme-kit"] || !got["remote-acme"] || got["other-kit"] || got["remote-other"] {
+		t.Fatalf("filter mismatch: %#v", got)
+	}
+}
+
+type kitJSONRow struct {
+	Name             string `json:"name"`
+	Registry         string `json:"registry,omitempty"`
+	Path             string `json:"path,omitempty"`
+	Remote           bool   `json:"remote,omitempty"`
+	InstalledLocally bool   `json:"installed_locally,omitempty"`
+}
+
+func stubKitFactory(t *testing.T, repos []string, kitsByRepo map[string][]registry.ManifestKit) {
+	t.Helper()
 	oldFactory := commandFactory
 	oldList := listRemoteKitsFn
 	t.Cleanup(func() {
 		commandFactory = oldFactory
 		listRemoteKitsFn = oldList
 	})
+	regs := make([]config.RegistryConfig, 0, len(repos))
+	for _, r := range repos {
+		regs = append(regs, config.RegistryConfig{Repo: r, Enabled: true})
+	}
 	commandFactory = func() *app.Factory {
 		return &app.Factory{
 			Config: func() (*config.Config, error) {
-				return &config.Config{Registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}}}, nil
+				return &config.Config{Registries: regs}, nil
 			},
 			Client: func() (*gh.Client, error) {
 				return gh.NewClient(context.Background(), ""), nil
@@ -140,45 +297,31 @@ skills:
 		}
 	}
 	listRemoteKitsFn = func(_ context.Context, _ registry.FileFetcher, repo string) ([]registry.ManifestKit, error) {
-		return []registry.ManifestKit{{
-			Registry:    repo,
-			Name:        "remote-kit",
-			Path:        "kits/remote-kit.yaml",
-			Description: "Remote kit",
-			Author:      "acme",
-		}}, nil
+		return kitsByRepo[repo], nil
 	}
+}
 
+func executeKitListJSON(t *testing.T, args ...string) []kitJSONRow {
+	t.Helper()
 	cmd := newKitListCommand()
-	cmd.SetArgs([]string{"--remote", "--json"})
+	cmd.SetArgs(args)
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&bytes.Buffer{})
 	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute kit list --remote: %v", err)
+		t.Fatalf("Execute kit list %v: %v", args, err)
 	}
-
 	var env testEnvelope
 	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
 		t.Fatalf("unmarshal envelope: %v\n%s", err, out.String())
 	}
-	var data struct {
-		Kits []struct {
-			Name     string `json:"name"`
-			Registry string `json:"registry,omitempty"`
-			Path     string `json:"path,omitempty"`
-			Remote   bool   `json:"remote,omitempty"`
-		} `json:"kits"`
+	var payload struct {
+		Kits []kitJSONRow `json:"kits"`
 	}
-	if err := json.Unmarshal(env.Data, &data); err != nil {
+	if err := json.Unmarshal(env.Data, &payload); err != nil {
 		t.Fatalf("unmarshal data: %v", err)
 	}
-	if len(data.Kits) != 2 {
-		t.Fatalf("kits count = %d, want 2: %#v", len(data.Kits), data.Kits)
-	}
-	if data.Kits[1].Name != "remote-kit" || data.Kits[1].Registry != "acme/skills" || data.Kits[1].Path != "kits/remote-kit.yaml" || !data.Kits[1].Remote {
-		t.Fatalf("remote kit = %#v", data.Kits[1])
-	}
+	return payload.Kits
 }
 
 func writeKitFixture(t *testing.T, home, name, content string) {

--- a/cmd/project_init.go
+++ b/cmd/project_init.go
@@ -60,13 +60,21 @@ func runProjectInit(cmd *cobra.Command, opts *projectInitOptions) error {
 		return err
 	}
 
-	availableKits, err := discoverProjectInitKits()
+	available, err := discoverProjectInitKits(cmd)
 	if err != nil {
 		return err
 	}
-	selectedKits, err := selectProjectInitKits(cmd, opts.kits, availableKits)
+	selected, err := selectProjectInitKits(cmd, opts.kits, available)
 	if err != nil {
 		return err
+	}
+	if err := installRemoteProjectInitKits(cmd, selected); err != nil {
+		return err
+	}
+
+	selectedKits := make([]string, 0, len(selected))
+	for _, k := range selected {
+		selectedKits = append(selectedKits, k.LocalName)
 	}
 
 	projectPath := filepath.Join(cwd, projectfile.Filename)
@@ -105,7 +113,15 @@ func ensureProjectFileWritable(cwd string, force bool) error {
 	return nil
 }
 
-func discoverProjectInitKits() ([]string, error) {
+type projectInitKit struct {
+	Display   string
+	Selector  string
+	LocalName string
+	Registry  string
+	Remote    bool
+}
+
+func discoverProjectInitKits(cmd *cobra.Command) ([]projectInitKit, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("resolve home directory: %w", err)
@@ -115,36 +131,87 @@ func discoverProjectInitKits() ([]string, error) {
 		return nil, err
 	}
 
-	kits := make([]string, 0, len(loaded))
+	kits := make([]projectInitKit, 0, len(loaded))
 	for name := range loaded {
-		if strings.TrimSpace(name) != "" {
-			kits = append(kits, name)
+		if strings.TrimSpace(name) == "" {
+			continue
 		}
+		kits = append(kits, projectInitKit{Display: name, Selector: name, LocalName: name})
 	}
-	sort.Strings(kits)
+
+	remote, err := remoteKitListItems(cmd, &kitListOptions{}, loaded)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: skip remote kits: %v\n", err)
+	}
+	for _, r := range remote {
+		ref := r.Registry + ":" + r.Name
+		kits = append(kits, projectInitKit{
+			Display:   ref + " (remote)",
+			Selector:  ref,
+			LocalName: r.Name,
+			Registry:  r.Registry,
+			Remote:    true,
+		})
+	}
+
+	sort.Slice(kits, func(i, j int) bool {
+		if kits[i].Remote != kits[j].Remote {
+			return !kits[i].Remote
+		}
+		return kits[i].Display < kits[j].Display
+	})
 	return kits, nil
 }
 
-func selectProjectInitKits(cmd *cobra.Command, rawKits string, availableKits []string) ([]string, error) {
+func selectProjectInitKits(cmd *cobra.Command, rawKits string, available []projectInitKit) ([]projectInitKit, error) {
+	bySelector := make(map[string]projectInitKit, len(available))
+	for _, k := range available {
+		bySelector[k.Selector] = k
+	}
+
 	if strings.TrimSpace(rawKits) != "" {
 		selected := splitProjectInitKits(rawKits)
-		warnUnknownProjectInitKits(cmd, selected, availableKits)
-		return selected, nil
+		byLocalName := make(map[string]projectInitKit, len(available))
+		for _, k := range available {
+			if !k.Remote {
+				byLocalName[k.LocalName] = k
+			}
+		}
+		out := make([]projectInitKit, 0, len(selected))
+		for _, raw := range selected {
+			if k, ok := bySelector[raw]; ok {
+				out = append(out, k)
+				continue
+			}
+			if strings.Contains(raw, ":") {
+				idx := strings.LastIndex(raw, ":")
+				localName := raw[idx+1:]
+				if k, ok := byLocalName[localName]; ok {
+					out = append(out, k)
+					continue
+				}
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: unknown remote kit %s — registry not connected or kit missing\n", raw)
+				continue
+			}
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: unknown kit %s\n", raw)
+			out = append(out, projectInitKit{Display: raw, Selector: raw, LocalName: raw})
+		}
+		return out, nil
 	}
 
-	if len(availableKits) == 0 || !isatty.IsTerminal(os.Stdin.Fd()) {
-		return []string{}, nil
+	if len(available) == 0 || !isatty.IsTerminal(os.Stdin.Fd()) {
+		return nil, nil
 	}
 
-	opts := make([]huh.Option[string], len(availableKits))
-	for i, kit := range availableKits {
-		opts[i] = huh.NewOption(kit, kit)
+	opts := make([]huh.Option[string], len(available))
+	for i, k := range available {
+		opts[i] = huh.NewOption(k.Display, k.Selector)
 	}
-	var selected []string
+	var selectors []string
 	if err := huh.NewMultiSelect[string]().
 		Title("Select kits for this project").
 		Options(opts...).
-		Value(&selected).
+		Value(&selectors).
 		Run(); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
 			return nil, clierrors.Wrap(err, "USER_CANCELED", clierrors.ExitCanceled,
@@ -153,7 +220,29 @@ func selectProjectInitKits(cmd *cobra.Command, rawKits string, availableKits []s
 		}
 		return nil, err
 	}
-	return selected, nil
+	out := make([]projectInitKit, 0, len(selectors))
+	for _, sel := range selectors {
+		if k, ok := bySelector[sel]; ok {
+			out = append(out, k)
+		}
+	}
+	return out, nil
+}
+
+func installRemoteProjectInitKits(cmd *cobra.Command, selected []projectInitKit) error {
+	for _, k := range selected {
+		if !k.Remote {
+			continue
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(), "Installing remote kit %s\n", k.Selector)
+		if err := runKitInstall(cmd, k.Selector, &kitInstallOptions{noInteraction: true, silent: true}); err != nil {
+			return clierrors.Wrap(err, "PROJECT_INIT_KIT_INSTALL_FAILED", clierrors.ExitGeneral,
+				clierrors.WithMessage(fmt.Sprintf("install remote kit %s: %v", k.Selector, err)),
+				clierrors.WithRemediation("Run `scribe kit install "+k.Selector+"` manually to inspect the failure."),
+			)
+		}
+	}
+	return nil
 }
 
 func splitProjectInitKits(raw string) []string {
@@ -165,16 +254,4 @@ func splitProjectInitKits(raw string) []string {
 		}
 	}
 	return kits
-}
-
-func warnUnknownProjectInitKits(cmd *cobra.Command, selected, available []string) {
-	known := make(map[string]bool, len(available))
-	for _, kit := range available {
-		known[kit] = true
-	}
-	for _, kit := range selected {
-		if !known[kit] {
-			fmt.Fprintf(cmd.ErrOrStderr(), "warning: unknown kit %s\n", kit)
-		}
-	}
 }

--- a/cmd/project_init.go
+++ b/cmd/project_init.go
@@ -68,17 +68,21 @@ func runProjectInit(cmd *cobra.Command, opts *projectInitOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := installRemoteProjectInitKits(cmd, selected); err != nil {
-		return err
-	}
 
 	selectedKits := make([]string, 0, len(selected))
 	for _, k := range selected {
 		selectedKits = append(selectedKits, k.LocalName)
 	}
 
+	// Write .scribe.yaml *before* installing remote kits. If a remote install
+	// fails mid-loop, the project file still points at the intended kits so
+	// the user can re-run `scribe kit install` (or `project init --force`)
+	// without losing the selection.
 	projectPath := filepath.Join(cwd, projectfile.Filename)
 	if err := projectfile.Save(projectPath, &projectfile.ProjectFile{Kits: selectedKits}); err != nil {
+		return err
+	}
+	if err := installRemoteProjectInitKits(cmd, selected); err != nil {
 		return err
 	}
 
@@ -132,11 +136,15 @@ func discoverProjectInitKits(cmd *cobra.Command) ([]projectInitKit, error) {
 	}
 
 	kits := make([]projectInitKit, 0, len(loaded))
-	for name := range loaded {
+	for name, k := range loaded {
 		if strings.TrimSpace(name) == "" {
 			continue
 		}
-		kits = append(kits, projectInitKit{Display: name, Selector: name, LocalName: name})
+		entry := projectInitKit{Display: name, Selector: name, LocalName: name}
+		if k != nil && k.Source != nil {
+			entry.Registry = k.Source.Registry
+		}
+		kits = append(kits, entry)
 	}
 
 	remote, err := remoteKitListItems(cmd, &kitListOptions{}, loaded)
@@ -185,8 +193,13 @@ func selectProjectInitKits(cmd *cobra.Command, rawKits string, available []proje
 			}
 			if strings.Contains(raw, ":") {
 				idx := strings.LastIndex(raw, ":")
+				registryName := raw[:idx]
 				localName := raw[idx+1:]
-				if k, ok := byLocalName[localName]; ok {
+				// Only fall back to a locally installed kit when its source
+				// registry matches the explicitly requested registry —
+				// otherwise the user typed `acme/skills:foo` and would
+				// silently get a `foo` kit sourced from another registry.
+				if k, ok := byLocalName[localName]; ok && strings.EqualFold(k.Registry, registryName) {
 					out = append(out, k)
 					continue
 				}

--- a/cmd/project_init_test.go
+++ b/cmd/project_init_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -325,6 +326,152 @@ func TestProjectInitWarnsOnUnknownRemoteKit(t *testing.T) {
 	}
 	if len(pf.Kits) != 0 {
 		t.Fatalf("kits = %#v, want empty (unknown remote dropped)", pf.Kits)
+	}
+}
+
+func TestProjectInitRejectsLocalKitFromDifferentRegistry(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Local kit sourced from other/skills — should NOT satisfy a request for
+	// acme/skills:daily-workflow even though the local name matches.
+	if err := os.MkdirAll(filepath.Join(home, ".scribe", "kits"), 0o755); err != nil {
+		t.Fatalf("mkdir kit: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".scribe", "kits", "daily-workflow.yaml"), []byte("name: daily-workflow\nsource:\n  registry: other/skills\nskills: []\n"), 0o644); err != nil {
+		t.Fatalf("write kit: %v", err)
+	}
+	withProjectInitWorkingDir(t, dir)
+
+	oldFactory := commandFactory
+	t.Cleanup(func() { commandFactory = oldFactory })
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) { return &config.Config{}, nil },
+		}
+	}
+
+	cmd := newProjectInitCommand()
+	cmd.SetArgs([]string{"--kits", "acme/skills:daily-workflow"})
+	var stderr bytes.Buffer
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&stderr)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute project init: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "warning: unknown remote kit acme/skills:daily-workflow") {
+		t.Fatalf("stderr = %q, want unknown remote kit warning (registry mismatch must not silently resolve)", stderr.String())
+	}
+	pf, err := projectfile.Load(filepath.Join(dir, projectfile.Filename))
+	if err != nil {
+		t.Fatalf("load project file: %v", err)
+	}
+	if len(pf.Kits) != 0 {
+		t.Fatalf("kits = %#v, want empty (registry-mismatch local kit must not resolve)", pf.Kits)
+	}
+}
+
+func TestProjectInitResolvesLocalKitFromMatchingRegistry(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".scribe", "kits"), 0o755); err != nil {
+		t.Fatalf("mkdir kit: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".scribe", "kits", "daily-workflow.yaml"), []byte("name: daily-workflow\nsource:\n  registry: acme/skills\nskills: []\n"), 0o644); err != nil {
+		t.Fatalf("write kit: %v", err)
+	}
+	withProjectInitWorkingDir(t, dir)
+
+	oldFactory := commandFactory
+	t.Cleanup(func() { commandFactory = oldFactory })
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) { return &config.Config{}, nil },
+		}
+	}
+
+	cmd := newProjectInitCommand()
+	cmd.SetArgs([]string{"--kits", "acme/skills:daily-workflow"})
+	var stderr bytes.Buffer
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&stderr)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute project init: %v", err)
+	}
+	if strings.Contains(stderr.String(), "warning: unknown remote kit") {
+		t.Fatalf("stderr = %q, want no warning (matching-registry local kit should resolve cleanly)", stderr.String())
+	}
+	pf, err := projectfile.Load(filepath.Join(dir, projectfile.Filename))
+	if err != nil {
+		t.Fatalf("load project file: %v", err)
+	}
+	if got := strings.Join(pf.Kits, ","); got != "daily-workflow" {
+		t.Fatalf("kits = %q, want daily-workflow", got)
+	}
+}
+
+func TestProjectInitWritesScribeYamlBeforeRemoteInstall(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	withProjectInitWorkingDir(t, dir)
+
+	st := stateFixture(t, home)
+	oldFactory := commandFactory
+	oldList := listRemoteKitsFn
+	oldFind := findRemoteKitFn
+	oldFetch := fetchRemoteKitFn
+	oldRev := remoteKitRevFn
+	oldDeps := runKitInstallDepsFn
+	t.Cleanup(func() {
+		commandFactory = oldFactory
+		listRemoteKitsFn = oldList
+		findRemoteKitFn = oldFind
+		fetchRemoteKitFn = oldFetch
+		remoteKitRevFn = oldRev
+		runKitInstallDepsFn = oldDeps
+	})
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) {
+				return &config.Config{Registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}}}, nil
+			},
+			State:  func() (*state.State, error) { return st, nil },
+			Client: func() (*gh.Client, error) { return gh.NewClient(context.Background(), ""), nil },
+		}
+	}
+	listRemoteKitsFn = func(_ context.Context, _ registry.FileFetcher, repo string) ([]registry.ManifestKit, error) {
+		return []registry.ManifestKit{{Registry: repo, Name: "remote-kit", Path: "kits/remote-kit.yaml"}}, nil
+	}
+	findRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, _, name string) (manifest.KitEntry, error) {
+		return manifest.KitEntry{Name: name, Path: "kits/" + name + ".yaml"}, nil
+	}
+	fetchRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, registryRepo string, entry manifest.KitEntry) (*kit.Kit, error) {
+		return &kit.Kit{Name: entry.Name, Skills: []string{"x"}, Source: &kit.Source{Registry: registryRepo}}, nil
+	}
+	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "abc", nil }
+	// Simulate install failure mid-flow.
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, _ map[string][]kitInstallDep, _ bool, _ bool) error {
+		return fmt.Errorf("simulated install failure")
+	}
+
+	cmd := newProjectInitCommand()
+	cmd.SetArgs([]string{"--kits", "acme/skills:remote-kit"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute project init: expected error from install failure, got nil")
+	}
+	// Critical: .scribe.yaml must already exist with the selected kit, so the
+	// user can recover by rerunning `scribe kit install` or `project init --force`.
+	pf, perr := projectfile.Load(filepath.Join(dir, projectfile.Filename))
+	if perr != nil {
+		t.Fatalf("load project file after install failure: %v — .scribe.yaml must be written before remote install runs", perr)
+	}
+	if got := strings.Join(pf.Kits, ","); got != "remote-kit" {
+		t.Fatalf("kits = %q, want remote-kit (project file must persist the selection through install failures)", got)
 	}
 }
 

--- a/cmd/project_init_test.go
+++ b/cmd/project_init_test.go
@@ -2,15 +2,25 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
+	"github.com/Naoray/scribe/internal/app"
 	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	clischema "github.com/Naoray/scribe/internal/cli/schema"
+	"github.com/Naoray/scribe/internal/config"
+	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/kit"
+	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/projectfile"
+	"github.com/Naoray/scribe/internal/registry"
+	"github.com/Naoray/scribe/internal/state"
 )
 
 func TestProjectInitCreatesProjectFile(t *testing.T) {
@@ -209,6 +219,112 @@ func TestProjectInitKitsFlagUsesProvidedValues(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "warning: unknown kit unknown") {
 		t.Fatalf("stderr = %q, want unknown kit warning", stderr.String())
+	}
+}
+
+func TestProjectInitInstallsRemoteKitFromKitsFlag(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	withProjectInitWorkingDir(t, dir)
+
+	st := stateFixture(t, home)
+	oldFactory := commandFactory
+	oldList := listRemoteKitsFn
+	oldFind := findRemoteKitFn
+	oldFetch := fetchRemoteKitFn
+	oldRev := remoteKitRevFn
+	oldDeps := runKitInstallDepsFn
+	t.Cleanup(func() {
+		commandFactory = oldFactory
+		listRemoteKitsFn = oldList
+		findRemoteKitFn = oldFind
+		fetchRemoteKitFn = oldFetch
+		remoteKitRevFn = oldRev
+		runKitInstallDepsFn = oldDeps
+	})
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) {
+				return &config.Config{Registries: []config.RegistryConfig{{Repo: "acme/skills", Enabled: true}}}, nil
+			},
+			State: func() (*state.State, error) { return st, nil },
+			Client: func() (*gh.Client, error) {
+				return gh.NewClient(context.Background(), ""), nil
+			},
+		}
+	}
+	listRemoteKitsFn = func(_ context.Context, _ registry.FileFetcher, repo string) ([]registry.ManifestKit, error) {
+		return []registry.ManifestKit{{Registry: repo, Name: "daily-workflow", Path: "kits/daily-workflow.yaml"}}, nil
+	}
+	findRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, _, name string) (manifest.KitEntry, error) {
+		return manifest.KitEntry{Name: name, Path: "kits/" + name + ".yaml"}, nil
+	}
+	fetchRemoteKitFn = func(_ context.Context, _ registry.FileFetcher, registryRepo string, entry manifest.KitEntry) (*kit.Kit, error) {
+		return &kit.Kit{Name: entry.Name, Skills: []string{"plan-my-day"}, Source: &kit.Source{Registry: registryRepo}}, nil
+	}
+	remoteKitRevFn = func(context.Context, *gh.Client, string) (string, error) { return "abc123", nil }
+	depsCalled := false
+	runKitInstallDepsFn = func(_ *cobra.Command, _ *app.Factory, _ map[string][]kitInstallDep, _ bool, _ bool) error {
+		depsCalled = true
+		return nil
+	}
+
+	cmd := newProjectInitCommand()
+	cmd.SetArgs([]string{"--kits", "acme/skills:daily-workflow"})
+	var stderr bytes.Buffer
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&stderr)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute project init --kits acme/skills:daily-workflow: %v", err)
+	}
+
+	if !depsCalled {
+		t.Fatal("expected remote kit install to call dep workflow")
+	}
+	pf, err := projectfile.Load(filepath.Join(dir, projectfile.Filename))
+	if err != nil {
+		t.Fatalf("load project file: %v", err)
+	}
+	if got := strings.Join(pf.Kits, ","); got != "daily-workflow" {
+		t.Fatalf("kits = %q, want daily-workflow", got)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".scribe", "kits", "daily-workflow.yaml")); err != nil {
+		t.Fatalf("installed kit missing: %v", err)
+	}
+}
+
+func TestProjectInitWarnsOnUnknownRemoteKit(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	withProjectInitWorkingDir(t, dir)
+
+	oldFactory := commandFactory
+	t.Cleanup(func() { commandFactory = oldFactory })
+	commandFactory = func() *app.Factory {
+		return &app.Factory{
+			Config: func() (*config.Config, error) { return &config.Config{}, nil },
+		}
+	}
+
+	cmd := newProjectInitCommand()
+	cmd.SetArgs([]string{"--kits", "ghost/skills:nope"})
+	var stderr bytes.Buffer
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&stderr)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute project init: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "warning: unknown remote kit ghost/skills:nope") {
+		t.Fatalf("stderr = %q, want unknown remote kit warning", stderr.String())
+	}
+	pf, err := projectfile.Load(filepath.Join(dir, projectfile.Filename))
+	if err != nil {
+		t.Fatalf("load project file: %v", err)
+	}
+	if len(pf.Kits) != 0 {
+		t.Fatalf("kits = %#v, want empty (unknown remote dropped)", pf.Kits)
 	}
 }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -64,12 +64,12 @@ Tune individual skills, project-author new ones, and decide which AI tools each 
 | `scribe tools` | List, enable, or disable detected tools machine-wide |
 | `scribe tools add` | Register a custom tool integration (`--detect`, `--install`, `--path`, `--uninstall`) |
 | `scribe kit create <name>` | Create a local kit — a named list of skills and MCP servers scoped to a project (saved to `~/.scribe/kits/<name>.yaml`). Use `--skills`, `--mcp-servers`, and `--registry` to populate it. Reference the kit by name in a project's `.scribe.yaml` under `kits:`. |
-| `scribe kit list` | List local kits from `~/.scribe/kits/*.yaml`. Supports `--fields` and `--json` for agent-readable output. Add `--remote` to include registry-published kits, or `--registry <owner/repo>` to restrict remote discovery to one connected registry. |
+| `scribe kit list` | List local kits from `~/.scribe/kits/*.yaml` *and* registry-published kits from every connected registry by default (per-registry skip-and-warn when a registry has no `scribe.yaml` kit manifest). Pass `--local` to skip the network, `--remote` to hide local kits, or `--registry <owner/repo>` to filter both views to one registry. Supports `--fields` and `--json` for agent-readable output. |
 | `scribe kit show <name>` | Show one local kit, including skills and source metadata. Use `scribe kit show <owner/repo>:<kit>` to inspect a registry-published kit without installing it. |
 | `scribe kit install <registry>:<kit>` | Install a registry-published kit into `~/.scribe/kits/`, stamping the source registry. |
 | `scribe kit sync` | Reconcile installed registry-published kits against their upstream registries. |
 | `scribe kit push <name>` | Push a local kit back to its source registry. |
-| `scribe project init` | Create a committed project `.scribe.yaml` for repo-local loadouts. Use `--kits a,b` for non-interactive setup or pick from local kits interactively. |
+| `scribe project init` | Create a committed project `.scribe.yaml` for repo-local loadouts. The picker discovers local kits and kits available from connected registries (selecting a remote kit installs it first). `--kits a,b,owner/repo:c` accepts both local kit names and `owner/repo:name` remote refs for non-interactive setup. |
 
 ## Conflicts and recovery
 

--- a/docs/projects-and-kits.md
+++ b/docs/projects-and-kits.md
@@ -18,7 +18,7 @@ Effect: a session's skill set is determined by `cwd`. Two repos see two differen
 
 ## `.scribe.yaml`
 
-A `.scribe.yaml` at a project root declares the project's intent. All keys are optional. Run `scribe project init` to scaffold the file, optionally with `--kits web,backend` for non-interactive setup.
+A `.scribe.yaml` at a project root declares the project's intent. All keys are optional. Run `scribe project init` to scaffold the file, optionally with `--kits web,backend` for non-interactive setup. The picker lists local kits *and* kits available from connected registries (shown as `owner/repo:name (remote)`); selecting a remote kit installs it first, then writes the local name into `.scribe.yaml`. The flag form accepts the same `owner/repo:name` syntax — useful for non-interactive setup that needs a registry kit you have not installed yet.
 
 ```yaml
 # .scribe.yaml — committed to the repo so the team shares the same skill set
@@ -103,7 +103,7 @@ mcp_servers:
 
 Projects list which kits they want via `kits:` in `.scribe.yaml`. Multiple kits union; the project may add or remove individual skills on top with `add:` / `remove:`. MCP servers can also be declared through kits or directly in `.scribe.yaml` with `mcp:` / `mcp_servers:`; `scribe sync` uses those names to select definitions from project `.mcp.json`. Claude gets enabled server names in `.claude/settings.json`, Codex gets selected definitions in `.codex/config.toml`, and Cursor gets selected definitions in `.cursor/mcp.json`. Existing unmanaged Codex/Cursor entries are preserved; Scribe only replaces entries it previously projected. Scribe does not start MCP server processes.
 
-Use `scribe kit list --remote` to list kits from connected registries, `scribe kit list --registry <owner/repo>` to restrict discovery, and `scribe kit show <owner/repo>:<kit> --json` to inspect a remote kit body. Remote show classifies each skill ref as same-registry, cross-registry, or local and reports whether referenced registries are connected.
+`scribe kit list` shows local kits *and* kits from every connected registry by default, marking remote-only entries so you can spot them in the merged view. Pass `--local` to skip the network call (offline / fast iteration), `--remote` to hide local kits, and `--registry <owner/repo>` to filter both views to a single registry. Registries that lack a `scribe.yaml` kit manifest are skipped with a stderr warning instead of aborting the listing. Use `scribe kit show <owner/repo>:<kit> --json` to inspect a remote kit body without installing it; remote show classifies each skill ref as same-registry, cross-registry, or local and reports whether referenced registries are connected.
 
 ### Kits from registries
 


### PR DESCRIPTION
## Summary

Two related ergonomic fixes for kit discovery and project bootstrap:

**`scribe kit list` defaults to merged local + remote.** Previously local-only — Naoray/skills (or any other registry) only showed up behind a `--remote` flag that aborted hard on the first connected registry without a kit manifest (e.g. anthropics/skills). Now the default merges both views; per-registry failures skip-and-warn instead of killing the listing.

- `--local` skips the network for offline / fast iteration
- `--remote` hides local-only kits (semantic shift, mutually exclusive with `--local`)
- `--registry <owner/repo>` filters both views to one registry
- Local kits gain a `Source.Registry` field in the JSON output so the merged view stays disambiguatable

**`scribe project init` accepts remote kits.** The interactive picker now discovers remote kits from connected registries (shown as `owner/repo:name (remote)`); selecting one installs the kit and its skills first, then writes the local kit name into `.scribe.yaml`. The `--kits` flag accepts the same `owner/repo:name` syntax for non-interactive setup. JSON callers see a single envelope on stdout — nested install output is suppressed via a new `kitInstallOptions.silent` flag.

Already-installed local kits referenced by their remote selector resolve correctly (lookup falls back to local-name match).

## Files

- `cmd/kit.go` — kit list flow, dedup vs local, lazy GitHub client, silent install path
- `cmd/project_init.go` — discover + install + flag-syntax handling for remote kits
- `cmd/kit_list_test.go`, `cmd/kit_install_test.go`, `cmd/project_init_test.go` — coverage for new defaults, mutex, registry filter, skip-on-error, remote-kit install via `--kits`, unknown-remote warning, signature changes
- `docs/commands.md`, `docs/projects-and-kits.md`, `SKILL.md`, `CHANGELOG.md` (Unreleased), `CLAUDE.md` — flag table + trigger phrase updates

## Test plan

- [x] `go test ./...` passes
- [x] End-to-end: `scribe kit list` against the actual installed registries shows Naoray's 5 kits alongside locals, with stderr warnings for the three manifest-less registries
- [x] `scribe kit list --registry Naoray/skills` returns only Naoray's 5 kits
- [x] `scribe kit list --local` runs offline (zero network calls)
- [x] `scribe kit list --local --remote` rejected with mutex error
- [x] `scribe project init --kits Naoray/skills:methodology --json --force` installs the kit + dependent skills, writes single JSON envelope on stdout, `.scribe.yaml` contains `methodology` (local name)
- [x] Same command after the kit is already installed locally still resolves cleanly (no "unknown remote" warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)