### PR TITLE
fix(budget): compact preflight warning + scribe show --verbose for breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Changed
+- **Budget warnings are now compact.** Preflight emits a single line per over-budget agent (`Codex skill budget exceeded — X / Y bytes (Z%, N contributors). Run `scribe show --verbose` for breakdown.`). Run `scribe show --verbose` for the per-skill contributor breakdown.
+
 ## v1.5.2 — 2026-05-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 
 ### Changed
-- **Budget warnings are now compact.** Preflight emits a single line per over-budget agent (`Codex skill budget exceeded — X / Y bytes (Z%, N contributors). Run `scribe show --verbose` for breakdown.`). Run `scribe show --verbose` for the per-skill contributor breakdown.
+- **Budget warnings are now compact.** Preflight emits a single line per over-budget agent — example: `Codex skill budget exceeded — X / Y bytes (Z%, N contributors). Run scribe show --verbose for breakdown.` Run `scribe show --verbose` for the per-skill contributor breakdown.
 
 ## v1.5.2 — 2026-05-21
 

--- a/cmd/budget_helpers.go
+++ b/cmd/budget_helpers.go
@@ -195,7 +195,7 @@ func enforceCurrentBudget(factory *app.Factory) error {
 		result := budget.CheckProjectionBudget(budgetSkillsForAgent(set, st, agent), agent)
 		switch result.Status {
 		case budget.StatusRefuse:
-			warnings = append(warnings, budget.FormatOverflow(result))
+			warnings = append(warnings, budget.FormatOverflowCompact(result))
 		case budget.StatusWarn:
 			warnings = append(warnings, budget.FormatResult(result))
 		}

--- a/cmd/budget_helpers_test.go
+++ b/cmd/budget_helpers_test.go
@@ -201,13 +201,64 @@ func TestEnforceCurrentBudgetWarnsOnOverflow(t *testing.T) {
 	for _, want := range []string{
 		"warning:",
 		"Codex skill budget exceeded",
-		"estimated: 5800 / 5440 bytes",
+		"5800 / 5440 bytes (107%, 2 contributors)",
+		"Run `scribe show --verbose` for breakdown.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{
+		"estimated:",
 		"biggest contributors:",
 		"huge-alpha: 4000 bytes",
 		"huge-beta: 1800 bytes",
 	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("stderr should not include %q:\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestShowVerbosePrintsBudgetContributors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wd := t.TempDir()
+	t.Chdir(wd)
+
+	writeBudgetSkill(t, home, "huge-alpha", longBudgetSkillContent("huge-alpha", 4000))
+	writeBudgetSkill(t, home, "huge-beta", longBudgetSkillContent("huge-beta", 1800))
+	writeBudgetKit(t, home, "over-budget", []string{"huge-alpha", "huge-beta"})
+	if err := os.WriteFile(filepath.Join(wd, ".scribe.yaml"), []byte("kits:\n - over-budget\n"), 0o644); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+
+	factory := budgetTestFactory(&state.State{Installed: map[string]state.InstalledSkill{
+		"huge-alpha": {Tools: []string{"codex"}},
+		"huge-beta":  {Tools: []string{"codex"}},
+	}})
+	oldFactory := commandFactory
+	commandFactory = func() *app.Factory { return factory }
+	t.Cleanup(func() { commandFactory = oldFactory })
+
+	cmd := newShowCommand()
+	cmd.SetArgs([]string{"--verbose"})
+	var execErr error
+	got := captureStdout(t, func() {
+		execErr = cmd.Execute()
+	})
+	if execErr != nil {
+		t.Fatalf("show --verbose returned error: %v\nstdout=%s", execErr, got)
+	}
+	for _, want := range []string{
+		"Budgets:",
+		"  Codex budget: 107% (5800 / 5440 bytes) — exceeded",
+		"    contributors:",
+		"      huge-alpha: 4000 bytes",
+		"      huge-beta: 1800 bytes",
+	} {
 		if !strings.Contains(got, want) {
-			t.Fatalf("stderr missing %q:\n%s", want, got)
+			t.Fatalf("stdout missing %q:\n%s", want, got)
 		}
 	}
 }
@@ -251,8 +302,11 @@ func TestSyncCommandWarnsAndContinuesWhenBudgetExceeded(t *testing.T) {
 	if execErr != nil {
 		t.Fatalf("sync Execute() returned error: %v\nstdout=%s\nstderr=%s%s", execErr, out.String(), errOut.String(), got)
 	}
-	if !strings.Contains(got, "Codex skill budget exceeded") || !strings.Contains(got, "huge-alpha: 4000 bytes") {
+	if !strings.Contains(got, "Codex skill budget exceeded") || !strings.Contains(got, "Run `scribe show --verbose` for breakdown.") {
 		t.Fatalf("stderr missing budget warning:\n%s", got)
+	}
+	if strings.Contains(got, "huge-alpha: 4000 bytes") {
+		t.Fatalf("stderr should not include contributor breakdown:\n%s", got)
 	}
 }
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -11,11 +11,13 @@ import (
 )
 
 func newShowCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Show the resolved project skill set and agent budgets",
 		RunE:  runShow,
 	}
+	cmd.Flags().BoolP("verbose", "v", false, "Show budget contributor breakdowns")
+	return cmd
 }
 
 func runShow(cmd *cobra.Command, args []string) error {
@@ -30,6 +32,10 @@ func runShow(cmd *cobra.Command, args []string) error {
 	}
 
 	set, err := resolveBudgetSet(st)
+	if err != nil {
+		return err
+	}
+	verbose, err := cmd.Flags().GetBool("verbose")
 	if err != nil {
 		return err
 	}
@@ -68,6 +74,12 @@ func runShow(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stdout, "  %s — exceeded\n", line)
 		default:
 			fmt.Fprintf(os.Stdout, "  %s\n", line)
+		}
+		if verbose && (result.Status == budget.StatusWarn || result.Status == budget.StatusRefuse) && len(result.Overflow) > 0 {
+			fmt.Fprintln(os.Stdout, "    contributors:")
+			for _, item := range result.Overflow {
+				fmt.Fprintf(os.Stdout, "      %s: %d bytes\n", item.Skill, item.Bytes)
+			}
 		}
 	}
 	return nil

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -89,17 +89,17 @@ func checkBudget(skills []Skill, agent string, estimate func(Skill) int) Result 
 		}
 		result.Used += size
 	}
