### PR TITLE
fix(budget): convert byte-budget guardrails to warn-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Changed
+- Budget guardrails are now warn-only. `scribe add`, `scribe install`, `scribe sync`, and `scribe kit install` no longer abort when projected skills exceed an agent's description-byte budget; they emit a warning and proceed. `--force` is preserved as a deprecated no-op.
+
 ## v1.5.1 — 2026-05-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 
 ### Changed
-- Budget guardrails are now warn-only. `scribe add`, `scribe install`, `scribe sync`, and `scribe kit install` no longer abort when projected skills exceed an agent's description-byte budget; they emit a warning and proceed. `--force` is preserved as a deprecated no-op.
+- Budget guardrails are now warn-only. `scribe add`, `scribe install`, `scribe sync`, `scribe kit install`, and `scribe migrate global-to-projects` no longer abort when projected skills exceed an agent's description-byte budget; they emit a warning and proceed. `--force` is preserved as a deprecated no-op.
 
 ## v1.5.1 — 2026-05-17
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -73,7 +73,7 @@ Examples:
 	addNoInteractionFlag(cmd, "Disable interactive prompts", false)
 	cmd.Flags().Bool("json", false, "Output machine-readable JSON")
 	addSourceFlags(cmd, true)
-	cmd.Flags().Bool("force", false, "Project skills even when an agent budget is exceeded")
+	cmd.Flags().Bool("force", false, "Deprecated: budget guardrails are warn-only (no-op)")
 	cmd.Flags().Bool("resync", false, "Overwrite local edits with the upstream version for modified skills")
 	cmd.Flags().String("alias", "", "Install incoming skill under this name when a local directory conflicts")
 	return markJSONSupported(cmd)
@@ -87,6 +87,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	forceBudget, _ := cmd.Flags().GetBool("force")
+	warnDeprecatedForceBudget(cmd)
 	resync, _ := cmd.Flags().GetBool("resync")
 	aliasName, _ := cmd.Flags().GetString("alias")
 
@@ -104,7 +105,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("load state: %w", err)
 	}
