### PR TITLE
fix(kit-list): silently skip registries without a kit manifest

### DIFF
--- a/cmd/kit.go
+++ b/cmd/kit.go
@@ -1040,6 +1040,9 @@ func remoteKitListItems(cmd *cobra.Command, opts *kitListOptions, local map[stri
 	for _, repo := range repos {
 		kits, err := listRemoteKitsFn(cmd.Context(), client, repo)
 		if err != nil {
+			if clierrors.IsCode(err, "REGISTRY_NOT_FOUND") {
+				continue
+			}
 			fmt.Fprintf(cmd.ErrOrStderr(), "warning: skip remote kits from %s: %v\n", repo, err)
 			continue
 		}

--- a/cmd/kit_list_test.go
+++ b/cmd/kit_list_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/Naoray/scribe/internal/app"
+	clierrors "github.com/Naoray/scribe/internal/cli/errors"
 	"github.com/Naoray/scribe/internal/config"
 	gh "github.com/Naoray/scribe/internal/github"
 	"github.com/Naoray/scribe/internal/registry"
@@ -192,7 +193,7 @@ skills:
 	}
 }
 
-func TestKitListSkipsRegistryWithoutManifest(t *testing.T) {
+func TestKitListWarnsOnRegistryListFailure(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -203,7 +204,7 @@ func TestKitListSkipsRegistryWithoutManifest(t *testing.T) {
 	oldList := listRemoteKitsFn
 	listRemoteKitsFn = func(ctx context.Context, f registry.FileFetcher, repo string) ([]registry.ManifestKit, error) {
 		if repo == "broken/skills" {
-			return nil, fmt.Errorf("no manifest")
+			return nil, fmt.Errorf("permission denied")
 		}
 		return []registry.ManifestKit{{Registry: repo, Name: "good-kit", Path: "kits/good-kit.yaml"}}, nil
 	}
@@ -219,6 +220,49 @@ func TestKitListSkipsRegistryWithoutManifest(t *testing.T) {
 	}
 	if !strings.Contains(errBuf.String(), "warning: skip remote kits from broken/skills") {
 		t.Fatalf("missing skip warning, stderr = %q", errBuf.String())
+	}
+	var env testEnvelope
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	var data struct {
+		Kits []kitJSONRow `json:"kits"`
+	}
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if len(data.Kits) != 1 || data.Kits[0].Name != "good-kit" {
+		t.Fatalf("data = %#v, want one good-kit row", data.Kits)
+	}
+}
+
+func TestKitListSilentlySkipsRegistryWithoutManifest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	stubKitFactory(t, []string{"missing/skills", "acme/skills"}, map[string][]registry.ManifestKit{
+		"missing/skills": nil,
+		"acme/skills":    {{Registry: "acme/skills", Name: "good-kit", Path: "kits/good-kit.yaml"}},
+	})
+	oldList := listRemoteKitsFn
+	listRemoteKitsFn = func(ctx context.Context, f registry.FileFetcher, repo string) ([]registry.ManifestKit, error) {
+		if repo == "missing/skills" {
+			return nil, clierrors.Wrap(fmt.Errorf("no manifest"), "REGISTRY_NOT_FOUND", clierrors.ExitNotFound)
+		}
+		return []registry.ManifestKit{{Registry: repo, Name: "good-kit", Path: "kits/good-kit.yaml"}}, nil
+	}
+	t.Cleanup(func() { listRemoteKitsFn = oldList })
+
+	cmd := newKitListCommand()
+	cmd.SetArgs([]string{"--json"})
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute kit list: %v", err)
+	}
+	if strings.Contains(errBuf.String(), "warning: skip remote kits from missing/skills") {
+		t.Fatalf("unexpected skip warning, stderr = %q", errBuf.String())
 	}
 	var env testEnvelope
 	if err := json.Unmarshal(out.Bytes(), &env); err != nil {

--- a/internal/add/events.go
+++ b/internal/add/events.go
@@ -21,5 +21,3 @@ type SkillAddErrorMsg struct {
 	Name string
 	Err  error
 }
-
-

--- a/internal/adopt/adopt.go
+++ b/internal/adopt/adopt.go
@@ -55,7 +55,7 @@ type Result struct {
 type Adopter struct {
 	State *state.State
 	Tools []tools.Tool // tools to consider (typically tools.DefaultTools())
-	Emit  func(any)   // optional; nil is safe
+	Emit  func(any)    // optional; nil is safe
 }
 
 // FindCandidates walks configured adoption paths (via cfg.AdoptionPaths())

--- a/internal/cli/errors/error.go
+++ b/internal/cli/errors/error.go
@@ -99,6 +99,11 @@ func Wrap(err error, code string, exit int, opts ...Option) error {
 	return ce
 }
 
+func IsCode(err error, code string) bool {
+	var ce *Error
+	return stderrors.As(err, &ce) && ce.Code == code
+}
+
 func ExitCode(err error) int {
 	if err == nil {
 		return ExitOK

--- a/internal/sync/detect.go
+++ b/internal/sync/detect.go
@@ -24,11 +24,11 @@ const (
 // its repo root. Presence of any (executable or not) marks a payload as a
 // self-installing package when the root SKILL.md is absent.
 var installScriptNames = map[string]bool{
-	"setup":       true,
-	"install.sh":  true,
-	"install":     true,
-	"bootstrap":   true,
-	"Makefile":    true,
+	"setup":        true,
+	"install.sh":   true,
+	"install":      true,
+	"bootstrap":    true,
+	"Makefile":     true,
 	"package.json": true,
 }
 

--- a/internal/sync/detect_test.go
+++ b/internal/sync/detect_test.go
@@ -80,7 +80,7 @@ func TestDetectKind(t *testing.T) {
 			want: sync.KindSkill,
 		},
 		{
-			name: "skill: empty tree",
+			name:  "skill: empty tree",
 			files: []tools.SkillFile{},
 			want:  sync.KindSkill,
 		},

--- a/internal/sync/package_install.go
+++ b/internal/sync/package_install.go
@@ -117,7 +117,7 @@ func RunPackageCommand(ctx context.Context, exec CommandExecutor, pkgDir, cmd st
 }
 
 // shellQuote wraps s in single quotes so it can be safely interpolated into
-// a sh -c command string. Any single quote inside is escaped via '\''.
+// a sh -c command string.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/sync/package_install.go
+++ b/internal/sync/package_install.go
@@ -117,7 +117,8 @@ func RunPackageCommand(ctx context.Context, exec CommandExecutor, pkgDir, cmd st
 }
 
 // shellQuote wraps s in single quotes so it can be safely interpolated into
-// a sh -c command string.
+// a sh -c command string. Embedded single quotes are escaped by closing the
+// quoted span, emitting an escaped quote, and reopening.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/workflow/list_test.go
+++ b/internal/workflow/list_test.go
@@ -402,8 +402,8 @@ func TestBuildLocalRows_HidesBootstrapOrigin(t *testing.T) {
 	// by the CLI and shouldn't appear in `scribe list`. It can't be removed
 	// — the next invocation re-installs it — so listing it just clutters.
 	st := &state.State{Installed: map[string]state.InstalledSkill{
-		"my-skill":     {Origin: state.OriginRegistry},
-		"scribe": {Origin: state.OriginBootstrap},
+		"my-skill": {Origin: state.OriginRegistry},
+		"scribe":   {Origin: state.OriginBootstrap},
 	}}
 	skills := []discovery.Skill{
 		{Name: "my-skill", Managed: true},
@@ -438,9 +438,9 @@ func TestBuildLocalRowsExcluding_FiltersBootstrapAfterMatching(t *testing.T) {
 	// matched entries. Verify the bootstrap filter survives the exclusion
 	// path (regression for #487 second-order coverage).
 	st := &state.State{Installed: map[string]state.InstalledSkill{
-		"matched":      {Origin: state.OriginRegistry},
-		"my-skill":     {Origin: state.OriginRegistry},
-		"scribe": {Origin: state.OriginBootstrap},
+		"matched":  {Origin: state.OriginRegistry},
+		"my-skill": {Origin: state.OriginRegistry},
+		"scribe":   {Origin: state.OriginBootstrap},
 	}}
 	skills := []discovery.Skill{
 		{Name: "matched", Managed: true},


### PR DESCRIPTION
- Silently skips remote kit registries whose manifest lookup returns REGISTRY_NOT_FOUND, which covers skill-only registries without scribe.yaml or scribe.toml.
- Keeps warnings for other registry listing failures such as permission, network, or manifest parse errors.
- Adds clierrors.IsCode and kit-list coverage for both the silent not-found path and the still-warning failure path.
- Brief: solo://proj/10/scratchpad/brief-quiet-scribe-k--904