+	sort.SliceStable(contributions, func(i, j int) bool {
+		if contributions[i].Bytes == contributions[j].Bytes {
+			return contributions[i].Skill < contributions[j].Skill
+		}
+		return contributions[i].Bytes > contributions[j].Bytes
+	})
+	result.Overflow = contributions
 
 	switch {
 	case result.Used >= limit:
 		result.Status = StatusRefuse
-		sort.SliceStable(contributions, func(i, j int) bool {
-			if contributions[i].Bytes == contributions[j].Bytes {
-				return contributions[i].Skill < contributions[j].Skill
-			}
-			return contributions[i].Bytes > contributions[j].Bytes
-		})
-		result.Overflow = contributions
 	case float64(result.Used) >= float64(limit)*warnRatio:
 		result.Status = StatusWarn
 	default:
@@ -113,6 +113,10 @@ func FormatResult(result Result) string {
 		return ""
 	}
 	return fmt.Sprintf("%s budget: %d%% (%d / %d bytes)", title(result.Agent), result.Percent(), result.Used, result.Limit)
+}
+
+func FormatOverflowCompact(result Result) string {
+	return fmt.Sprintf("%s skill budget exceeded — %d / %d bytes (%d%%, %d contributors). Run `scribe show --verbose` for breakdown.", title(result.Agent), result.Used, result.Limit, result.Percent(), len(result.Overflow))
 }
 
 func FormatOverflow(result Result) string {

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -131,6 +131,43 @@ func TestCheckBudgetOverflowBreakdownShowsBiggestContributors(t *testing.T) {
 	}
 }
 
+func TestCheckBudgetWarnPopulatesBreakdown(t *testing.T) {
+	skills := []Skill{
+		skillWithDescription("b", 2000),
+		skillWithDescription("a", 1900),
+	}
+
+	result := CheckBudget(skills, "codex")
+	if result.Status != StatusWarn {
+		t.Fatalf("Status = %s, want %s", result.Status, StatusWarn)
+	}
+	want := []Overflow{
+		{Skill: "b", Bytes: 2000},
+		{Skill: "a", Bytes: 1900},
+	}
+	if len(result.Overflow) != len(want) {
+		t.Fatalf("Overflow = %#v, want %#v", result.Overflow, want)
+	}
+	for i := range want {
+		if result.Overflow[i] != want[i] {
+			t.Fatalf("Overflow[%d] = %#v, want %#v", i, result.Overflow[i], want[i])
+		}
+	}
+}
+
+func TestFormatOverflowCompact(t *testing.T) {
+	result := CheckBudget([]Skill{
+		skillWithDescription("a", 4000),
+		skillWithDescription("b", 1800),
+	}, "codex")
+
+	got := FormatOverflowCompact(result)
+	want := "Codex skill budget exceeded — 5800 / 5440 bytes (107%, 2 contributors). Run `scribe show --verbose` for breakdown."
+	if got != want {
+		t.Fatalf("FormatOverflowCompact() = %q, want %q", got, want)
+	}
+}
+
 func TestCheckProjectionBudgetUsesRawCodexDescriptions(t *testing.T) {
 	skills := []Skill{
 		skillWithSentenceDescription("a", strings.Repeat("a", 3000)+". "+strings.Repeat("ignored", 100)),


### PR DESCRIPTION
- Compact over-budget preflight warnings to a single line with a `scribe show --verbose` breakdown hint.
- Add `scribe show --verbose` / `-v` contributor rendering for warn/refuse budget states.
- Keep budget overflow contributors populated and sorted for warning-level results.
- Brief: solo://proj/10/scratchpad/brief-compact-budget--918