### PR TITLE
Fix list attribution order

### DIFF
--- a/cmd/list_tui_render.go
+++ b/cmd/list_tui_render.go
@@ -396,13 +396,13 @@ func (m listModel) formatRow(row listRow, isCursor bool, nameCol int, compact bo
 	author = runewidth.FillRight(author, 12)
 
 	line := prefix + nameStyle.Render(name) + "  " + ltDimStyle.Render(ver) + "  " + ltDimStyle.Render(author)
-	line += sourceAttributionMarker(row)
 
 	if row.HasStatus {
 		icon := statusStyles[row.Status].Render(row.Status.Display().Icon)
 		label := statusStyles[row.Status].Render(row.Status.Display().Label)
 		line += "  " + icon + " " + label
 	}
+	line += sourceAttributionMarker(row)
 
 	if !row.Managed {
 		line += " " + ltDimStyle.Render("[unmanaged]")

--- a/cmd/list_tui_test.go
+++ b/cmd/list_tui_test.go
@@ -1353,6 +1353,31 @@ func TestFormatRow_LocalRowsShowSourceAttributionMarker(t *testing.T) {
 	}
 }
 
+func TestFormatRow_FullStatusRowsShowSourceAttributionAfterStatus(t *testing.T) {
+	m := listModel{width: 120}
+	row := listRow{
+		Name:      "recap",
+		Managed:   true,
+		HasStatus: true,
+		Status:    sync.StatusCurrent,
+		Version:   "v1.2.3",
+		Author:    "artistfy",
+		Source: discovery.Source{
+			Author: "acme",
+		},
+	}
+
+	formatted := m.formatRow(row, false, 20, false)
+	statusIndex := strings.Index(formatted, "current")
+	attributionIndex := strings.Index(formatted, "ℹ️ (via acme)")
+	if statusIndex == -1 || attributionIndex == -1 {
+		t.Fatalf("formatted row should include status and source marker, got: %q", formatted)
+	}
+	if attributionIndex < statusIndex {
+		t.Fatalf("source marker should appear after status, got: %q", formatted)
+	}
+}
+
 func TestFormatRow_LocalRegistryRowsShowSkeletonWhileBackgroundLoading(t *testing.T) {
 	m := listModel{width: 120, backgroundLoad: true, spinnerFrame: 0}
 	row := listRow{


### PR DESCRIPTION
## Summary
- Move source attribution after the status icon and label for full list rows with status
- Add a focused regression test for status/source marker ordering

## Tests
- go test ./cmd
- go test ./...