### PR TITLE
fix(treescan): dedup skills mirrored across agent-tool dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Changed
 - **Budget warnings are now compact.** Preflight emits a single line per over-budget agent — example: `Codex skill budget exceeded — X / Y bytes (Z%, N contributors). Run scribe show --verbose for breakdown.` Run `scribe show --verbose` for the per-skill contributor breakdown.
 
+### Fixed
+- **`scribe list` no longer duplicates skills mirrored across agent-tool dirs** — tree-scan discovery now picks one canonical `SKILL.md` per skill (preferring `.agents/skills/<name>/SKILL.md`) when a repo mirrors the same skill into `.claude/skills/`, `.codex/skills/`, etc.
+
 ## v1.5.2 — 2026-05-21
 
 ### Changed

--- a/internal/provider/treescan.go
+++ b/internal/provider/treescan.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 	"regexp"
+	"sort"
 
 	"github.com/Naoray/scribe/internal/discovery"
 	"github.com/Naoray/scribe/internal/manifest"
@@ -13,15 +14,15 @@ const skillFileName = "SKILL.md"
 
 var treeScanSkillName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
-// ScanTreeForSkills finds all SKILL.md files in a tree listing and returns
-// catalog entries for each. The skill name is derived from the parent directory.
-// A root-level SKILL.md uses the repo name.
+// ScanTreeForSkills finds SKILL.md files in a tree listing and returns one
+// catalog entry per skill name. The skill name is derived from the parent
+// directory. A root-level SKILL.md uses the repo name.
 func ScanTreeForSkills(tree []TreeEntry, owner, repo string) []manifest.Entry {
 	return scanTreeForSkillsWithSource(tree, owner, repo, fmt.Sprintf("github:%s/%s@HEAD", owner, repo))
 }
 
 func scanTreeForSkillsWithSource(tree []TreeEntry, owner, repo, source string) []manifest.Entry {
-	var entries []manifest.Entry
+	candidatesByName := make(map[string][]string)
 	for _, entry := range tree {
 		if entry.Type != "blob" {
 			continue
@@ -43,15 +44,52 @@ func scanTreeForSkillsWithSource(tree []TreeEntry, owner, repo, source string) [
 			skillPath = dir
 		}
 
+		candidatesByName[name] = append(candidatesByName[name], skillPath)
+	}
+
+	names := make([]string, 0, len(candidatesByName))
+	for name := range candidatesByName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	entries := make([]manifest.Entry, 0, len(names))
+	for _, name := range names {
 		entries = append(entries, manifest.Entry{
 			Name:   name,
 			Source: source,
-			Path:   skillPath,
+			Path:   selectCanonicalSkillPath(candidatesByName[name]),
 			Author: owner,
 		})
 	}
 
 	return entries
+}
+
+func selectCanonicalSkillPath(candidates []string) string {
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	paths := append([]string(nil), candidates...)
+	sort.Strings(paths)
+
+	for _, candidate := range paths {
+		if path.Dir(candidate) == ".agents/skills" {
+			return candidate
+		}
+	}
+	for _, candidate := range paths {
+		if path.Dir(candidate) == "." {
+			return candidate
+		}
+	}
+	for _, candidate := range paths {
+		if path.Dir(candidate) == "skills" {
+			return candidate
+		}
+	}
+	return paths[0]
 }
 
 // EnrichTreeSkillEntry applies SKILL.md frontmatter metadata to a tree-scan

--- a/internal/provider/treescan_test.go
+++ b/internal/provider/treescan_test.go
@@ -3,6 +3,7 @@ package provider_test
 import (
 	"testing"
 
+	"github.com/Naoray/scribe/internal/manifest"
 	"github.com/Naoray/scribe/internal/provider"
 )
 
@@ -45,6 +46,89 @@ func TestScanTreeForSkills(t *testing.T) {
 	if !names["tool"] {
 		t.Error("expected nested/deep/tool skill")
 	}
+}
+
+func TestScanTreeForSkillsAgentsLayout(t *testing.T) {
+	entries := provider.ScanTreeForSkills([]provider.TreeEntry{
+		{Path: ".agents/skills/foo/SKILL.md", Type: "blob"},
+	}, "acme", "repo")
+
+	assertTreeSkill(t, entries, "foo", ".agents/skills/foo")
+}
+
+func TestScanTreeForSkillsDedupsMirroredAgentToolDirs(t *testing.T) {
+	entries := provider.ScanTreeForSkills([]provider.TreeEntry{
+		{Path: ".claude/skills/foo/SKILL.md", Type: "blob"},
+		{Path: ".codex/skills/foo/SKILL.md", Type: "blob"},
+		{Path: ".agents/skills/foo/SKILL.md", Type: "blob"},
+	}, "acme", "repo")
+
+	assertTreeSkill(t, entries, "foo", ".agents/skills/foo")
+}
+
+func TestScanTreeForSkillsKeepsSingleMirrorWithoutCanonical(t *testing.T) {
+	entries := provider.ScanTreeForSkills([]provider.TreeEntry{
+		{Path: ".claude/skills/foo/SKILL.md", Type: "blob"},
+	}, "acme", "repo")
+
+	assertTreeSkill(t, entries, "foo", ".claude/skills/foo")
+}
+
+func TestScanTreeForSkillsPrefersTopLevelSkillDirectory(t *testing.T) {
+	entries := provider.ScanTreeForSkills([]provider.TreeEntry{
+		{Path: ".agents/skills/foo/SKILL.md", Type: "blob"},
+		{Path: "foo/SKILL.md", Type: "blob"},
+		{Path: "skills/foo/SKILL.md", Type: "blob"},
+	}, "acme", "repo")
+
+	assertTreeSkill(t, entries, "foo", ".agents/skills/foo")
+
+	entries = provider.ScanTreeForSkills([]provider.TreeEntry{
+		{Path: ".claude/skills/foo/SKILL.md", Type: "blob"},
+		{Path: "foo/SKILL.md", Type: "blob"},
+		{Path: "skills/foo/SKILL.md", Type: "blob"},
+	}, "acme", "repo")
+
+	assertTreeSkill(t, entries, "foo", "foo")
+}
+
+func TestScanTreeForSkillsPrefersRootSkillFileOverMirror(t *testing.T) {
+	entries := provider.ScanTreeForSkills([]provider.TreeEntry{
+		{Path: ".claude/skills/repo/SKILL.md", Type: "blob"},
+		{Path: "SKILL.md", Type: "blob"},
+	}, "acme", "repo")
+
+	assertTreeSkill(t, entries, "repo", "SKILL.md")
+}
+
+func TestScanTreeForSkillsDedupsDistinctSkills(t *testing.T) {
+	entries := provider.ScanTreeForSkills([]provider.TreeEntry{
+		{Path: ".codex/skills/foo/SKILL.md", Type: "blob"},
+		{Path: ".claude/skills/bar/SKILL.md", Type: "blob"},
+		{Path: ".agents/skills/foo/SKILL.md", Type: "blob"},
+		{Path: "skills/bar/SKILL.md", Type: "blob"},
+	}, "acme", "repo")
+
+	if len(entries) != 2 {
+		t.Fatalf("entries: got %d, want 2", len(entries))
+	}
+
+	byName := entriesByName(entries)
+	if byName["foo"].Path != ".agents/skills/foo" {
+		t.Fatalf("foo path = %q", byName["foo"].Path)
+	}
+	if byName["bar"].Path != "skills/bar" {
+		t.Fatalf("bar path = %q", byName["bar"].Path)
+	}
+}
+
+func TestScanTreeForSkillsMirrorTieBreaksByPath(t *testing.T) {
+	entries := provider.ScanTreeForSkills([]provider.TreeEntry{
+		{Path: ".codex/skills/foo/SKILL.md", Type: "blob"},
+		{Path: ".claude/skills/foo/SKILL.md", Type: "blob"},
+	}, "acme", "repo")
+
+	assertTreeSkill(t, entries, "foo", ".claude/skills/foo")
 }
 
 func TestScanTreeForSkillsEmpty(t *testing.T) {
@@ -100,4 +184,25 @@ author: vercel
 	if enriched.Path != "skills/nextjs" {
 		t.Fatalf("Path = %q", enriched.Path)
 	}
+}
+
+func assertTreeSkill(t *testing.T, entries []manifest.Entry, name, skillPath string) {
+	t.Helper()
+	if len(entries) != 1 {
+		t.Fatalf("entries: got %d, want 1", len(entries))
+	}
+	if entries[0].Name != name {
+		t.Fatalf("Name = %q, want %q", entries[0].Name, name)
+	}
+	if entries[0].Path != skillPath {
+		t.Fatalf("Path = %q, want %q", entries[0].Path, skillPath)
+	}
+}
+
+func entriesByName(entries []manifest.Entry) map[string]manifest.Entry {
+	byName := make(map[string]manifest.Entry, len(entries))
+	for _, entry := range entries {
+		byName[entry.Name] = entry
+	}
+	return byName
 }


### PR DESCRIPTION
- Problem: tree-scan discovery emitted duplicate catalog entries when a repo mirrored the same skill across agent-tool directories.
- Fix: group SKILL.md candidates by skill name and emit one canonical entry per name.
- Priority: .agents/skills/<name>/SKILL.md, then root-level <name>/SKILL.md or SKILL.md, then skills/<name>/SKILL.md, then lexicographic first path.
- Brief: solo://proj/10/scratchpad/brief-dedup-tree-sca--927