-	if err := enforceCurrentBudget(factory, forceBudget); err != nil {
+	if err := enforceCurrentBudget(factory); err != nil {
 		return err
 	}
 

--- a/cmd/budget_helpers.go
+++ b/cmd/budget_helpers.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/Naoray/scribe/internal/app"
 	"github.com/Naoray/scribe/internal/budget"
@@ -15,6 +16,7 @@ import (
 	"github.com/Naoray/scribe/internal/snippet"
 	"github.com/Naoray/scribe/internal/state"
 	"github.com/Naoray/scribe/internal/tools"
+	"github.com/spf13/cobra"
 )
 
 type resolvedBudgetSet struct {
@@ -165,7 +167,15 @@ func containsBudgetTool(tools []string, agent string) bool {
 	return false
 }
 
-func enforceCurrentBudget(factory *app.Factory, force bool) error {
+const deprecatedForceBudgetWarning = "warning: --force is deprecated; budget guardrails are now warn-only"
+
+func warnDeprecatedForceBudget(cmd *cobra.Command) {
+	if cmd.Flags().Changed("force") {
+		fmt.Fprintln(cmd.ErrOrStderr(), deprecatedForceBudgetWarning)
+	}
+}
+
+func enforceCurrentBudget(factory *app.Factory) error {
 	cfg, err := factory.Config()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
@@ -180,16 +190,18 @@ func enforceCurrentBudget(factory *app.Factory, force bool) error {
 		// validation, fetch, or auth errors.
 		return nil
 	}
+	var warnings []string
 	for _, agent := range budgetAgents(cfg) {
 		result := budget.CheckProjectionBudget(budgetSkillsForAgent(set, st, agent), agent)
 		switch result.Status {
 		case budget.StatusRefuse:
-			if !force {
-				return fmt.Errorf("%s\nTry removing one kit, or rerun with --force to project anyway.", budget.FormatOverflow(result))
-			}
+			warnings = append(warnings, budget.FormatOverflow(result))
 		case budget.StatusWarn:
-			fmt.Fprintf(os.Stderr, "warning: %s\n", budget.FormatResult(result))
+			warnings = append(warnings, budget.FormatResult(result))
 		}
+	}
+	if len(warnings) > 0 {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", strings.Join(warnings, "\n\n"))
 	}
 	return nil
 }

--- a/cmd/budget_helpers_test.go
+++ b/cmd/budget_helpers_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +12,9 @@ import (
 	"github.com/Naoray/scribe/internal/app"
 	"github.com/Naoray/scribe/internal/budget"
 	"github.com/Naoray/scribe/internal/config"
+	gh "github.com/Naoray/scribe/internal/github"
+	"github.com/Naoray/scribe/internal/manifest"
+	"github.com/Naoray/scribe/internal/provider"
 	"github.com/Naoray/scribe/internal/state"
 )
 
@@ -168,7 +174,7 @@ func TestProjectBudgetIncludesTargetedSnippets(t *testing.T) {
 	}
 }
 
-func TestEnforceCurrentBudgetReportsOverflowContributors(t *testing.T) {
+func TestEnforceCurrentBudgetWarnsOnOverflow(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	wd := t.TempDir()
@@ -182,29 +188,31 @@ func TestEnforceCurrentBudgetReportsOverflowContributors(t *testing.T) {
 	}
 
 	factory := budgetTestFactory(&state.State{Installed: map[string]state.InstalledSkill{
-		"huge-alpha": {Tools: []string{"codex"}},
-		"huge-beta":  {Tools: []string{"codex"}},
+		"huge-alpha": {Tools: []string{"codex"}, Sources: []state.SkillSource{{Registry: "acme/team", Ref: "main"}}},
+		"huge-beta":  {Tools: []string{"codex"}, Sources: []state.SkillSource{{Registry: "acme/team", Ref: "main"}}},
 	}})
-	err := enforceCurrentBudget(factory, false)
-	if err == nil {
-		t.Fatal("enforceCurrentBudget returned nil, want budget refusal")
+	var err error
+	got := captureStderr(t, func() {
+		err = enforceCurrentBudget(factory)
+	})
+	if err != nil {
+		t.Fatalf("enforceCurrentBudget returned error: %v", err)
 	}
-	got := err.Error()
 	for _, want := range []string{
+		"warning:",
 		"Codex skill budget exceeded",
 		"estimated: 5800 / 5440 bytes",
 		"biggest contributors:",
 		"huge-alpha: 4000 bytes",
 		"huge-beta: 1800 bytes",
-		"rerun with --force",
 	} {
 		if !strings.Contains(got, want) {
-			t.Fatalf("error missing %q:\n%s", want, got)
+			t.Fatalf("stderr missing %q:\n%s", want, got)
 		}
 	}
 }
 
-func TestEnforceCurrentBudgetForceBypassesRefusal(t *testing.T) {
+func TestSyncCommandWarnsAndContinuesWhenBudgetExceeded(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	wd := t.TempDir()
@@ -221,9 +229,44 @@ func TestEnforceCurrentBudgetForceBypassesRefusal(t *testing.T) {
 		"huge-alpha": {Tools: []string{"codex"}},
 		"huge-beta":  {Tools: []string{"codex"}},
 	}})
-	if err := enforceCurrentBudget(factory, true); err != nil {
-		t.Fatalf("enforceCurrentBudget(force=true): %v", err)
+	factory.Config = func() (*config.Config, error) {
+		return &config.Config{Registries: []config.RegistryConfig{{Repo: "acme/team", Enabled: true, Type: config.RegistryTypeTeam}}}, nil
 	}
+	factory.Provider = func() (provider.Provider, error) {
+		return budgetSyncProvider{}, nil
+	}
+	oldFactory := commandFactory
+	commandFactory = func() *app.Factory { return factory }
+	t.Cleanup(func() { commandFactory = oldFactory })
+
+	cmd := newSyncCommand()
+	cmd.SetArgs(nil)
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	var execErr error
+	got := captureStderr(t, func() {
+		execErr = cmd.Execute()
+	})
+	if execErr != nil {
+		t.Fatalf("sync Execute() returned error: %v\nstdout=%s\nstderr=%s%s", execErr, out.String(), errOut.String(), got)
+	}
+	if !strings.Contains(got, "Codex skill budget exceeded") || !strings.Contains(got, "huge-alpha: 4000 bytes") {
+		t.Fatalf("stderr missing budget warning:\n%s", got)
+	}
+}
+
+type budgetSyncProvider struct{}
+
+func (budgetSyncProvider) Discover(context.Context, string) (*provider.DiscoverResult, error) {
+	return &provider.DiscoverResult{IsTeam: true, Entries: []manifest.Entry{
+		{Name: "huge-alpha", Source: "github:acme/team@main"},
+		{Name: "huge-beta", Source: "github:acme/team@main"},
+	}}, nil
+}
+
+func (budgetSyncProvider) Fetch(_ context.Context, entry manifest.Entry) ([]provider.File, error) {
+	return []provider.File{{Path: "SKILL.md", Content: []byte("# " + entry.Name + "\n")}}, nil
 }
 
 func budgetTestFactory(st *state.State) *app.Factory {
@@ -234,7 +277,40 @@ func budgetTestFactory(st *state.State) *app.Factory {
 		State: func() (*state.State, error) {
 			return st, nil
 		},
+		Client: func() (*gh.Client, error) {
+			return gh.NewClient(context.Background(), ""), nil
+		},
+		Provider: func() (provider.Provider, error) {
+			client := gh.NewClient(context.Background(), "")
+			return provider.NewCompositeProvider(provider.NewGitHubProvider(provider.WrapGitHubClient(client))), nil
+		},
 	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	original := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = writer
+	t.Cleanup(func() { os.Stderr = original })
+
+	fn()
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, reader); err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close stderr reader: %v", err)
+	}
+	return buf.String()
 }
 
 func writeBudgetSkill(t *testing.T, home, name, content string) {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -22,7 +22,7 @@ Pass skill names to install specific skills, or use --all to install everything.
 	}
 	cmd.Flags().Bool("all", false, "Install all available skills without prompting")
 	cmd.Flags().String("registry", "", "Limit to a specific registry (owner/repo)")
-	cmd.Flags().Bool("force", false, "Project skills even when an agent budget is exceeded")
+	cmd.Flags().Bool("force", false, "Deprecated: budget guardrails are warn-only (no-op)")
 	cmd.Flags().String("alias", "", "Install incoming skill under this name when a local directory conflicts")
 	return cmd
 }
@@ -31,10 +31,11 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	allFlag, _ := cmd.Flags().GetBool("all")
 	repoFlag, _ := cmd.Flags().GetString("registry")
 	forceBudget, _ := cmd.Flags().GetBool("force")
+	warnDeprecatedForceBudget(cmd)
 	aliasName, _ := cmd.Flags().GetString("alias")
 	factory := newCommandFactory()
 
-	if err := enforceCurrentBudget(factory, forceBudget); err != nil {
+	if err := enforceCurrentBudget(factory); err != nil {
 		return err
 	}
 

--- a/cmd/kit.go
+++ b/cmd/kit.go
@@ -247,7 +247,7 @@ func newKitInstallCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&opts.alias, "alias", "", "Install incoming kit under this local name")
-	cmd.Flags().BoolVar(&opts.forceBudget, "force", false, "Project skills even when an agent budget is exceeded")
+	cmd.Flags().BoolVar(&opts.forceBudget, "force", false, "Deprecated: budget guardrails are warn-only (no-op)")
 	cmd.Flags().BoolVar(&opts.noDeps, "no-deps", false, "Install kit body without installing referenced skills")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output machine-readable JSON")
 	addNoInteractionFlag(cmd, "Disable interactive prompts", false)
@@ -266,7 +266,7 @@ func newKitSyncCommand() *cobra.Command {
 			return runKitSync(cmd, opts)
 		},
 	}
-	cmd.Flags().BoolVar(&opts.forceBudget, "force", false, "Project skills even when an agent budget is exceeded")
+	cmd.Flags().BoolVar(&opts.forceBudget, "force", false, "Deprecated: budget guardrails are warn-only (no-op)")
 	cmd.Flags().BoolVar(&opts.noDeps, "no-deps", false, "Refresh kit bodies without installing referenced skills")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output machine-readable JSON")
 	addNoInteractionFlag(cmd, "Disable interactive prompts", false)
@@ -438,6 +438,7 @@ func runKitInstall(cmd *cobra.Command, ref string, opts *kitInstallOptions) erro
 	if opts == nil {
 		opts = &kitInstallOptions{}
 	}
+	warnDeprecatedForceBudget(cmd)
 	registryRepo, kitName, err := parseSkillRef(ref)
 	if err != nil {
 		return err
@@ -697,6 +698,7 @@ func runKitSync(cmd *cobra.Command, opts *kitInstallOptions) error {
 	if opts == nil {
 		opts = &kitInstallOptions{}
 	}
+	warnDeprecatedForceBudget(cmd)
 	factory := commandFactory()
 	cfg, err := factory.Config()
 	if err != nil {

--- a/cmd/kit_install_test.go
+++ b/cmd/kit_install_test.go
@@ -80,11 +80,14 @@ func TestKitInstallWritesKitStateAndInstallsSameRegistryDeps(t *testing.T) {
 
 	cmd := newKitInstallCommand()
 	cmd.SetArgs([]string{"acme/skills:baseline", "--json", "--force"})
-	var out bytes.Buffer
+	var out, errOut bytes.Buffer
 	cmd.SetOut(&out)
-	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetErr(&errOut)
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("kit install: %v", err)
+	}
+	if got := errOut.String(); !strings.Contains(got, deprecatedForceBudgetWarning) {
+		t.Fatalf("stderr = %q, want deprecated force warning", got)
 	}
 	wantDeps := map[string][]kitInstallDep{
 		"acme/skills":  {{Name: "tdd"}},

--- a/cmd/migrate_global.go
+++ b/cmd/migrate_global.go
@@ -49,7 +49,7 @@ Examples:
 		RunE: runGlobalToProjects,
 	}
 	cmd.Flags().Bool("dry-run", false, "Preview migration without writing .scribe.yaml or removing global symlinks")
-	cmd.Flags().Bool("force", false, "Allow migration even if a project exceeds an agent skill budget")
+	cmd.Flags().Bool("force", false, "Deprecated: budget guardrails are warn-only (no-op)")
 	cmd.Flags().Bool("undo", false, "Restore the latest global-to-projects migration snapshot")
 	addNoInteractionFlag(cmd, "Disable interactive prompts", false)
 	cmd.Flags().StringArray("project", nil, "Project directory to keep the current global skill set (repeatable; skips prompt)")
@@ -63,6 +63,7 @@ func runGlobalToProjects(cmd *cobra.Command, args []string) error {
 func runGlobalToProjectsWithSelector(cmd *cobra.Command, _ []string, selector projectSelector) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	forceBudget, _ := cmd.Flags().GetBool("force")
+	warnDeprecatedForceBudget(cmd)
 	undo, _ := cmd.Flags().GetBool("undo")
 	yes := noInteractionFlagPassed(cmd)
 	jsonFlag := jsonFlagPassed(cmd)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -22,7 +22,7 @@ func newSyncCommand() *cobra.Command {
 	cmd.Flags().String("registry", "", "Sync only this registry (owner/repo or repo name)")
 	cmd.Flags().Bool("trust-all", false, "Approve all package install commands without prompting")
 	cmd.Flags().Bool("all", false, "Sync all registries (default behavior)")
-	cmd.Flags().Bool("force", false, "Project skills even when an agent budget is exceeded")
+	cmd.Flags().Bool("force", false, "Deprecated: budget guardrails are warn-only (no-op)")
 	cmd.Flags().String("alias", "", "Install incoming skill under this name when a local directory conflicts")
 	cmd.Flags().MarkHidden("all")
 	return markJSONSupported(cmd)
@@ -33,10 +33,11 @@ func runSync(cmd *cobra.Command, args []string) error {
 	repoFlag, _ := cmd.Flags().GetString("registry")
 	trustAllFlag, _ := cmd.Flags().GetBool("trust-all")
 	forceBudget, _ := cmd.Flags().GetBool("force")
+	warnDeprecatedForceBudget(cmd)
 	aliasName, _ := cmd.Flags().GetString("alias")
 	factory := commandFactory()
 
-	if err := enforceCurrentBudget(factory, forceBudget); err != nil {
+	if err := enforceCurrentBudget(factory); err != nil {
 		return err
 	}
 

--- a/internal/projectmigrate/migrate.go
+++ b/internal/projectmigrate/migrate.go
@@ -59,7 +59,6 @@ func BuildPlan(discovery Discovery, selectedProjects []string, dryRun bool, forc
 	if len(skills) == 0 {
 		return MigrationPlan{DryRun: dryRun, GlobalLinks: discovery.GlobalSymlinks}, nil
 	}
-	forceMigration := len(force) > 0 && force[0]
 
 	selected := normalizeSelectedProjects(selectedProjects)
 	projectFiles := make([]ProjectChange, 0, len(selected))
@@ -73,13 +72,6 @@ func BuildPlan(discovery Discovery, selectedProjects []string, dryRun bool, forc
 			return MigrationPlan{}, err
 		}
 		change.BudgetPerAgent = budgetPerAgent
-		if !dryRun && !forceMigration {
-			for agent, result := range budgetPerAgent {
-				if result.Status == budget.StatusRefuse {
-					return MigrationPlan{}, fmt.Errorf("project %s exceeds %s budget by %d bytes; pass --force to proceed", change.Project, agent, result.Used-result.Limit)
-				}
-			}
-		}
 		projectFiles = append(projectFiles, change)
 	}
 

--- a/internal/projectmigrate/migrate_test.go
+++ b/internal/projectmigrate/migrate_test.go
@@ -308,19 +308,19 @@ func TestMigrate_ForcePreservesKitYAML(t *testing.T) {
 	}
 }
 
-func TestBuildPlan_FailsBudget_NoForce(t *testing.T) {
+func TestBuildPlan_RecordsBudgetRefuseWithoutForce(t *testing.T) {
 	home, project, link := setupBudgetMigrationFixture(t, "claude", "oversized", 200)
 	t.Setenv("HOME", home)
 	old := budget.AgentBudgets
 	budget.AgentBudgets = map[string]int{"claude": 20}
 	t.Cleanup(func() { budget.AgentBudgets = old })
 	discovery := undoDiscovery(home, project, link, "claude", "oversized")
-	_, err := BuildPlan(discovery, []string{project}, false)
-	if err == nil {
-		t.Fatal("BuildPlan() error = nil, want budget refusal")
+	plan, err := BuildPlan(discovery, []string{project}, false)
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "project "+project+" exceeds claude budget") || !strings.Contains(err.Error(), "pass --force to proceed") {
-		t.Fatalf("error = %q, want budget refusal", err.Error())
+	if got := plan.ProjectFiles[0].BudgetPerAgent["claude"].Status; got != budget.StatusRefuse {
+		t.Fatalf("budget status = %s, want refuse", got)
 	}
 }
 
@@ -355,13 +355,9 @@ func TestBuildPlan_BudgetIncludesExistingProjectSkills(t *testing.T) {
 	budget.AgentBudgets = map[string]int{"claude": 25}
 	t.Cleanup(func() { budget.AgentBudgets = old })
 	discovery := undoDiscovery(home, project, link, "claude", "migrated")
-	_, err := BuildPlan(discovery, []string{project}, false)
-	if err == nil {
-		t.Fatal("BuildPlan() error = nil, want budget refusal")
-	}
-	plan, err := BuildPlan(discovery, []string{project}, false, true)
+	plan, err := BuildPlan(discovery, []string{project}, false)
 	if err != nil {
-		t.Fatalf("BuildPlan() with force error = %v", err)
+		t.Fatalf("BuildPlan() error = %v", err)
 	}
 	if got := plan.ProjectFiles[0].BudgetPerAgent["claude"].Status; got != budget.StatusRefuse {
 		t.Fatalf("budget status = %s, want refuse", got)

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -74,8 +74,8 @@ type Syncer struct {
 	// TrustAll skips approval prompts for packages (--trust-all flag).
 	TrustAll bool
 
-	// ForceBudget allows projection even when an agent description-byte budget
-	// would otherwise be exceeded.
+	// ForceBudget is kept for deprecated --force plumbing; budget guardrails
+	// are warn-only and no longer block projection.
 	ForceBudget bool
 
 	// ApprovalFunc is called when a package needs interactive approval.
@@ -1010,14 +1010,6 @@ func (s *Syncer) applySource(ctx context.Context, teamRepo string, spec *source.
 			// selection; inherit mode uses every globally-enabled tool).
 			effectiveTools := selectEffectiveTools(s.Tools, installed, s.ProjectRoot)
 
-			if !s.ForceBudget {
-				if err := s.checkBudgetBeforeProjection(st, sk.Name, tFiles, effectiveTools); err != nil {
-					s.emit(SkillErrorMsg{Name: sk.Name, Err: err})
-					summary.Failed++
-					continue
-				}
-			}
-
 			installName := sk.Name
 			aliasFor := ""
 			if alias := strings.TrimSpace(s.SkillAliases[sk.Name]); alias != "" {
@@ -1203,21 +1195,12 @@ func (s *Syncer) promoteProjectProjection(name string, st *state.State, summary 
 		return
 	}
 	canonicalDir := filepath.Join(storeDir, name)
-	content, err := os.ReadFile(filepath.Join(canonicalDir, "SKILL.md"))
-	if err != nil {
-		s.emit(SkillErrorMsg{Name: name, Err: fmt.Errorf("read stored skill: %w", err)})
+	if _, err := os.Stat(filepath.Join(canonicalDir, "SKILL.md")); err != nil {
+		s.emit(SkillErrorMsg{Name: name, Err: fmt.Errorf("stat stored skill: %w", err)})
 		summary.Failed++
 		return
 	}
 	effectiveTools := selectEffectiveTools(s.Tools, installed, s.ProjectRoot)
-	if !s.ForceBudget {
-		files := []tools.SkillFile{{Path: "SKILL.md", Content: content}}
-		if err := s.checkBudgetBeforeProjection(st, name, files, effectiveTools); err != nil {
-			s.emit(SkillErrorMsg{Name: name, Err: err})
-			summary.Failed++
-			return
-		}
-	}
 	var paths []string
 	var toolNames []string
 	for _, t := range effectiveTools {

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -1331,7 +1331,7 @@ func TestRunWithDiff_BudgetUsesCurrentProjectProjection(t *testing.T) {
 	}
 }
 
-func TestRunWithDiff_EmitsBudgetWarningForPostChangeProjection(t *testing.T) {
+func TestRunWithDiff_DoesNotEmitPerSkillBudgetWarning(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -1371,17 +1371,16 @@ func TestRunWithDiff_EmitsBudgetWarningForPostChangeProjection(t *testing.T) {
 	}
 
 	for _, event := range events {
-		if msg, ok := event.(sync.BudgetWarningMsg); ok {
-			if msg.Agent != "codex" {
-				t.Fatalf("Agent = %q, want codex", msg.Agent)
-			}
-			if !strings.Contains(msg.Message, "Codex budget") {
-				t.Fatalf("Message = %q, want Codex budget warning", msg.Message)
-			}
-			return
+		switch msg := event.(type) {
+		case sync.BudgetWarningMsg:
+			t.Fatalf("unexpected BudgetWarningMsg: %#v", msg)
+		case sync.SkillErrorMsg:
+			t.Fatalf("unexpected SkillErrorMsg: %v", msg.Err)
 		}
 	}
-	t.Fatal("expected BudgetWarningMsg")
+	if _, ok := st.Installed["incoming"]; !ok {
+		t.Fatal("incoming skill was not installed")
+	}
 }
 
 func TestRunWithDiff_SkipsBudgetOnMigrationSource(t *testing.T) {

--- a/internal/workflow/bag.go
+++ b/internal/workflow/bag.go
@@ -33,7 +33,7 @@ type Bag struct {
 	InitialQuery       string // initial search/filter text for TUI surfaces
 	TrustAllFlag       bool   // --trust-all: approve all package commands without prompting
 	InstallAllFlag     bool   // --all: install all available skills without prompting
-	ForceBudget        bool   // --force: allow projection over agent description-byte budgets
+	ForceBudget        bool   // deprecated --force no-op for budget guardrails
 	ForceKits          bool   // --force-kits: overwrite existing kit files from connect/resync
 	RefreshKits        bool   // --refresh-kits: opt into kit refresh during registry resync
 	AliasName          string // --alias: install incoming skill under another name on projection conflict


### PR DESCRIPTION
- solo://proj/10/scratchpad/brief-convert-scribe--900
- Converts budget preflight refusals into aggregated stderr warnings while preserving REFUSE as reporting data.
- Deprecates `--force` as a no-op across add/install/sync/kit/migrate paths, with a one-time stderr warning when passed.
- Removes syncer projection short-circuits so per-skill budget checks no longer abort installs or emit duplicate sync warnings.
- Keeps migration/show budget reporting informational and updates tests plus changelog for warn-only behavior.