### PR TITLE
[agent] fix kits-only project sync

### DIFF
--- a/cmd/project_sync.go
+++ b/cmd/project_sync.go
@@ -106,10 +106,13 @@ func runProjectSync(cmd *cobra.Command, opts *projectSyncOptions) error {
 	if err != nil {
 		return err
 	}
-	skillNames := resolveProjectSkillNames(pf, globalKits)
 	vendorSet := map[string]bool{}
 	for _, name := range opts.vendors {
 		vendorSet[projectSkillName(name)] = true
+	}
+	var skillNames []string
+	if shouldSyncProjectSkills(pf, vendorSet) {
+		skillNames = resolveProjectSkillNames(pf, globalKits)
 	}
 	lockEntries, err := syncProjectSkills(projectRoot, storeDir, skillNames, vendorSet, st, opts, &out)
 	if err != nil {
@@ -417,6 +420,13 @@ func writeProjectLock(projectRoot string, kits []lockfile.ProjectKit, entries []
 		)
 	}
 	return store.WriteProjectLockfile(lf)
+}
+
+func shouldSyncProjectSkills(pf *projectfile.ProjectFile, vendorSet map[string]bool) bool {
+	if pf != nil && len(pf.Add) > 0 {
+		return true
+	}
+	return len(vendorSet) > 0
 }
 
 func resolveProjectSkillNames(pf *projectfile.ProjectFile, kits map[string]*kit.Kit) []string {

--- a/cmd/project_test.go
+++ b/cmd/project_test.go
@@ -130,6 +130,64 @@ func TestProjectSyncVendorsProjectSkillAndPinsRegistrySkill(t *testing.T) {
 	}
 }
 
+func TestProjectSyncKitsOnlySkipsSkillHashing(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	t.Setenv("HOME", home)
+	mustChdir(t, project)
+
+	mustWriteProjectFile(t, filepath.Join(project, ".scribe.yaml"), "kits:\n  - core\n")
+	mustSaveProjectKit(t, filepath.Join(home, ".scribe", "kits", "core.yaml"), &kit.Kit{Name: "core", Skills: []string{"deploy"}})
+	if err := os.MkdirAll(filepath.Join(home, ".scribe", "skills", "deploy"), 0o755); err != nil {
+		t.Fatalf("mkdir empty skill dir: %v", err)
+	}
+
+	st := stateFixture(t, home)
+	st.Kits["core"] = state.InstalledKit{
+		Name:           "core",
+		SourceRegistry: "acme/skills",
+		Rev:            "kitsha",
+		ContentHash:    "kithash",
+		Skills:         []string{"deploy"},
+	}
+	st.Installed["deploy"] = state.InstalledSkill{
+		InstalledHash: "hash",
+		Sources: []state.SkillSource{{
+			Registry:   "acme/skills",
+			SourceRepo: "acme/source",
+			Path:       "skills/deploy",
+			Ref:        "main",
+			LastSHA:    "abc123",
+			LastSynced: time.Now(),
+		}},
+	}
+	if err := st.Save(); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	for _, args := range [][]string{{}, {"--force"}} {
+		cmd := newProjectSyncCommand()
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("project sync %v: %v", args, err)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(project, ".ai", "kits", "core.yaml")); err != nil {
+		t.Fatalf("project kit missing: %v", err)
+	}
+	lf, err := projectstore.Project(project).LoadProjectLockfile()
+	if err != nil {
+		t.Fatalf("load lockfile: %v", err)
+	}
+	if len(lf.Entries) != 0 {
+		t.Fatalf("entries = %+v, want none for kits-only project sync", lf.Entries)
+	}
+	if len(lf.Kits) != 1 || lf.Kits[0].Name != "core" {
+		t.Fatalf("kit pins = %+v", lf.Kits)
+	}
+}
+
 func TestProjectSyncPinsPackagePerToolCommands(t *testing.T) {
 	home := t.TempDir()
 	project := t.TempDir()


### PR DESCRIPTION
## Summary
- skip project skill hash/pin generation for kits-only project sync manifests
- keep kit artifact publishing and kit pin lockfile output intact
- add regression coverage for `scribe project sync` and `scribe project sync --force` with a kits-only manifest and empty skill tree

## Tests
- `go test ./cmd ./internal/sync ./internal/projectstore`
- `go test ./...`

## Risk
- Low. The skip is limited to manifests without `add:` entries and without explicit `--vendor`; existing non-empty project skill sync still resolves kit skills and writes lock entries.